### PR TITLE
Issue #12: add isa-debug-exit pass/fail signaling

### DIFF
--- a/docs/BOOTSTRAP_TESTING.md
+++ b/docs/BOOTSTRAP_TESTING.md
@@ -15,7 +15,18 @@ This repository includes a minimal x86 boot sector validation to verify local bu
 - `nasm` can assemble a boot sector binary
 - output image is exactly 512 bytes with boot signature
 - `qemu-system-x86_64` boots the image headlessly
+- boot code exits through `isa-debug-exit` on I/O port `0xF4`
 - serial output contains `SecureOS boot sector OK`
+
+### Debug-exit code mapping
+
+Boot test binaries should write one byte to debug-exit (`out 0xF4, al`).
+`run_qemu.sh` maps those semantic codes to QEMU process return codes using:
+
+- `EXIT_PASS = 0x10` → expected QEMU return code `0x21` (`33`)
+- `EXIT_FAIL = 0x11` → expected QEMU return code `0x23` (`35`)
+
+The harness treats pass/fail based on debug-exit return mapping, not timeout behavior.
 
 ### Expected result
 

--- a/experiments/bootloader/boot.asm
+++ b/experiments/bootloader/boot.asm
@@ -2,6 +2,9 @@
 [bits 16]
 
 %define COM1 0x3F8
+%define DEBUG_EXIT 0xF4
+%define EXIT_PASS 0x10
+%define EXIT_FAIL 0x11
 
 start:
     cli
@@ -22,10 +25,12 @@ start:
     jmp .print
 
 .done:
-    cli
-.hang:
-    hlt
-    jmp .hang
+    mov al, EXIT_PASS
+    call debug_exit
+
+.fail:
+    mov al, EXIT_FAIL
+    call debug_exit
 
 serial_init:
     ; Disable interrupts
@@ -74,6 +79,14 @@ serial_out:
     mov dx, COM1
     out dx, al
     ret
+
+debug_exit:
+    mov dx, DEBUG_EXIT
+    out dx, al
+    cli
+.hang:
+    hlt
+    jmp .hang
 
 msg db 'SecureOS boot sector OK', 0x0D, 0x0A, 0
 


### PR DESCRIPTION
## Summary
- add bootloader debug-exit helper on I/O port `0xF4`
- emit explicit pass/fail semantic codes (`0x10` pass, `0x11` fail) from boot test
- run QEMU with `isa-debug-exit` and evaluate pass/fail using deterministic return-code mapping
- document return-code mapping in bootstrap testing docs

Closes #12

## Validation
- `./build/scripts/test.sh hello_boot`
  - result: PASS
  - `artifacts/qemu/hello_boot.meta.json` shows `qemuExitCode=33`, `debugExitResult=pass`, `status=pass`
