### PR TITLE
Phase 0: add pinned toolchain container + lock metadata

### DIFF
--- a/build/docker/Dockerfile.toolchain
+++ b/build/docker/Dockerfile.toolchain
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+# Pinned Debian Bookworm slim base image (immutable digest)
+FROM docker.io/library/debian@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    clang \
+    lld \
+    gcc \
+    g++ \
+    binutils \
+    nasm \
+    make \
+    ninja-build \
+    cmake \
+    python3 \
+    python3-pip \
+    qemu-system-x86 \
+    xorriso \
+    grub-common \
+    mtools \
+    git \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -1,0 +1,27 @@
+# Toolchain Container
+
+This image is the baseline for deterministic SecureOS builds.
+
+## Build
+
+```bash
+docker build -f build/docker/Dockerfile.toolchain -t secureos/toolchain:bookworm-2026-02-12 .
+```
+
+## Verify base image digest
+
+```bash
+docker image inspect debian:bookworm-slim --format '{{index .RepoDigests 0}}'
+```
+
+Expected digest (see `build/toolchain.lock`):
+
+```text
+docker.io/library/debian@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
+```
+
+## Run toolchain shell
+
+```bash
+docker run --rm -it -v "$PWD":/workspace -w /workspace secureos/toolchain:bookworm-2026-02-12 bash
+```

--- a/build/toolchain.lock
+++ b/build/toolchain.lock
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "name": "secureos-toolchain",
+  "baseImage": {
+    "reference": "docker.io/library/debian@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe",
+    "sourceTag": "debian:bookworm-slim",
+    "resolvedAt": "2026-02-12"
+  },
+  "requiredTools": [
+    "clang",
+    "lld",
+    "gcc",
+    "g++",
+    "binutils",
+    "nasm",
+    "make",
+    "ninja",
+    "cmake",
+    "python3",
+    "qemu-system-x86_64",
+    "xorriso",
+    "grub-mkrescue",
+    "mtools",
+    "git",
+    "jq"
+  ],
+  "build": {
+    "dockerfile": "build/docker/Dockerfile.toolchain",
+    "imageTag": "secureos/toolchain:bookworm-2026-02-12"
+  },
+  "verification": {
+    "buildCommand": "docker build -f build/docker/Dockerfile.toolchain -t secureos/toolchain:bookworm-2026-02-12 .",
+    "digestCheckCommand": "docker image inspect debian:bookworm-slim --format '{{index .RepoDigests 0}}'"
+  }
+}


### PR DESCRIPTION
## Summary
- add `build/docker/Dockerfile.toolchain` with an immutable Debian base-image digest
- install required Phase-0 toolchain packages (clang/lld, gcc/binutils, nasm, qemu-system-x86, xorriso/grub tooling, python3, make/ninja, etc.)
- add `build/toolchain.lock` capturing base digest + expected toolchain metadata
- add `build/docker/README.md` with build and digest-verification commands

## Validation
- Ran successfully from clean checkout:
  - `docker build -f build/docker/Dockerfile.toolchain -t secureos/toolchain:bookworm-2026-02-12 .`

## Issue
Closes #4
