### PR TITLE
M1-CAP-008: gate debug-exit behind explicit capability checks

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -10,6 +10,7 @@ Current stable IDs:
 
 - `CAP_CONSOLE_WRITE = 1`
 - `CAP_SERIAL_WRITE = 2`
+- `CAP_DEBUG_EXIT = 3`
 
 Rules:
 
@@ -59,4 +60,5 @@ Validation command:
 - CAP-004 is complete: capability allow/deny markers are integrated in broader harness flows and validation bundles.
 - CAP-005 is complete: see `docs/adr/0001-capability-core-boundary.md` for the architecture decision record.
 - CAP-006 is complete: table internals now use packed bitsets while preserving external API semantics.
-- CAP-007 is active: add a serial-write capability boundary and explicit gate validation without changing zero-trust defaults.
+- CAP-007 is complete: serial-write capability boundary and dual-cap isolation tests are merged.
+- CAP-008 is active: gate debug-exit authorization behind explicit capability checks and marker-backed validation.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -29,6 +29,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-004 | `./build/scripts/test.sh hello_boot` | done |
 | M1-CAP-006 | M1 | Bitset-backed subject capability storage migration | M1-CAP-005 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | done |
+| M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | in-progress |
 
 ## Notes
 

--- a/kernel/cap/cap_gate.c
+++ b/kernel/cap/cap_gate.c
@@ -29,3 +29,8 @@ cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *mes
 cap_result_t cap_serial_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written) {
   return cap_write_gate(subject_id, CAP_SERIAL_WRITE, message, bytes_written);
 }
+
+cap_result_t cap_debug_exit_gate(cap_subject_id_t subject_id, int exit_code) {
+  (void)exit_code;
+  return cap_check(subject_id, CAP_DEBUG_EXIT);
+}

--- a/kernel/cap/cap_gate.h
+++ b/kernel/cap/cap_gate.h
@@ -7,5 +7,6 @@
 
 cap_result_t cap_console_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written);
 cap_result_t cap_serial_write_gate(cap_subject_id_t subject_id, const char *message, size_t *bytes_written);
+cap_result_t cap_debug_exit_gate(cap_subject_id_t subject_id, int exit_code);
 
 #endif

