### PR TITLE
M1 CAP-003: gate privileged console path behind capability checks

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -6,7 +6,7 @@ TEST_NAME="${1:-hello_boot}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate]
 
 Runs SecureOS test targets.
 EOF
@@ -31,6 +31,9 @@ case "$TEST_NAME" in
     ;;
   capability_table)
     "$ROOT_DIR/build/scripts/test_capability_table.sh"
+    ;;
+  capability_gate)
+    "$ROOT_DIR/build/scripts/test_capability_gate.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_capability_gate.sh
+++ b/build/scripts/test_capability_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/tests/capability_gate_test.c" \
+  -o "$OUT_DIR/capability_gate_test"
+
+"$OUT_DIR/capability_gate_test"

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -40,7 +40,20 @@ A fixed-capacity table now owns subject capability grants.
 
 Current implementation stores `CAP_CONSOLE_WRITE` grants in an internal array while keeping the table interface stable for additional capability IDs.
 
+## CAP-003 privileged console gate
+
+The first privileged path now enforces capability checks via `cap_console_write_gate(...)`.
+
+- The gate requires `CAP_CONSOLE_WRITE` before success.
+- Default path denies with `CAP_ERR_MISSING` until explicit grant.
+- Revoke restores deny behavior immediately.
+- Invalid subjects are rejected with `CAP_ERR_SUBJECT_INVALID`.
+
+Validation command:
+
+- `./build/scripts/test.sh capability_gate`
+
 ## Follow-on
 
-- CAP-003: gate first privileged operation (console write) behind capability checks.
+- CAP-004: capability allow/deny markers integrated in broader harness flows.
 - Extension path: move table internals from per-cap arrays to packed bitsets as capability IDs grow, without changing external API semantics.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -23,8 +23,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M0-BOOT-002 | M0 | Boot smoke marker parser and pass/fail contract | M0-BOOT-001 | `./build/scripts/test.sh hello_boot` | done |
 | M0-BOOT-003 | M0 | Negative-path failing fixture in harness | M0-BOOT-002 | `./build/scripts/test.sh hello_boot_negative` | done |
 | M1-CAP-001 | M1 | Capability IDs + check API skeleton | M0-BOOT-003 | `./build/scripts/test.sh cap_api_contract` | done |
-| M1-CAP-002 | M1 | Per-subject capability table (deny-by-default) | M1-CAP-001 | `./build/scripts/test.sh capability_table` | in-progress |
-| M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | todo |
+| M1-CAP-002 | M1 | Per-subject capability table (deny-by-default) | M1-CAP-001 | `./build/scripts/test.sh capability_table` | done |
+| M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | in-progress |
 | M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | todo |
 | M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-003 | `./build/scripts/test.sh hello_boot` | todo |
 

--- a/kernel/cap/cap_gate.c
+++ b/kernel/cap/cap_gate.c
@@ -1,0 +1,20 @@
+#include "cap_gate.h"
+
+#include <string.h>
+
+cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written) {
+  cap_result_t check_result = cap_check(subject_id, CAP_CONSOLE_WRITE);
+  if (check_result != CAP_OK) {
+    return check_result;
+  }
+
+  if (bytes_written != NULL) {
+    if (message == NULL) {
+      *bytes_written = 0u;
+    } else {
+      *bytes_written = strlen(message);
+    }
+  }
+
+  return CAP_OK;
+}

--- a/kernel/cap/cap_gate.h
+++ b/kernel/cap/cap_gate.h
@@ -1,0 +1,10 @@
+#ifndef SECUREOS_CAP_GATE_H
+#define SECUREOS_CAP_GATE_H
+
+#include <stddef.h>
+
+#include "capability.h"
+
+cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written);
+
+#endif

--- a/tests/capability_gate_test.c
+++ b/tests/capability_gate_test.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_gate.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_table.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:capability_gate:%s\n", reason);
+  exit(1);
+}
+
+int main(void) {
+  size_t bytes_written = 999u;
+
+  printf("TEST:START:capability_gate\n");
+
+  cap_table_init();
+
+  if (cap_console_write_gate(1u, "hello", &bytes_written) != CAP_ERR_MISSING) {
+    fail("default_deny_missing");
+  }
+  if (bytes_written != 999u) {
+    fail("default_deny_side_effect");
+  }
+  printf("TEST:PASS:capability_gate_default_deny\n");
+
+  if (cap_table_grant(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_failed");
+  }
+  if (cap_console_write_gate(1u, "secureos", &bytes_written) != CAP_OK) {
+    fail("allow_after_grant_missing");
+  }
+  if (bytes_written != 8u) {
+    fail("allow_after_grant_bad_count");
+  }
+  printf("TEST:PASS:capability_gate_allow_after_grant\n");
+
+  if (cap_table_revoke(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_failed");
+  }
+  if (cap_console_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
+    fail("revoke_restore_deny_missing");
+  }
+  printf("TEST:PASS:capability_gate_revoke_restores_deny\n");
+
+  if (cap_console_write_gate(CAP_TABLE_MAX_SUBJECTS, "secureos", &bytes_written) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_subject_not_rejected");
+  }
+  printf("TEST:PASS:capability_gate_invalid_subject\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `cap_console_write_gate(...)` privileged operation gate requiring `CAP_CONSOLE_WRITE`
- add deterministic `capability_gate` test target + markers
- wire `capability_gate` into `build/scripts/test.sh`
- update capability docs and M0/M1 registry status (CAP-002 done, CAP-003 in-progress)

## Validation
- ./build/scripts/test.sh cap_api_contract
- ./build/scripts/test.sh capability_table
- ./build/scripts/test.sh capability_gate

Closes #37
