### PR TITLE
Issue #16: define agent task DAG schema for execution/validation

### DIFF
--- a/docs/architecture/AGENT_TASK_DAG.md
+++ b/docs/architecture/AGENT_TASK_DAG.md
@@ -1,0 +1,36 @@
+# Agent Task DAG Schema
+
+This document defines the machine-readable task DAG used to coordinate planning, implementation, and validation work for SecureOS.
+
+## Goals
+
+- deterministic execution contracts
+- explicit dependency edges
+- machine-verifiable completion criteria
+- compatibility with zero-trust review/audit workflows
+
+## Files
+
+- Schema: `manifests/task-dag.schema.json`
+- Example: `manifests/task-dag.example.json`
+
+## Rules
+
+1. Every task must have a unique `taskId`.
+2. `dependsOn` must reference existing `taskId` values.
+3. `ownerRole` is constrained to planner/implementer/test-engineer/validator.
+4. `passCondition` must be structured and evaluable (no free-form "looks good").
+5. Artifacts must be explicit when a task produces verification evidence.
+
+## Validation (recommended)
+
+Use any Draft 2020-12 JSON schema validator:
+
+```bash
+# Example with ajv-cli if installed
+ajv validate -s manifests/task-dag.schema.json -d manifests/task-dag.example.json
+```
+
+## Zero-trust alignment
+
+The DAG model ensures privileged transitions (build→run→validate→merge) are explicit and auditable. It supports deny-by-default process controls by making required checks and pass conditions first-class data.

--- a/manifests/task-dag.example.json
+++ b/manifests/task-dag.example.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0",
+  "pipeline": {
+    "name": "m0-to-m1-capability-gate",
+    "entryTasks": ["M0_BOOT_SMOKE"]
+  },
+  "tasks": [
+    {
+      "taskId": "M0_BOOT_SMOKE",
+      "ownerRole": "validator",
+      "run": "./build/scripts/test.sh hello_boot",
+      "passCondition": {
+        "type": "log_marker",
+        "marker": "QEMU_PASS:hello_boot"
+      },
+      "artifacts": ["artifacts/qemu/hello_boot.log"]
+    },
+    {
+      "taskId": "M1_CAP_MODEL",
+      "ownerRole": "implementer",
+      "dependsOn": ["M0_BOOT_SMOKE"],
+      "run": ["./build/scripts/build.sh", "./build/scripts/test.sh capability_model"],
+      "passCondition": {
+        "type": "expression",
+        "expression": "exit_code == 0 && log_has('TEST:PASS:cap_model_skeleton')"
+      }
+    }
+  ]
+}

--- a/manifests/task-dag.schema.json
+++ b/manifests/task-dag.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://secureos.dev/schemas/task-dag.schema.json",
+  "title": "SecureOS Agent Task DAG",
+  "type": "object",
+  "required": ["version", "pipeline", "tasks"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string", "pattern": "^1\\.0$" },
+    "pipeline": {
+      "type": "object",
+      "required": ["name", "entryTasks"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "entryTasks": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Z0-9_-]+$" },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["taskId", "ownerRole", "run", "passCondition"],
+        "additionalProperties": false,
+        "properties": {
+          "taskId": { "type": "string", "pattern": "^[A-Z0-9_-]+$" },
+          "ownerRole": {
+            "type": "string",
+            "enum": ["planner", "implementer", "test-engineer", "validator"]
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[A-Z0-9_-]+$" },
+            "uniqueItems": true
+          },
+          "run": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 },
+                "minItems": 1
+              }
+            ]
+          },
+          "artifacts": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "passCondition": {
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["exit_code", "log_marker", "expression"]
+              },
+              "expected": { "type": ["integer", "string", "boolean"] },
+              "marker": { "type": "string" },
+              "expression": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #16

## What changed
- Added JSON Schema: `manifests/task-dag.schema.json`.
- Added runnable example manifest: `manifests/task-dag.example.json`.
- Added architecture doc: `docs/architecture/AGENT_TASK_DAG.md`.

## Validation
- `python3 -m json.tool manifests/task-dag.schema.json`
- `python3 -m json.tool manifests/task-dag.example.json`

Both files parse cleanly.
