### PR TITLE
Issue #32: implement CAP-001 capability API contract

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Boot negative-path fixture validation
         run: ./build/scripts/test.sh hello_boot_negative
 
+      - name: Capability API contract validation
+        run: ./build/scripts/test.sh cap_api_contract
+
       - name: Upload kernel artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -6,7 +6,7 @@ TEST_NAME="${1:-hello_boot}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract]
 
 Runs SecureOS test targets.
 EOF
@@ -25,6 +25,9 @@ case "$TEST_NAME" in
   hello_boot_negative)
     "$ROOT_DIR/build/scripts/test_boot_sector_fail.sh"
     "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail
+    ;;
+  cap_api_contract)
+    "$ROOT_DIR/build/scripts/test_cap_api_contract.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_cap_api_contract.sh
+++ b/build/scripts/test_cap_api_contract.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/tests/cap_api_contract_test.c" \
+  -o "$OUT_DIR/cap_api_contract_test"
+
+"$OUT_DIR/cap_api_contract_test"

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -1,0 +1,35 @@
+# SecureOS Capabilities (M1 bootstrap)
+
+## CAP-001 contract
+
+SecureOS capability checks are deny-by-default and produce explicit result codes.
+
+### Capability IDs
+
+Current stable IDs:
+
+- `CAP_CONSOLE_WRITE = 1`
+
+Rules:
+
+- IDs are append-only once merged.
+- Existing numeric IDs are never renumbered.
+- Unknown IDs must return `CAP_ERR_CAP_INVALID`.
+
+### Check result semantics
+
+- `CAP_OK` — subject has explicit grant.
+- `CAP_ERR_MISSING` — subject is valid but capability is not granted.
+- `CAP_ERR_SUBJECT_INVALID` — subject identifier is out of bounds/unknown.
+- `CAP_ERR_CAP_INVALID` — capability identifier is out of bounds/unknown.
+
+### Zero-trust invariants
+
+- Default state is deny for all subject/capability pairs.
+- No implicit grants are allowed.
+- Invalid inputs are explicit errors, never treated as success.
+
+## Follow-on
+
+- CAP-002: dedicated per-subject table abstraction with explicit grant/revoke flows.
+- CAP-003: gate first privileged operation (console write) behind capability checks.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -21,8 +21,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M0-TOOLING-002 | M0 | Canonical build/test/run wrapper scripts | M0-TOOLING-001 | `./build/scripts/test.sh hello_boot` | done |
 | M0-BOOT-001 | M0 | Deterministic QEMU harness args + metadata | M0-TOOLING-002 | `./build/scripts/test.sh hello_boot` | done |
 | M0-BOOT-002 | M0 | Boot smoke marker parser and pass/fail contract | M0-BOOT-001 | `./build/scripts/test.sh hello_boot` | done |
-| M0-BOOT-003 | M0 | Negative-path failing fixture in harness | M0-BOOT-002 | `./build/scripts/test.sh hello_boot_negative` | todo |
-| M1-CAP-001 | M1 | Capability IDs + check API skeleton | M0-BOOT-003 | `./build/scripts/test.sh capability_model` | todo |
+| M0-BOOT-003 | M0 | Negative-path failing fixture in harness | M0-BOOT-002 | `./build/scripts/test.sh hello_boot_negative` | done |
+| M1-CAP-001 | M1 | Capability IDs + check API skeleton | M0-BOOT-003 | `./build/scripts/test.sh cap_api_contract` | in-progress |
 | M1-CAP-002 | M1 | Per-subject capability table (deny-by-default) | M1-CAP-001 | `./build/scripts/test.sh capability_table` | todo |
 | M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | todo |
 | M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | todo |

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -1,0 +1,52 @@
+#include "capability.h"
+
+#define CAP_SUBJECT_MAX 8u
+#define CAP_ID_MAX CAP_CONSOLE_WRITE
+
+static uint8_t subject_console_write_grant[CAP_SUBJECT_MAX];
+
+static int cap_subject_valid(cap_subject_id_t subject_id) {
+  return subject_id < CAP_SUBJECT_MAX;
+}
+
+static int cap_id_valid(capability_id_t capability_id) {
+  return capability_id >= CAP_CONSOLE_WRITE && capability_id <= CAP_ID_MAX;
+}
+
+void cap_reset_for_tests(void) {
+  for (uint32_t i = 0; i < CAP_SUBJECT_MAX; ++i) {
+    subject_console_write_grant[i] = 0;
+  }
+}
+
+cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
+  if (!cap_subject_valid(subject_id)) {
+    return CAP_ERR_SUBJECT_INVALID;
+  }
+
+  if (!cap_id_valid(capability_id)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  if (capability_id == CAP_CONSOLE_WRITE) {
+    subject_console_write_grant[subject_id] = 1;
+  }
+
+  return CAP_OK;
+}
+
+cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id) {
+  if (!cap_subject_valid(subject_id)) {
+    return CAP_ERR_SUBJECT_INVALID;
+  }
+
+  if (!cap_id_valid(capability_id)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  if (capability_id == CAP_CONSOLE_WRITE && subject_console_write_grant[subject_id] == 1) {
+    return CAP_OK;
+  }
+
+  return CAP_ERR_MISSING;
+}

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -1,0 +1,23 @@
+#ifndef SECUREOS_CAPABILITY_H
+#define SECUREOS_CAPABILITY_H
+
+#include <stdint.h>
+
+typedef uint32_t cap_subject_id_t;
+
+typedef enum {
+  CAP_CONSOLE_WRITE = 1,
+} capability_id_t;
+
+typedef enum {
+  CAP_OK = 0,
+  CAP_ERR_MISSING = 1,
+  CAP_ERR_SUBJECT_INVALID = 2,
+  CAP_ERR_CAP_INVALID = 3,
+} cap_result_t;
+
+void cap_reset_for_tests(void);
+cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
+cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id);
+
+#endif

--- a/tests/cap_api_contract_test.c
+++ b/tests/cap_api_contract_test.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/capability.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_api_contract:%s\n", reason);
+  exit(1);
+}
+
+int main(void) {
+  printf("TEST:START:cap_api_contract\n");
+
+  cap_reset_for_tests();
+
+  if (cap_check(0u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("default_deny");
+  }
+  printf("TEST:PASS:cap_api_contract_default_deny\n");
+
+  if (cap_grant_for_tests(0u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_failed");
+  }
+  if (cap_check(0u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("allow_failed");
+  }
+  printf("TEST:PASS:cap_api_contract_allow\n");
+
+  if (cap_check(999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_subject");
+  }
+  if (cap_check(0u, (capability_id_t)999u) != CAP_ERR_CAP_INVALID) {
+    fail("invalid_cap");
+  }
+  printf("TEST:PASS:cap_api_contract_invalid_inputs\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add CAP-001 capability API surface with stable `CAP_CONSOLE_WRITE` ID and explicit result semantics
- implement deterministic deny-by-default checks plus test-only grant/reset helpers
- add `cap_api_contract` validation target with machine-readable pass/fail markers
- document capability invariants and update M0→M1 task registry status
- run CAP-001 validation in PR CI workflow

## Validation
- `./build/scripts/test.sh cap_api_contract`
- `./build/scripts/test.sh hello_boot`
- `./build/scripts/test.sh hello_boot_negative`

Closes #32
