### PR TITLE
CAP-004: integrate capability gate markers into validation bundle

### DIFF
--- a/build/scripts/test_capability_gate.sh
+++ b/build/scripts/test_capability_gate.sh
@@ -13,4 +13,10 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/tests/capability_gate_test.c" \
   -o "$OUT_DIR/capability_gate_test"
 
-"$OUT_DIR/capability_gate_test"
+LOG_PATH="$OUT_DIR/capability_gate_test.log"
+"$OUT_DIR/capability_gate_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:capability_gate_default_deny" "$LOG_PATH"
+grep -q "TEST:PASS:capability_gate_allow_after_grant" "$LOG_PATH"
+grep -q "TEST:PASS:capability_gate_revoke_restores_deny" "$LOG_PATH"
+grep -q "TEST:PASS:capability_gate_invalid_subject" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -15,6 +15,7 @@ TEST_TARGETS=(
   hello_boot_negative
   cap_api_contract
   capability_table
+  capability_gate
 )
 
 STATUS_LINES=()

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -24,8 +24,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M0-BOOT-003 | M0 | Negative-path failing fixture in harness | M0-BOOT-002 | `./build/scripts/test.sh hello_boot_negative` | done |
 | M1-CAP-001 | M1 | Capability IDs + check API skeleton | M0-BOOT-003 | `./build/scripts/test.sh cap_api_contract` | done |
 | M1-CAP-002 | M1 | Per-subject capability table (deny-by-default) | M1-CAP-001 | `./build/scripts/test.sh capability_table` | done |
-| M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | in-progress |
-| M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | todo |
+| M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | done |
+| M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | in-progress |
 | M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-003 | `./build/scripts/test.sh hello_boot` | todo |
 
 ## Notes


### PR DESCRIPTION
## Summary
- include `capability_gate` in `validate_bundle.sh` default test targets
- capture `capability_gate` marker output to `artifacts/tests/capability_gate_test.log`
- assert required capability gate PASS markers are present in the captured log
- update task registry status (`M1-CAP-003` done, `M1-CAP-004` in-progress)

## Validation
- ./build/scripts/test.sh capability_gate
- ./build/scripts/validate_bundle.sh

Closes #40
