### PR TITLE
cap: implement M1-CAP-009 audit ring for capability checks

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -6,7 +6,7 @@ TEST_NAME="${1:-hello_boot}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit]
 
 Runs SecureOS test targets.
 EOF
@@ -34,6 +34,9 @@ case "$TEST_NAME" in
     ;;
   capability_gate)
     "$ROOT_DIR/build/scripts/test_capability_gate.sh"
+    ;;
+  capability_audit)
+    "$ROOT_DIR/build/scripts/test_capability_audit.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_capability_audit.sh
+++ b/build/scripts/test_capability_audit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/tests/capability_audit_test.c" \
+  -o "$OUT_DIR/capability_audit_test"
+
+LOG_PATH="$OUT_DIR/capability_audit_test.log"
+"$OUT_DIR/capability_audit_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:capability_audit_core_paths" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_ring_wrap" "$LOG_PATH"

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -61,4 +61,5 @@ Validation command:
 - CAP-005 is complete: see `docs/adr/0001-capability-core-boundary.md` for the architecture decision record.
 - CAP-006 is complete: table internals now use packed bitsets while preserving external API semantics.
 - CAP-007 is complete: serial-write capability boundary and dual-cap isolation tests are merged.
-- CAP-008 is active: gate debug-exit authorization behind explicit capability checks and marker-backed validation.
+- CAP-008 is complete: debug-exit authorization is gated behind explicit capability checks and marker-backed validation.
+- CAP-009 is complete: capability checks now write deterministic audit events (subject, capability, result) into a bounded ring buffer for test-time visibility without changing allow/deny semantics.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -30,6 +30,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-006 | M1 | Bitset-backed subject capability storage migration | M1-CAP-005 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | done |
+| M1-CAP-009 | M1 | Capability-check audit log + deterministic ring-buffer tests | M1-CAP-008 | `./build/scripts/test.sh capability_audit` | done |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -2,8 +2,50 @@
 
 #include "cap_table.h"
 
+static cap_audit_event_t cap_audit_events[CAP_AUDIT_EVENT_MAX];
+static size_t cap_audit_next_index;
+static size_t cap_audit_event_count;
+
+static void cap_audit_record(cap_subject_id_t subject_id,
+                             capability_id_t capability_id,
+                             cap_result_t result) {
+  cap_audit_events[cap_audit_next_index].subject_id = subject_id;
+  cap_audit_events[cap_audit_next_index].capability_id = capability_id;
+  cap_audit_events[cap_audit_next_index].result = result;
+
+  cap_audit_next_index = (cap_audit_next_index + 1u) % CAP_AUDIT_EVENT_MAX;
+  if (cap_audit_event_count < CAP_AUDIT_EVENT_MAX) {
+    cap_audit_event_count++;
+  }
+}
+
+void cap_audit_reset_for_tests(void) {
+  cap_audit_next_index = 0u;
+  cap_audit_event_count = 0u;
+}
+
+size_t cap_audit_count_for_tests(void) {
+  return cap_audit_event_count;
+}
+
+cap_result_t cap_audit_get_for_tests(size_t index, cap_audit_event_t *out_event) {
+  if (out_event == 0 || index >= cap_audit_event_count) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  size_t start = 0u;
+  if (cap_audit_event_count == CAP_AUDIT_EVENT_MAX) {
+    start = cap_audit_next_index;
+  }
+
+  const size_t slot = (start + index) % CAP_AUDIT_EVENT_MAX;
+  *out_event = cap_audit_events[slot];
+  return CAP_OK;
+}
+
 void cap_reset_for_tests(void) {
   cap_table_reset();
+  cap_audit_reset_for_tests();
 }
 
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
@@ -15,5 +57,7 @@ cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t c
 }
 
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id) {
-  return cap_table_check(subject_id, capability_id);
+  cap_result_t result = cap_table_check(subject_id, capability_id);
+  cap_audit_record(subject_id, capability_id, result);
+  return result;
 }

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -1,6 +1,7 @@
 #ifndef SECUREOS_CAPABILITY_H
 #define SECUREOS_CAPABILITY_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 typedef uint32_t cap_subject_id_t;
