### PR TITLE
CAP-007: add serial-write capability gate + dual-cap isolation tests

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -9,6 +9,7 @@ SecureOS capability checks are deny-by-default and produce explicit result codes
 Current stable IDs:
 
 - `CAP_CONSOLE_WRITE = 1`
+- `CAP_SERIAL_WRITE = 2`
 
 Rules:
 
@@ -38,7 +39,7 @@ A fixed-capacity table now owns subject capability grants.
 - grant/revoke/check are explicit API calls with bounded input validation
 - invalid subject or capability IDs return explicit error codes
 
-Current implementation stores `CAP_CONSOLE_WRITE` grants in an internal array while keeping the table interface stable for additional capability IDs.
+Current implementation stores per-subject capability grants in packed bitsets, with explicit ID validation preserving append-only capability growth.
 
 ## CAP-003 privileged console gate
 
@@ -57,4 +58,5 @@ Validation command:
 
 - CAP-004 is complete: capability allow/deny markers are integrated in broader harness flows and validation bundles.
 - CAP-005 is complete: see `docs/adr/0001-capability-core-boundary.md` for the architecture decision record.
-- CAP-006 is active: migrate table internals from per-cap arrays to packed bitsets as capability IDs grow, without changing external API semantics.
+- CAP-006 is complete: table internals now use packed bitsets while preserving external API semantics.
+- CAP-007 is active: add a serial-write capability boundary and explicit gate validation without changing zero-trust defaults.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -27,7 +27,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-003 | M1 | Gate first privileged operation behind capability check | M1-CAP-002 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-004 | M1 | Capability allow/deny markers integrated in harness | M1-CAP-003 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-004 | `./build/scripts/test.sh hello_boot` | done |
-| M1-CAP-006 | M1 | Bitset-backed subject capability storage migration | M1-CAP-005 | `./build/scripts/test.sh capability_table` | in-progress |
+| M1-CAP-006 | M1 | Bitset-backed subject capability storage migration | M1-CAP-005 | `./build/scripts/test.sh capability_table` | done |
+| M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | in-progress |
 
 ## Notes
 

--- a/kernel/cap/cap_gate.c
+++ b/kernel/cap/cap_gate.c
@@ -2,8 +2,11 @@
 
 #include <string.h>
 
-cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written) {
-  cap_result_t check_result = cap_check(subject_id, CAP_CONSOLE_WRITE);
+static cap_result_t cap_write_gate(cap_subject_id_t subject_id,
+                                   capability_id_t required_capability,
+                                   const char *message,
+                                   size_t *bytes_written) {
+  cap_result_t check_result = cap_check(subject_id, required_capability);
   if (check_result != CAP_OK) {
     return check_result;
   }
@@ -17,4 +20,12 @@ cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *mes
   }
 
   return CAP_OK;
+}
+
+cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written) {
+  return cap_write_gate(subject_id, CAP_CONSOLE_WRITE, message, bytes_written);
+}
+
+cap_result_t cap_serial_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written) {
+  return cap_write_gate(subject_id, CAP_SERIAL_WRITE, message, bytes_written);
 }

--- a/kernel/cap/cap_gate.h
+++ b/kernel/cap/cap_gate.h
@@ -6,5 +6,6 @@
 #include "capability.h"
 
 cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written);
+cap_result_t cap_serial_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written);
 
 #endif

