### PR TITLE
Issue #14: add boot negative-path fixture + harness validation

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Boot smoke validation
         run: ./build/scripts/test.sh hello_boot
 
+      - name: Boot negative-path fixture validation
+        run: ./build/scripts/test.sh hello_boot_negative
+
       - name: Upload kernel artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 artifacts/
 experiments/bootloader/boot.bin
+experiments/bootloader/boot_fail.bin

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -6,7 +6,7 @@ TEST_NAME="${1:-hello_boot}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative]
 
 Runs SecureOS test targets.
 EOF
@@ -21,6 +21,10 @@ case "$TEST_NAME" in
   hello_boot)
     "$ROOT_DIR/build/scripts/test_boot_sector.sh"
     "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot
+    ;;
+  hello_boot_negative)
+    "$ROOT_DIR/build/scripts/test_boot_sector_fail.sh"
+    "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_boot_sector_fail.sh
+++ b/build/scripts/test_boot_sector_fail.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPERIMENT_DIR="$ROOT_DIR/experiments/bootloader"
+BOOT_ASM="$EXPERIMENT_DIR/boot_fail.asm"
+BOOT_BIN="$EXPERIMENT_DIR/boot_fail.bin"
+
+if [[ ! -f "$BOOT_ASM" ]]; then
+  echo "Missing failing fixture source: $BOOT_ASM"
+  exit 1
+fi
+
+command -v nasm >/dev/null 2>&1 || { echo "nasm is required"; exit 1; }
+
+nasm -f bin "$BOOT_ASM" -o "$BOOT_BIN"
+
+if [[ ! -f "$BOOT_BIN" ]]; then
+  echo "Failed to build failing boot sector fixture"
+  exit 1
+fi
+
+BOOT_SIZE=$(wc -c < "$BOOT_BIN" | tr -d '[:space:]')
+if [[ "$BOOT_SIZE" -ne 512 ]]; then
+  echo "Failing fixture size is not 512 bytes (got $BOOT_SIZE)"
+  exit 1
+fi
+
+echo "PASS: built failing boot sector fixture"

--- a/docs/BOOTSTRAP_TESTING.md
+++ b/docs/BOOTSTRAP_TESTING.md
@@ -32,10 +32,22 @@ Boot test binaries should write one byte to debug-exit (`out 0xF4, al`).
 
 The harness treats pass/fail based on debug-exit return mapping, not timeout behavior.
 
-### Expected result
+### Negative-path fixture
 
-The script prints QEMU serial output and ends with:
+Run intentional failing fixture validation:
+
+```bash
+./build/scripts/test.sh hello_boot_negative
+```
+
+Expected markers for this fixture:
+
+- `TEST:START:hello_boot_fail`
+- `TEST:FAIL:hello_boot_fail:intentional-fixture`
+- no pass marker
+
+Even though the fixture exits with `EXIT_FAIL`, the harness reports success when the failure is correctly detected and prints:
 
 ```text
-QEMU_PASS:hello_boot
+QEMU_PASS:hello_boot_fail
 ```

--- a/experiments/bootloader/boot_fail.asm
+++ b/experiments/bootloader/boot_fail.asm
@@ -1,0 +1,91 @@
+[org 0x7C00]
+[bits 16]
+
+%define COM1 0x3F8
+%define DEBUG_EXIT 0xF4
+%define EXIT_FAIL 0x11
+
+start:
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00
+
+    call serial_init
+
+    mov si, marker_start
+    call serial_print
+
+    mov si, marker_fail
+    call serial_print
+
+    mov al, EXIT_FAIL
+    call debug_exit
+
+serial_init:
+    mov dx, COM1 + 1
+    mov al, 0x00
+    out dx, al
+
+    mov dx, COM1 + 3
+    mov al, 0x80
+    out dx, al
+
+    mov dx, COM1 + 0
+    mov al, 0x03
+    out dx, al
+    mov dx, COM1 + 1
+    mov al, 0x00
+    out dx, al
+
+    mov dx, COM1 + 3
+    mov al, 0x03
+    out dx, al
+
+    mov dx, COM1 + 2
+    mov al, 0xC7
+    out dx, al
+
+    mov dx, COM1 + 4
+    mov al, 0x0B
+    out dx, al
+    ret
+
+serial_print:
+.next:
+    lodsb
+    test al, al
+    jz .done
+    call serial_out
+    jmp .next
+.done:
+    ret
+
+serial_out:
+    push ax
+.wait:
+    mov dx, COM1 + 5
+    in al, dx
+    test al, 0x20
+    jz .wait
+
+    pop ax
+    mov dx, COM1
+    out dx, al
+    ret
+
+debug_exit:
+    mov dx, DEBUG_EXIT
+    out dx, al
+    cli
+.hang:
+    hlt
+    jmp .hang
+
+marker_start db 'TEST:START:hello_boot_fail', 0x0D, 0x0A, 0
+marker_fail db 'TEST:FAIL:hello_boot_fail:intentional-fixture', 0x0D, 0x0A, 0
+
+times 510 - ($ - $$) db 0
+dw 0xAA55


### PR DESCRIPTION
## Summary
- add an intentional failing boot fixture (`hello_boot_fail`) with deterministic markers
- extend `run_qemu.sh` to support expected fail fixtures and still produce machine-readable metadata
- add `hello_boot_negative` test target and run it in PR CI
- document negative-path validation usage in bootstrap testing docs

## Validation
- `./build/scripts/test.sh hello_boot`
- `./build/scripts/test.sh hello_boot_negative`

Closes #14