@@ -18,9 +19,23 @@ typedef enum {
   CAP_ERR_CAP_INVALID = 3,
 } cap_result_t;
 
+enum {
+  CAP_AUDIT_EVENT_MAX = 32,
+};
+
+typedef struct {
+  cap_subject_id_t subject_id;
+  capability_id_t capability_id;
+  cap_result_t result;
+} cap_audit_event_t;
+
 void cap_reset_for_tests(void);
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id);
+
+void cap_audit_reset_for_tests(void);
+size_t cap_audit_count_for_tests(void);
+cap_result_t cap_audit_get_for_tests(size_t index, cap_audit_event_t *out_event);
 
 #endif

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/capability.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:capability_audit:%s\n", reason);
+  exit(1);
+}
+
+static void expect_event(size_t index,
+                         cap_subject_id_t subject,
+                         capability_id_t capability,
+                         cap_result_t result,
+                         const char *reason) {
+  cap_audit_event_t event = {0};
+  if (cap_audit_get_for_tests(index, &event) != CAP_OK) {
+    fail(reason);
+  }
+
+  if (event.subject_id != subject || event.capability_id != capability || event.result != result) {
+    fail(reason);
+  }
+}
+
+int main(void) {
+  printf("TEST:START:capability_audit\n");
+
+  cap_reset_for_tests();
+
+  if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("default_deny_result");
+  }
+  expect_event(0u, 1u, CAP_CONSOLE_WRITE, CAP_ERR_MISSING, "default_deny_event");
+
+  if (cap_grant_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_failed");
+  }
+  if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("allow_result");
+  }
+  expect_event(1u, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
+
+  if (cap_check(999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_subject_result");
+  }
+  expect_event(2u, 999u, CAP_CONSOLE_WRITE, CAP_ERR_SUBJECT_INVALID, "invalid_subject_event");
+
+  if (cap_check(1u, (capability_id_t)999u) != CAP_ERR_CAP_INVALID) {
+    fail("invalid_cap_result");
+  }
+  expect_event(3u, 1u, (capability_id_t)999u, CAP_ERR_CAP_INVALID, "invalid_cap_event");
+  printf("TEST:PASS:capability_audit_core_paths\n");
+
+  cap_reset_for_tests();
+  for (size_t i = 0; i < (size_t)CAP_AUDIT_EVENT_MAX + 5u; ++i) {
+    (void)cap_check((cap_subject_id_t)i, CAP_CONSOLE_WRITE);
+  }
+
+  if (cap_audit_count_for_tests() != (size_t)CAP_AUDIT_EVENT_MAX) {
+    fail("audit_ring_count");
+  }
+
+  expect_event(0u,
+               5u,
+               CAP_CONSOLE_WRITE,
+               CAP_ERR_MISSING,
+               "audit_ring_oldest_after_wrap");
+  expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
+               (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
+               CAP_CONSOLE_WRITE,
+               CAP_ERR_SUBJECT_INVALID,
+               "audit_ring_latest_after_wrap");
+
+  if (cap_audit_get_for_tests((size_t)CAP_AUDIT_EVENT_MAX, 0) != CAP_ERR_CAP_INVALID) {
+    fail("audit_out_of_bounds_rejected");
+  }
+  printf("TEST:PASS:capability_audit_ring_wrap\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
Implements #51 (M1-CAP-009) by adding deterministic audit visibility for capability checks without changing allow/deny semantics.

## Changes
- Add bounded audit ring buffer in `capability.c`
- Record every `cap_check(...)` decision (`subject`, `capability`, `result`)
- Add test-only audit accessors in `capability.h`
- Add `tests/capability_audit_test.c`
- Wire new harness target via `build/scripts/test_capability_audit.sh` and `./build/scripts/test.sh capability_audit`
- Update capability architecture follow-on notes and task registry status

## Validation
- `./build/scripts/test.sh cap_api_contract`
- `./build/scripts/test.sh capability_table`
- `./build/scripts/test.sh capability_gate`
- `./build/scripts/test.sh capability_audit`
- `./build/scripts/validate_bundle.sh`
