### PR TITLE
CAP-005: add capability core ADR and mark M1 registry complete

### DIFF
--- a/docs/adr/0001-capability-core-boundary.md
+++ b/docs/adr/0001-capability-core-boundary.md
@@ -1,0 +1,68 @@
+# ADR 0001: Capability core boundary and first privileged gate
+
+- Status: Accepted
+- Date: 2026-02-16
+- Deciders: SecureOS maintainers
+- Related: M1-CAP-001, M1-CAP-002, M1-CAP-003, M1-CAP-004, M1-CAP-005
+
+## Context
+
+SecureOS M1 establishes the first enforceable capability boundary. Prior to M1, privileged paths were implicitly allowed and lacked machine-verifiable deny-by-default behavior.
+
+The M1 implementation introduced:
+
+- Stable capability IDs with explicit check result codes.
+- A bounded per-subject capability table with deny-by-default semantics.
+- A first privileged gate for console writes (`CAP_CONSOLE_WRITE`).
+- Deterministic allow/deny markers integrated into validation bundles.
+
+Without a committed architecture decision, future capability work risks drift in error semantics, ID stability, and validation contracts.
+
+## Decision
+
+Adopt the capability core boundary with these explicit architectural rules:
+
+1. **Capability IDs are stable and append-only**
+   - Existing numeric IDs are never renumbered.
+   - Unknown IDs return explicit invalid-capability errors.
+
+2. **Checks are deny-by-default with explicit outcomes**
+   - Success is only possible with an explicit grant.
+   - Missing grants and invalid inputs are distinct error states.
+
+3. **Capability storage is bounded by subject capacity**
+   - Subject identifiers are validated at API boundaries.
+   - Invalid subjects return explicit invalid-subject errors.
+
+4. **Privileged operations must route through capability gates**
+   - The first gate is console write.
+   - New privileged operations must add a gate before being considered complete.
+
+5. **Validation must remain deterministic and machine-readable**
+   - Capability gate tests must emit stable pass/fail markers.
+   - Validation bundles must include capability marker artifacts.
+
+## Consequences
+
+### Positive
+
+- Establishes a durable security contract for capability growth.
+- Keeps zero-trust default behavior testable in CI.
+- Reduces ambiguity for future privileged paths and review.
+
+### Trade-offs
+
+- Adds up-front work for each new privileged operation (gate + tests + markers).
+- Requires discipline to preserve marker compatibility over time.
+
+## Validation
+
+Current deterministic checks:
+
+- `./build/scripts/test.sh capability_gate`
+- `./build/scripts/test.sh hello_boot`
+
+## Follow-up
+
+- Extend capability IDs and table internals (e.g., packed bitsets) without breaking API semantics.
+- Gate additional privileged kernel operations one-by-one under the same contract.

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -55,5 +55,6 @@ Validation command:
 
 ## Follow-on
 
-- CAP-004: capability allow/deny markers integrated in broader harness flows.
+- CAP-004 is complete: capability allow/deny markers are integrated in broader harness flows and validation bundles.
+- CAP-005 is complete: see `docs/adr/0001-capability-core-boundary.md` for the architecture decision record.
 - Extension path: move table internals from per-cap arrays to packed bitsets as capability IDs grow, without changing external API semantics.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -25,8 +25,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-001 | M1 | Capability IDs + check API skeleton | M0-BOOT-003 | `./build/scripts/test.sh cap_api_contract` | done |
 | M1-CAP-002 | M1 | Per-subject capability table (deny-by-default) | M1-CAP-001 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | done |
-| M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | in-progress |
-| M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-003 | `./build/scripts/test.sh hello_boot` | todo |
+| M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | done |
+| M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-004 | `./build/scripts/test.sh hello_boot` | done |
 
 ## Notes
 


### PR DESCRIPTION
## Summary\n- add ADR 0001 documenting the capability core boundary contract for M1\n- update capability architecture doc to reflect CAP-004/CAP-005 completion\n- mark M1-CAP-004 and M1-CAP-005 as done in the M0→M1 task registry\n\n## Validation\n- ./build/scripts/test.sh hello_boot\n- ./build/scripts/test.sh capability_gate\n\nCloses #30