--- a/kernel/cap/cap_table.c
+++ b/kernel/cap/cap_table.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #define CAP_ID_MIN CAP_CONSOLE_WRITE
-#define CAP_ID_MAX CAP_SERIAL_WRITE
+#define CAP_ID_MAX CAP_DEBUG_EXIT
 
 #define CAPABILITY_COUNT ((uint32_t)(CAP_ID_MAX - CAP_ID_MIN + 1u))
 #define CAP_WORD_BITS 8u

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -8,6 +8,7 @@ typedef uint32_t cap_subject_id_t;
 typedef enum {
   CAP_CONSOLE_WRITE = 1,
   CAP_SERIAL_WRITE = 2,
+  CAP_DEBUG_EXIT = 3,
 } capability_id_t;
 
 typedef enum {

--- a/tests/capability_gate_test.c
+++ b/tests/capability_gate_test.c
@@ -23,6 +23,9 @@ int main(void) {
   if (cap_serial_write_gate(1u, "hello", &bytes_written) != CAP_ERR_MISSING) {
     fail("default_deny_serial_missing");
   }
+  if (cap_debug_exit_gate(1u, 0) != CAP_ERR_MISSING) {
+    fail("default_deny_debug_exit_missing");
+  }
   if (bytes_written != 999u) {
     fail("default_deny_side_effect");
   }
@@ -40,6 +43,9 @@ int main(void) {
   if (cap_serial_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
     fail("console_grant_leaked_serial");
   }
+  if (cap_debug_exit_gate(1u, 0) != CAP_ERR_MISSING) {
+    fail("console_grant_leaked_debug_exit");
+  }
   printf("TEST:PASS:capability_gate_allow_after_grant\n");
   printf("TEST:PASS:capability_gate_console_allow_after_grant\n");
 
@@ -52,7 +58,18 @@ int main(void) {
   if (bytes_written != 8u) {
     fail("allow_serial_after_grant_bad_count");
   }
+  if (cap_debug_exit_gate(1u, 0) != CAP_ERR_MISSING) {
+    fail("serial_grant_leaked_debug_exit");
+  }
   printf("TEST:PASS:capability_gate_serial_allow_after_grant\n");
+
+  if (cap_table_grant(1u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("grant_debug_exit_failed");
+  }
+  if (cap_debug_exit_gate(1u, 33) != CAP_OK) {
+    fail("allow_debug_exit_after_grant_missing");
+  }
+  printf("TEST:PASS:capability_gate_debug_exit_allow_after_grant\n");
 
   if (cap_table_revoke(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("revoke_console_failed");
@@ -66,6 +83,12 @@ int main(void) {
   if (cap_serial_write_gate(1u, "secureos", &bytes_written) != CAP_ERR_MISSING) {
     fail("revoke_serial_restore_deny_missing");
   }
+  if (cap_table_revoke(1u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("revoke_debug_exit_failed");
+  }
+  if (cap_debug_exit_gate(1u, 33) != CAP_ERR_MISSING) {
+    fail("revoke_debug_exit_restore_deny_missing");
+  }
   printf("TEST:PASS:capability_gate_revoke_restores_deny\n");
 
   if (cap_console_write_gate(CAP_TABLE_MAX_SUBJECTS, "secureos", &bytes_written) != CAP_ERR_SUBJECT_INVALID) {
@@ -73,6 +96,9 @@ int main(void) {
   }
   if (cap_serial_write_gate(CAP_TABLE_MAX_SUBJECTS, "secureos", &bytes_written) != CAP_ERR_SUBJECT_INVALID) {
     fail("invalid_subject_serial_not_rejected");
+  }
+  if (cap_debug_exit_gate(CAP_TABLE_MAX_SUBJECTS, 33) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_subject_debug_exit_not_rejected");
   }
   printf("TEST:PASS:capability_gate_invalid_subject\n");
 

--- a/tests/capability_table_test.c
+++ b/tests/capability_table_test.c
@@ -21,6 +21,9 @@ int main(void) {
     if (cap_table_check(subject, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
       fail("default_deny_serial");
     }
+    if (cap_table_check(subject, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+      fail("default_deny_debug_exit");
+    }
   }
   printf("TEST:PASS:capability_table_default_deny\n");
 
@@ -49,6 +52,19 @@ int main(void) {
   if (cap_table_check(3u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
     fail("grant_serial_leaked_subject");
   }
+
+  if (cap_table_grant(5u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("grant_debug_exit_failed");
+  }
+  if (cap_table_check(5u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("grant_debug_exit_allow_missing");
+  }
+  if (cap_table_check(5u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_debug_exit_leaked_console");
+  }
+  if (cap_table_check(5u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_debug_exit_leaked_serial");
+  }
   printf("TEST:PASS:capability_table_grant_allow\n");
 
   if (cap_table_revoke(3u, CAP_CONSOLE_WRITE) != CAP_OK) {
@@ -63,6 +79,12 @@ int main(void) {
   if (cap_table_check(4u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
     fail("revoke_serial_deny_missing");
   }
+  if (cap_table_revoke(5u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("revoke_debug_exit_failed");
+  }
+  if (cap_table_check(5u, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+    fail("revoke_debug_exit_deny_missing");
+  }
   printf("TEST:PASS:capability_table_revoke_deny\n");
 
   if (cap_table_grant(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
@@ -71,12 +93,18 @@ int main(void) {
   if (cap_table_grant(1u, CAP_SERIAL_WRITE) != CAP_OK) {
     fail("grant_before_reset_serial_failed");
   }
+  if (cap_table_grant(1u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("grant_before_reset_debug_exit_failed");
+  }
   cap_table_reset();
   if (cap_table_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
     fail("reset_default_deny_console_missing");
   }
   if (cap_table_check(1u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
     fail("reset_default_deny_serial_missing");
+  }
+  if (cap_table_check(1u, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+    fail("reset_default_deny_debug_exit_missing");
   }
   printf("TEST:PASS:capability_table_reset_clears_grants\n");
 


### PR DESCRIPTION
## Summary
Implements issue #48 / CAP-008 by adding an explicit debug-exit capability boundary and deterministic authorization tests.

## Changes
- Add append-only capability ID: `CAP_DEBUG_EXIT = 3`.
- Add `cap_debug_exit_gate(subject_id, exit_code)` API in capability gates.
- Expand capability table tests for debug-exit default-deny, grant isolation, revoke, and reset behavior.
- Expand capability gate tests for debug-exit deny/allow/revoke + invalid subject behavior.
- Update capability docs and task registry (`M1-CAP-008` marked in-progress).

## Validation
- `./build/scripts/test.sh capability_table`
- `./build/scripts/test.sh capability_gate`
- `./build/scripts/validate_bundle.sh`

All pass locally with deterministic markers.
