### PR TITLE
Boot slice: add minimal VGA writer + hello output

### DIFF
--- a/build/scripts/build_kernel_entry.sh
+++ b/build/scripts/build_kernel_entry.sh
@@ -16,10 +16,11 @@ docker run --rm -v "$ROOT_DIR":/workspace -w /workspace "$IMAGE_TAG" bash -lc '
   nasm -f elf32 kernel/arch/x86/boot/entry.asm -o artifacts/kernel/entry.o
   clang --target=i386-unknown-none-elf -ffreestanding -fno-stack-protector -m32 -c kernel/core/kmain.c -o artifacts/kernel/kmain.o
   clang --target=i386-unknown-none-elf -ffreestanding -fno-stack-protector -m32 -c kernel/arch/x86/serial.c -o artifacts/kernel/serial.o
+  clang --target=i386-unknown-none-elf -ffreestanding -fno-stack-protector -m32 -c kernel/arch/x86/vga.c -o artifacts/kernel/vga.o
   ld.lld -m elf_i386 -T kernel/arch/x86/boot/linker.ld \
     -Map=artifacts/kernel/kernel.map \
     -o artifacts/kernel/kernel.elf \
-    artifacts/kernel/entry.o artifacts/kernel/kmain.o artifacts/kernel/serial.o
+    artifacts/kernel/entry.o artifacts/kernel/kmain.o artifacts/kernel/serial.o artifacts/kernel/vga.o
   if command -v llvm-objdump >/dev/null 2>&1; then
     llvm-objdump -h artifacts/kernel/kernel.elf > artifacts/kernel/kernel.sections.txt
   else

--- a/docs/BOOT_ENTRY_X86.md
+++ b/docs/BOOT_ENTRY_X86.md
@@ -6,6 +6,7 @@ This introduces a minimal x86 boot-entry handoff scaffold:
 - `kernel/arch/x86/boot/linker.ld` — linker layout + entrypoint at 1 MiB
 - `kernel/core/kmain.c` — `kmain` handoff target with early test markers
 - `kernel/arch/x86/serial.c` + `serial.h` — COM1 early serial driver
+- `kernel/arch/x86/vga.c` + `vga.h` — minimal VGA text writer (`0xB8000`)
 
 ## Build
 

--- a/kernel/arch/x86/vga.c
+++ b/kernel/arch/x86/vga.c
@@ -1,0 +1,47 @@
+#include "vga.h"
+
+#define VGA_BUFFER ((volatile unsigned short *)0xB8000)
+#define VGA_WIDTH 80
+#define VGA_HEIGHT 25
+#define VGA_ATTR 0x07
+
+static int row = 0;
+static int col = 0;
+
+static inline unsigned short vga_entry(char c) {
+  return (unsigned short)VGA_ATTR << 8 | (unsigned char)c;
+}
+
+void vga_clear(void) {
+  for (int y = 0; y < VGA_HEIGHT; y++) {
+    for (int x = 0; x < VGA_WIDTH; x++) {
+      VGA_BUFFER[y * VGA_WIDTH + x] = vga_entry(' ');
+    }
+  }
+  row = 0;
+  col = 0;
+}
+
+static void vga_putc(char c) {
+  if (c == '\n') {
+    col = 0;
+    row++;
+  } else {
+    VGA_BUFFER[row * VGA_WIDTH + col] = vga_entry(c);
+    col++;
+    if (col >= VGA_WIDTH) {
+      col = 0;
+      row++;
+    }
+  }
+
+  if (row >= VGA_HEIGHT) {
+    row = 0;
+  }
+}
+
+void vga_write(const char *s) {
+  for (; *s; s++) {
+    vga_putc(*s);
+  }
+}

--- a/kernel/arch/x86/vga.h
+++ b/kernel/arch/x86/vga.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void vga_clear(void);
+void vga_write(const char *s);

--- a/kernel/core/kmain.c
+++ b/kernel/core/kmain.c
@@ -1,9 +1,14 @@
 #include "../arch/x86/serial.h"
+#include "../arch/x86/vga.h"
 
 __attribute__((used))
 void kmain(void) {
   serial_init();
+  vga_clear();
+
   serial_write("TEST:START:boot_entry\n");
+  serial_write("Hello, SecureOS\n");
+  vga_write("Hello, SecureOS\n");
   serial_write("KMAIN_REACHED\n");
   serial_write("TEST:PASS:boot_entry\n");
 


### PR DESCRIPTION
## Summary
- add minimal VGA text writer (`kernel/arch/x86/vga.c` + `vga.h`) using text-mode framebuffer at `0xB8000`
- update `kmain` to output `Hello, SecureOS` to both serial and VGA paths
- include VGA module in kernel entry/linker build
- document VGA component in boot entry docs

## Validation
- `./build/scripts/build_kernel_entry.sh` passes
- built ELF contains expected boot marker and hello strings:
  - `TEST:START:boot_entry`
  - `TEST:PASS:boot_entry`
  - `Hello, SecureOS`

## Issue
Closes #11
