### PR TITLE
Issue #13: add hello_boot structured markers and parser validation

### DIFF
--- a/docs/BOOTSTRAP_TESTING.md
+++ b/docs/BOOTSTRAP_TESTING.md
@@ -7,7 +7,7 @@ This repository includes a minimal x86 boot sector validation to verify local bu
 ### Run
 
 ```bash
-./build/scripts/test_boot_sector.sh
+./build/scripts/test.sh hello_boot
 ```
 
 ### What it checks
@@ -17,6 +17,10 @@ This repository includes a minimal x86 boot sector validation to verify local bu
 - `qemu-system-x86_64` boots the image headlessly
 - boot code exits through `isa-debug-exit` on I/O port `0xF4`
 - serial output contains `SecureOS boot sector OK`
+- structured markers are present:
+  - `TEST:START:hello_boot`
+  - `TEST:PASS:hello_boot`
+  - no `TEST:FAIL:hello_boot:<reason>` marker is present
 
 ### Debug-exit code mapping
 
@@ -33,5 +37,5 @@ The harness treats pass/fail based on debug-exit return mapping, not timeout beh
 The script prints QEMU serial output and ends with:
 
 ```text
-PASS: boot sector smoke test
+QEMU_PASS:hello_boot
 ```

--- a/experiments/bootloader/boot.asm
+++ b/experiments/bootloader/boot.asm
@@ -16,19 +16,22 @@ start:
 
     call serial_init
 
-    mov si, msg
-.print:
-    lodsb
-    test al, al
-    jz .done
-    call serial_out
-    jmp .print
+    mov si, marker_start
+    call serial_print
 
-.done:
+    mov si, msg_hello
+    call serial_print
+
+    mov si, marker_pass
+    call serial_print
+
     mov al, EXIT_PASS
     call debug_exit
 
 .fail:
+    mov si, marker_fail
+    call serial_print
+
     mov al, EXIT_FAIL
     call debug_exit
 
@@ -67,6 +70,16 @@ serial_init:
     out dx, al
     ret
 
+serial_print:
+.next:
+    lodsb
+    test al, al
+    jz .done
+    call serial_out
+    jmp .next
+.done:
+    ret
+
 serial_out:
     push ax
 .wait:
@@ -88,7 +101,10 @@ debug_exit:
     hlt
     jmp .hang
 
-msg db 'SecureOS boot sector OK', 0x0D, 0x0A, 0
+marker_start db 'TEST:START:hello_boot', 0x0D, 0x0A, 0
+msg_hello db 'SecureOS boot sector OK', 0x0D, 0x0A, 0
+marker_pass db 'TEST:PASS:hello_boot', 0x0D, 0x0A, 0
+marker_fail db 'TEST:FAIL:hello_boot:unexpected-path', 0x0D, 0x0A, 0
 
 times 510 - ($ - $$) db 0
 dw 0xAA55


### PR DESCRIPTION
## Summary
- emit structured boot markers from `experiments/bootloader/boot.asm`
  - `TEST:START:hello_boot`
  - `TEST:PASS:hello_boot`
  - `TEST:FAIL:hello_boot:<reason>` (reserved fail path)
- update `build/scripts/run_qemu.sh` to parse and validate marker presence/absence
- fail harness when marker contract is violated
- refresh bootstrap testing docs for marker + debug-exit expectations

## Validation
- `./build/scripts/test.sh hello_boot`

Closes #13