--- a/kernel/cap/cap_table.c
+++ b/kernel/cap/cap_table.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #define CAP_ID_MIN CAP_CONSOLE_WRITE
-#define CAP_ID_MAX CAP_CONSOLE_WRITE
+#define CAP_ID_MAX CAP_SERIAL_WRITE
 
 #define CAPABILITY_COUNT ((uint32_t)(CAP_ID_MAX - CAP_ID_MIN + 1u))
 #define CAP_WORD_BITS 8u

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -7,6 +7,7 @@ typedef uint32_t cap_subject_id_t;
 
 typedef enum {
   CAP_CONSOLE_WRITE = 1,
+  CAP_SERIAL_WRITE = 2,
 } capability_id_t;
 
 typedef enum {

--- a/tests/cap_api_contract_test.c
+++ b/tests/cap_api_contract_test.c
@@ -13,16 +13,37 @@ int main(void) {
 
   cap_reset_for_tests();
 
+  if (CAP_CONSOLE_WRITE != 1) {
+    fail("cap_console_write_id_stability");
+  }
+  if (CAP_SERIAL_WRITE != 2) {
+    fail("cap_serial_write_id_stability");
+  }
+  printf("TEST:PASS:cap_api_contract_id_stability\n");
+
   if (cap_check(0u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
-    fail("default_deny");
+    fail("default_deny_console");
+  }
+  if (cap_check(0u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("default_deny_serial");
   }
   printf("TEST:PASS:cap_api_contract_default_deny\n");
 
   if (cap_grant_for_tests(0u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("grant_failed");
+    fail("grant_console_failed");
   }
   if (cap_check(0u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("allow_failed");
+    fail("allow_console_failed");
+  }
+  if (cap_check(0u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("allow_console_leaked_serial");
+  }
+
+  if (cap_grant_for_tests(0u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_serial_failed");
+  }
+  if (cap_check(0u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("allow_serial_failed");
   }
   printf("TEST:PASS:cap_api_contract_allow\n");
 

--- a/tests/capability_gate_test.c
+++ b/tests/capability_gate_test.c
@@ -18,7 +18,10 @@ int main(void) {
   cap_table_init();
 
   if (cap_console_write_gate(1u, "hello", &bytes_written) != CAP_ERR_MISSING) {
-    fail("default_deny_missing");
+    fail("default_deny_console_missing");
+  }
+  if (cap_serial_write_gate(1u, "hello", &bytes_written) != CAP_ERR_MISSING) {
+    fail("default_deny_serial_missing");
   }
   if (bytes_written != 999u) {
     fail("default_deny_side_effect");
@@ -26,26 +29,50 @@ int main(void) {
   printf("TEST:PASS:capability_gate_default_deny\n");
 
   if (cap_table_grant(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("grant_failed");
+    fail("grant_console_failed");
   }
   if (cap_console_write_gate(1u, "secureos", &bytes_written) != CAP_OK) {
-    fail("allow_after_grant_missing");
+    fail("allow_console_after_grant_missing");
   }
   if (bytes_written != 8u) {
-    fail("allow_after_grant_bad_count");
+    fail("allow_console_after_grant_bad_count");
+  }
+  if (cap_serial_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
+    fail("console_grant_leaked_serial");
   }
   printf("TEST:PASS:capability_gate_allow_after_grant\n");
+  printf("TEST:PASS:capability_gate_console_allow_after_grant\n");
+
+  if (cap_table_grant(1u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_serial_failed");
+  }
+  if (cap_serial_write_gate(1u, "secureos", &bytes_written) != CAP_OK) {
+    fail("allow_serial_after_grant_missing");
+  }
+  if (bytes_written != 8u) {
+    fail("allow_serial_after_grant_bad_count");
+  }
+  printf("TEST:PASS:capability_gate_serial_allow_after_grant\n");
 
   if (cap_table_revoke(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("revoke_failed");
+    fail("revoke_console_failed");
   }
   if (cap_console_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
-    fail("revoke_restore_deny_missing");
+    fail("revoke_console_restore_deny_missing");
+  }
+  if (cap_table_revoke(1u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("revoke_serial_failed");
+  }
+  if (cap_serial_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
+    fail("revoke_serial_restore_deny_missing");
   }
   printf("TEST:PASS:capability_gate_revoke_restores_deny\n");
 
   if (cap_console_write_gate(CAP_TABLE_MAX_SUBJECTS, "secureos", &bytes_written) != CAP_ERR_SUBJECT_INVALID) {
-    fail("invalid_subject_not_rejected");
+    fail("invalid_subject_console_not_rejected");
+  }
+  if (cap_serial_write_gate(CAP_TABLE_MAX_SUBJECTS, "secureos", &bytes_written) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_subject_serial_not_rejected");
   }
   printf("TEST:PASS:capability_gate_invalid_subject\n");
 

--- a/tests/capability_table_test.c
+++ b/tests/capability_table_test.c
@@ -16,43 +16,74 @@ int main(void) {
 
   for (cap_subject_id_t subject = 0; subject < CAP_TABLE_MAX_SUBJECTS; ++subject) {
     if (cap_table_check(subject, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
-      fail("default_deny");
+      fail("default_deny_console");
+    }
+    if (cap_table_check(subject, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+      fail("default_deny_serial");
     }
   }
   printf("TEST:PASS:capability_table_default_deny\n");
 
   if (cap_table_grant(3u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("grant_failed");
+    fail("grant_console_failed");
   }
   if (cap_table_check(3u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("grant_allow_missing");
+    fail("grant_console_allow_missing");
+  }
+  if (cap_table_check(3u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_console_leaked_serial");
   }
   if (cap_table_check(2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
-    fail("grant_leaked_subject");
+    fail("grant_console_leaked_subject");
+  }
+
+  if (cap_table_grant(4u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_serial_failed");
+  }
+  if (cap_table_check(4u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_serial_allow_missing");
+  }
+  if (cap_table_check(4u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_serial_leaked_console");
+  }
+  if (cap_table_check(3u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_serial_leaked_subject");
   }
   printf("TEST:PASS:capability_table_grant_allow\n");
 
   if (cap_table_revoke(3u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("revoke_failed");
+    fail("revoke_console_failed");
   }
   if (cap_table_check(3u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
-    fail("revoke_deny_missing");
+    fail("revoke_console_deny_missing");
+  }
+  if (cap_table_revoke(4u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("revoke_serial_failed");
+  }
+  if (cap_table_check(4u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("revoke_serial_deny_missing");
   }
   printf("TEST:PASS:capability_table_revoke_deny\n");
 
   if (cap_table_grant(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
-    fail("grant_before_reset_failed");
+    fail("grant_before_reset_console_failed");
+  }
+  if (cap_table_grant(1u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_before_reset_serial_failed");
   }
   cap_table_reset();
   if (cap_table_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
-    fail("reset_default_deny_missing");
+    fail("reset_default_deny_console_missing");
+  }
+  if (cap_table_check(1u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("reset_default_deny_serial_missing");
   }
   printf("TEST:PASS:capability_table_reset_clears_grants\n");
 
   if (cap_table_grant(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
     fail("invalid_subject_grant");
   }
-  if (cap_table_revoke(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+  if (cap_table_revoke(CAP_TABLE_MAX_SUBJECTS, CAP_SERIAL_WRITE) != CAP_ERR_SUBJECT_INVALID) {
     fail("invalid_subject_revoke");
   }
   if (cap_table_check(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {


### PR DESCRIPTION
## Summary\n- add append-only capability id \n- extend cap gate API with  using explicit cap-check semantics\n- expand capability table/gate/API tests for dual-capability deny-by-default + isolation behavior\n- update architecture + M0/M1 registry docs (CAP-006 done, CAP-007 in-progress)\n\n## Validation\n- TEST:START:cap_api_contract
TEST:PASS:cap_api_contract_id_stability
TEST:PASS:cap_api_contract_default_deny
TEST:PASS:cap_api_contract_allow
TEST:PASS:cap_api_contract_invalid_inputs\n- TEST:START:capability_table
TEST:PASS:capability_table_default_deny
TEST:PASS:capability_table_grant_allow
TEST:PASS:capability_table_revoke_deny
TEST:PASS:capability_table_reset_clears_grants
TEST:PASS:capability_table_invalid_inputs\n- TEST:START:capability_gate
TEST:PASS:capability_gate_default_deny
TEST:PASS:capability_gate_allow_after_grant
TEST:PASS:capability_gate_console_allow_after_grant
TEST:PASS:capability_gate_serial_allow_after_grant
TEST:PASS:capability_gate_revoke_restores_deny
TEST:PASS:capability_gate_invalid_subject\n- c[?7l[2J[0mSeaBIOS (version rel-1.17.0-0-gb52ca86e094d-prebuilt.qemu.org)


iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+06FD1EC0+06F31EC0 CA00
Press Ctrl-B to configure iPXE (PCI 00:03.0)...                                                                               


Booting from Hard Disk...
Boot failed: could not read the boot disk

Booting from Floppy...
TEST:START:hello_boot
SecureOS boot sector OK
TEST:PASS:hello_boot
PASS: boot sector smoke test
c[?7l[2J[0mSeaBIOS (version rel-1.17.0-0-gb52ca86e094d-prebuilt.qemu.org)


iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+0EFD1EC0+0EF31EC0 CA00
Press Ctrl-B to configure iPXE (PCI 00:03.0)...
                                                                               


Booting from Hard Disk...
Boot failed: could not read the boot disk

Booting from Floppy...
TEST:START:hello_boot
SecureOS boot sector OK
TEST:PASS:hello_boot
META:/Users/rwrife/.openclaw/workspace/SecureOS/artifacts/qemu/hello_boot.meta.json
QEMU_PASS:hello_boot
PASS: built failing boot sector fixture
c[?7l[2J[0mSeaBIOS (version rel-1.17.0-0-gb52ca86e094d-prebuilt.qemu.org)


iPXE (http://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+0EFD1EC0+0EF31EC0 CA00
Press Ctrl-B to configure iPXE (PCI 00:03.0)...
                                                                               


Booting from Hard Disk...
Boot failed: could not read the boot disk

Booting from Floppy...
TEST:START:hello_boot_fail
TEST:FAIL:hello_boot_fail:intentional-fixture
META:/Users/rwrife/.openclaw/workspace/SecureOS/artifacts/qemu/hello_boot_fail.meta.json
QEMU_PASS:hello_boot_fail
TEST:START:cap_api_contract
TEST:PASS:cap_api_contract_id_stability
TEST:PASS:cap_api_contract_default_deny
TEST:PASS:cap_api_contract_allow
TEST:PASS:cap_api_contract_invalid_inputs
TEST:START:capability_table
TEST:PASS:capability_table_default_deny
TEST:PASS:capability_table_grant_allow
TEST:PASS:capability_table_revoke_deny
TEST:PASS:capability_table_reset_clears_grants
TEST:PASS:capability_table_invalid_inputs
TEST:START:capability_gate
TEST:PASS:capability_gate_default_deny
TEST:PASS:capability_gate_allow_after_grant
TEST:PASS:capability_gate_console_allow_after_grant
TEST:PASS:capability_gate_serial_allow_after_grant
TEST:PASS:capability_gate_revoke_restores_deny
TEST:PASS:capability_gate_invalid_subject
VALIDATION_REPORT:/Users/rwrife/.openclaw/workspace/SecureOS/artifacts/runs/20260218T020330Z-8b87293/validator_report.json
VALIDATION_PASS:/Users/rwrife/.openclaw/workspace/SecureOS/artifacts/runs/20260218T020330Z-8b87293/validator_report.json\n\nCloses #45