### PR TITLE
Phase 0: add canonical build/test/run wrapper scripts

### DIFF
--- a/build/scripts/README.md
+++ b/build/scripts/README.md
@@ -1,0 +1,24 @@
+# SecureOS Build Wrappers
+
+Canonical wrapper scripts for deterministic local/agent workflows.
+
+## Targets
+
+```bash
+./build/scripts/build.sh image
+./build/scripts/build.sh run
+./build/scripts/build.sh test-boot
+```
+
+## Direct test/run
+
+```bash
+./build/scripts/test.sh hello_boot
+./build/scripts/run_qemu.sh --test hello_boot
+```
+
+## Notes
+
+- Scripts are intended to run through the pinned toolchain container (`secureos/toolchain:bookworm-2026-02-12`).
+- If the image is missing, `build.sh` bootstraps it from `build/docker/Dockerfile.toolchain`.
+- QEMU logs are written to `artifacts/qemu/<test>.log`.

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_TAG="${SECUREOS_TOOLCHAIN_IMAGE:-secureos/toolchain:bookworm-2026-02-12}"
+DOCKERFILE="${SECUREOS_TOOLCHAIN_DOCKERFILE:-$ROOT_DIR/build/docker/Dockerfile.toolchain}"
+TARGET="${1:-image}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [kernel|modules|image|run|test-boot]
+
+Builds SecureOS targets using the pinned toolchain container.
+Environment overrides:
+  SECUREOS_TOOLCHAIN_IMAGE      Container image tag (default: $IMAGE_TAG)
+  SECUREOS_TOOLCHAIN_DOCKERFILE Dockerfile path for bootstrap build
+EOF
+}
+
+if [[ "${TARGET}" == "-h" || "${TARGET}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || { echo "docker is required"; exit 1; }
+
+if ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+  echo "Toolchain image not found: $IMAGE_TAG"
+  echo "Building it from: $DOCKERFILE"
+  docker build -f "$DOCKERFILE" -t "$IMAGE_TAG" "$ROOT_DIR"
+fi
+
+case "$TARGET" in
+  kernel|modules|image)
+    echo "[build] target=$TARGET"
+    docker run --rm -v "$ROOT_DIR":/workspace -w /workspace "$IMAGE_TAG" \
+      bash -lc "echo TODO: implement $TARGET target build graph"
+    ;;
+  run)
+    "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot
+    ;;
+  test-boot)
+    "$ROOT_DIR/build/scripts/test.sh" hello_boot
+    ;;
+  *)
+    echo "Unknown target: $TARGET"
+    usage
+    exit 1
+    ;;
+esac

--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ART_DIR="$ROOT_DIR/artifacts/qemu"
+TEST_NAME=""
+TIMEOUT_SECONDS="${SECUREOS_QEMU_TIMEOUT_SECONDS:-10}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --test <name>
+
+Supported tests:
+  hello_boot  Uses experiments/bootloader/boot.bin as floppy image
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --test)
+      TEST_NAME="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TEST_NAME" ]]; then
+  usage
+  exit 1
+fi
+
+mkdir -p "$ART_DIR"
+LOG_FILE="$ART_DIR/${TEST_NAME}.log"
+
+case "$TEST_NAME" in
+  hello_boot)
+    BOOT_BIN="$ROOT_DIR/experiments/bootloader/boot.bin"
+    if [[ ! -f "$BOOT_BIN" ]]; then
+      echo "Missing boot binary: $BOOT_BIN"
+      echo "Run build/scripts/test.sh hello_boot first."
+      exit 1
+    fi
+
+    set +e
+    python3 - <<PY >"$LOG_FILE" 2>&1
+import subprocess
+cmd = [
+  "qemu-system-x86_64",
+  "-drive", "format=raw,file=$BOOT_BIN,if=floppy",
+  "-nographic", "-serial", "stdio", "-monitor", "none",
+  "-m", "256M", "-smp", "1",
+]
+try:
+  p = subprocess.run(cmd, capture_output=True, text=True, timeout=$TIMEOUT_SECONDS)
+  print((p.stdout or "") + (p.stderr or ""), end="")
+  raise SystemExit(p.returncode)
+except subprocess.TimeoutExpired as e:
+  out = (e.stdout or b"") + (e.stderr or b"")
+  if isinstance(out, bytes):
+      out = out.decode("utf-8", errors="replace")
+  print(out, end="")
+  raise SystemExit(124)
+PY
+    QEMU_EXIT=$?
+    set -e
+    cat "$LOG_FILE"
+
+    if [[ $QEMU_EXIT -ne 0 && $QEMU_EXIT -ne 124 ]]; then
+      echo "QEMU failed with exit code $QEMU_EXIT"
+      exit 1
+    fi
+
+    if grep -q "SecureOS boot sector OK" "$LOG_FILE"; then
+      echo "QEMU_PASS:$TEST_NAME"
+      exit 0
+    fi
+
+    echo "QEMU_FAIL:$TEST_NAME"
+    exit 1
+    ;;
+  *)
+    echo "Unknown test: $TEST_NAME"
+    exit 1
+    ;;
+esac

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_NAME="${1:-hello_boot}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [hello_boot]
+
+Runs SecureOS test targets.
+EOF
+}
+
+if [[ "$TEST_NAME" == "-h" || "$TEST_NAME" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+case "$TEST_NAME" in
+  hello_boot)
+    "$ROOT_DIR/build/scripts/test_boot_sector.sh"
+    "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot
+    ;;
+  *)
+    echo "Unknown test: $TEST_NAME"
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add canonical wrapper scripts:
  - `build/scripts/build.sh`
  - `build/scripts/test.sh`
  - `build/scripts/run_qemu.sh`
- add `build/scripts/README.md` with usage examples
- wire wrappers to current hello-boot validation path and artifact logging

## What works now
- `build.sh` standard target entrypoint (`kernel|modules|image|run|test-boot`) with toolchain image bootstrap
- `test.sh hello_boot` runs boot-sector assembly smoke test + QEMU harness
- `run_qemu.sh --test hello_boot` executes deterministic headless QEMU run and writes logs to `artifacts/qemu/hello_boot.log`

## Validation
- Ran successfully:
  - `./build/scripts/test.sh hello_boot`

## Issue
Closes #5
