### PR TITLE
Boot slice: add COM1 serial driver + early boot markers

### DIFF
--- a/build/scripts/build_kernel_entry.sh
+++ b/build/scripts/build_kernel_entry.sh
@@ -15,10 +15,11 @@ docker run --rm -v "$ROOT_DIR":/workspace -w /workspace "$IMAGE_TAG" bash -lc '
   set -euo pipefail
   nasm -f elf32 kernel/arch/x86/boot/entry.asm -o artifacts/kernel/entry.o
   clang --target=i386-unknown-none-elf -ffreestanding -fno-stack-protector -m32 -c kernel/core/kmain.c -o artifacts/kernel/kmain.o
+  clang --target=i386-unknown-none-elf -ffreestanding -fno-stack-protector -m32 -c kernel/arch/x86/serial.c -o artifacts/kernel/serial.o
   ld.lld -m elf_i386 -T kernel/arch/x86/boot/linker.ld \
     -Map=artifacts/kernel/kernel.map \
     -o artifacts/kernel/kernel.elf \
-    artifacts/kernel/entry.o artifacts/kernel/kmain.o
+    artifacts/kernel/entry.o artifacts/kernel/kmain.o artifacts/kernel/serial.o
   if command -v llvm-objdump >/dev/null 2>&1; then
     llvm-objdump -h artifacts/kernel/kernel.elf > artifacts/kernel/kernel.sections.txt
   else

--- a/docs/BOOT_ENTRY_X86.md
+++ b/docs/BOOT_ENTRY_X86.md
@@ -4,7 +4,8 @@ This introduces a minimal x86 boot-entry handoff scaffold:
 
 - `kernel/arch/x86/boot/entry.asm` — `_start` entry and stack setup
 - `kernel/arch/x86/boot/linker.ld` — linker layout + entrypoint at 1 MiB
-- `kernel/core/kmain.c` — minimal `kmain` handoff target
+- `kernel/core/kmain.c` — `kmain` handoff target with early test markers
+- `kernel/arch/x86/serial.c` + `serial.h` — COM1 early serial driver
 
 ## Build
 

--- a/kernel/arch/x86/serial.c
+++ b/kernel/arch/x86/serial.c
@@ -1,0 +1,42 @@
+#include "serial.h"
+
+#define COM1 0x3F8
+
+static inline void outb(unsigned short port, unsigned char val) {
+  __asm__ __volatile__("outb %0, %1" : : "a"(val), "Nd"(port));
+}
+
+static inline unsigned char inb(unsigned short port) {
+  unsigned char ret;
+  __asm__ __volatile__("inb %1, %0" : "=a"(ret) : "Nd"(port));
+  return ret;
+}
+
+void serial_init(void) {
+  outb(COM1 + 1, 0x00);
+  outb(COM1 + 3, 0x80);
+  outb(COM1 + 0, 0x03);
+  outb(COM1 + 1, 0x00);
+  outb(COM1 + 3, 0x03);
+  outb(COM1 + 2, 0xC7);
+  outb(COM1 + 4, 0x0B);
+}
+
+static int serial_tx_empty(void) {
+  return inb(COM1 + 5) & 0x20;
+}
+
+static void serial_write_char(char c) {
+  while (!serial_tx_empty()) {
+  }
+  outb(COM1, (unsigned char)c);
+}
+
+void serial_write(const char *s) {
+  for (; *s; s++) {
+    if (*s == '\n') {
+      serial_write_char('\r');
+    }
+    serial_write_char(*s);
+  }
+}

--- a/kernel/arch/x86/serial.h
+++ b/kernel/arch/x86/serial.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void serial_init(void);
+void serial_write(const char *s);

--- a/kernel/core/kmain.c
+++ b/kernel/core/kmain.c
@@ -1,7 +1,12 @@
+#include "../arch/x86/serial.h"
+
 __attribute__((used))
 void kmain(void) {
-  volatile const char *marker = "KMAIN_REACHED";
-  (void)marker;
+  serial_init();
+  serial_write("TEST:START:boot_entry\n");
+  serial_write("KMAIN_REACHED\n");
+  serial_write("TEST:PASS:boot_entry\n");
+
   for (;;) {
     __asm__ __volatile__("hlt");
   }


### PR DESCRIPTION
## Summary
- add early COM1 serial driver (`kernel/arch/x86/serial.c` + `serial.h`)
- update `kmain` to initialize serial and emit structured boot markers:
  - `TEST:START:boot_entry`
  - `KMAIN_REACHED`
  - `TEST:PASS:boot_entry`
- update kernel entry build script to compile/link serial module
- update boot-entry docs with serial marker behavior

## Validation
- `./build/scripts/build_kernel_entry.sh` passes
- marker strings are present in built kernel ELF (`strings artifacts/kernel/kernel.elf`)

## Issue
Closes #10
