### PR TITLE
Phase 0: harden deterministic QEMU harness + log metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+experiments/bootloader/boot.bin

--- a/build/qemu/x86_64-headless.args
+++ b/build/qemu/x86_64-headless.args
@@ -1,0 +1,10 @@
+-nographic
+-serial
+stdio
+-monitor
+none
+-m
+256M
+-smp
+1
+-no-reboot

--- a/build/scripts/README.md
+++ b/build/scripts/README.md
@@ -21,4 +21,6 @@ Canonical wrapper scripts for deterministic local/agent workflows.
 
 - Scripts are intended to run through the pinned toolchain container (`secureos/toolchain:bookworm-2026-02-12`).
 - If the image is missing, `build.sh` bootstraps it from `build/docker/Dockerfile.toolchain`.
+- Deterministic QEMU flags live in `build/qemu/x86_64-headless.args`.
 - QEMU logs are written to `artifacts/qemu/<test>.log`.
+- Per-run metadata is written to `artifacts/qemu/<test>.meta.json`.

--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ART_DIR="$ROOT_DIR/artifacts/qemu"
+QEMU_ARGS_FILE="$ROOT_DIR/build/qemu/x86_64-headless.args"
 TEST_NAME=""
 TIMEOUT_SECONDS="${SECUREOS_QEMU_TIMEOUT_SECONDS:-10}"
 
@@ -12,6 +13,10 @@ Usage: $(basename "$0") --test <name>
 
 Supported tests:
   hello_boot  Uses experiments/bootloader/boot.bin as floppy image
+
+Outputs:
+  artifacts/qemu/<test>.log
+  artifacts/qemu/<test>.meta.json
 EOF
 }
 
@@ -38,8 +43,14 @@ if [[ -z "$TEST_NAME" ]]; then
   exit 1
 fi
 
+if [[ ! -f "$QEMU_ARGS_FILE" ]]; then
+  echo "Missing QEMU args file: $QEMU_ARGS_FILE"
+  exit 1
+fi
+
 mkdir -p "$ART_DIR"
 LOG_FILE="$ART_DIR/${TEST_NAME}.log"
+META_FILE="$ART_DIR/${TEST_NAME}.meta.json"
 
 case "$TEST_NAME" in
   hello_boot)
@@ -51,41 +62,58 @@ case "$TEST_NAME" in
     fi
 
     set +e
-    python3 - <<PY >"$LOG_FILE" 2>&1
-import subprocess
-cmd = [
-  "qemu-system-x86_64",
-  "-drive", "format=raw,file=$BOOT_BIN,if=floppy",
-  "-nographic", "-serial", "stdio", "-monitor", "none",
-  "-m", "256M", "-smp", "1",
-]
+    python3 - <<PY
+import json, pathlib, subprocess, shlex
+
+root = pathlib.Path(r'''$ROOT_DIR''')
+args_file = pathlib.Path(r'''$QEMU_ARGS_FILE''')
+log_file = pathlib.Path(r'''$LOG_FILE''')
+meta_file = pathlib.Path(r'''$META_FILE''')
+boot_bin = pathlib.Path(r'''$BOOT_BIN''')
+
+timeout_s = int(r'''$TIMEOUT_SECONDS''')
+
+raw_args = [line.strip() for line in args_file.read_text().splitlines() if line.strip() and not line.strip().startswith('#')]
+cmd = ["qemu-system-x86_64", "-drive", f"format=raw,file={boot_bin},if=floppy", *raw_args]
+
+result = {
+    "test": r'''$TEST_NAME''',
+    "timeoutSeconds": timeout_s,
+    "command": cmd,
+    "logFile": str(log_file),
+}
+
 try:
-  p = subprocess.run(cmd, capture_output=True, text=True, timeout=$TIMEOUT_SECONDS)
-  print((p.stdout or "") + (p.stderr or ""), end="")
-  raise SystemExit(p.returncode)
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+    output = (p.stdout or "") + (p.stderr or "")
+    log_file.write_text(output)
+    result["qemuExitCode"] = p.returncode
+    result["timedOut"] = False
 except subprocess.TimeoutExpired as e:
-  out = (e.stdout or b"") + (e.stderr or b"")
-  if isinstance(out, bytes):
-      out = out.decode("utf-8", errors="replace")
-  print(out, end="")
-  raise SystemExit(124)
+    out = (e.stdout or b"") + (e.stderr or b"")
+    if isinstance(out, bytes):
+        out = out.decode("utf-8", errors="replace")
+    log_file.write_text(out)
+    result["qemuExitCode"] = 124
+    result["timedOut"] = True
+
+log_text = log_file.read_text(errors="replace")
+result["detectedMessage"] = "SecureOS boot sector OK" in log_text
+result["status"] = "pass" if result["detectedMessage"] else "fail"
+meta_file.write_text(json.dumps(result, indent=2) + "\n")
+
+print(log_text, end="")
+print(f"META:{meta_file}")
+if result["status"] == "pass":
+    print(f"QEMU_PASS:{result['test']}")
+    raise SystemExit(0)
+
+print(f"QEMU_FAIL:{result['test']}")
+raise SystemExit(1)
 PY
-    QEMU_EXIT=$?
+    EXIT_CODE=$?
     set -e
-    cat "$LOG_FILE"
-
-    if [[ $QEMU_EXIT -ne 0 && $QEMU_EXIT -ne 124 ]]; then
-      echo "QEMU failed with exit code $QEMU_EXIT"
-      exit 1
-    fi
-
-    if grep -q "SecureOS boot sector OK" "$LOG_FILE"; then
-      echo "QEMU_PASS:$TEST_NAME"
-      exit 0
-    fi
-
-    echo "QEMU_FAIL:$TEST_NAME"
-    exit 1
+    exit $EXIT_CODE
     ;;
   *)
     echo "Unknown test: $TEST_NAME"


### PR DESCRIPTION
## Summary
- add deterministic QEMU args file at `build/qemu/x86_64-headless.args`
- harden `build/scripts/run_qemu.sh` to:
  - consume deterministic args from file
  - enforce timeout
  - always write per-test log and metadata files
  - emit stable PASS/FAIL output
- update `build/scripts/README.md` with harness outputs
- add `.gitignore` entries for generated artifacts

## Outputs
- `artifacts/qemu/<test>.log`
- `artifacts/qemu/<test>.meta.json`

## Validation
- `./build/scripts/test.sh hello_boot` succeeded
- generated metadata includes commandline, timeout, exit code, and pass/fail status

## Issue
Closes #6
