### PR TITLE
docs: close out M1-CAP-008 registry status

### DIFF
--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -29,7 +29,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-005 | M1 | Capability core ADR + architecture docs | M1-CAP-004 | `./build/scripts/test.sh hello_boot` | done |
 | M1-CAP-006 | M1 | Bitset-backed subject capability storage migration | M1-CAP-005 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | done |
-| M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | in-progress |
+| M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | done |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- mark M1-CAP-008 as done in the M0→M1 task registry now that PR #49 merged

## Validation
- ./build/scripts/test.sh capability_gate

Closes #48
