### PR TITLE
cap: audit grant/revoke mutation events in CAP ring

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -63,3 +63,4 @@ Validation command:
 - CAP-007 is complete: serial-write capability boundary and dual-cap isolation tests are merged.
 - CAP-008 is complete: debug-exit authorization is gated behind explicit capability checks and marker-backed validation.
 - CAP-009 is complete: capability checks now write deterministic audit events (subject, capability, result) into a bounded ring buffer for test-time visibility without changing allow/deny semantics.
+- CAP-010 is in progress: grant/revoke mutation operations are being added to the same bounded audit stream with explicit operation type metadata so tests can verify mixed ordering deterministically.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -31,6 +31,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-009 | M1 | Capability-check audit log + deterministic ring-buffer tests | M1-CAP-008 | `./build/scripts/test.sh capability_audit` | done |
+| M1-CAP-010 | M1 | Capability grant/revoke mutation audit events + mixed-flow ordering tests | M1-CAP-009 | `./build/scripts/test.sh capability_audit` | in-progress |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -6,9 +6,11 @@ static cap_audit_event_t cap_audit_events[CAP_AUDIT_EVENT_MAX];
 static size_t cap_audit_next_index;
 static size_t cap_audit_event_count;
 
-static void cap_audit_record(cap_subject_id_t subject_id,
+static void cap_audit_record(cap_audit_op_t operation,
+                             cap_subject_id_t subject_id,
                              capability_id_t capability_id,
                              cap_result_t result) {
+  cap_audit_events[cap_audit_next_index].operation = operation;
   cap_audit_events[cap_audit_next_index].subject_id = subject_id;
   cap_audit_events[cap_audit_next_index].capability_id = capability_id;
   cap_audit_events[cap_audit_next_index].result = result;
@@ -49,15 +51,19 @@ void cap_reset_for_tests(void) {
 }
 
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
-  return cap_table_grant(subject_id, capability_id);
+  cap_result_t result = cap_table_grant(subject_id, capability_id);
+  cap_audit_record(CAP_AUDIT_OP_GRANT, subject_id, capability_id, result);
+  return result;
 }
 
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
-  return cap_table_revoke(subject_id, capability_id);
+  cap_result_t result = cap_table_revoke(subject_id, capability_id);
+  cap_audit_record(CAP_AUDIT_OP_REVOKE, subject_id, capability_id, result);
+  return result;
 }
 
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id) {
   cap_result_t result = cap_table_check(subject_id, capability_id);
-  cap_audit_record(subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_CHECK, subject_id, capability_id, result);
   return result;
 }

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -23,7 +23,14 @@ enum {
   CAP_AUDIT_EVENT_MAX = 32,
 };
 
+typedef enum {
+  CAP_AUDIT_OP_CHECK = 0,
+  CAP_AUDIT_OP_GRANT = 1,
+  CAP_AUDIT_OP_REVOKE = 2,
+} cap_audit_op_t;
+
 typedef struct {
+  cap_audit_op_t operation;
   cap_subject_id_t subject_id;
   capability_id_t capability_id;
   cap_result_t result;

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -9,6 +9,7 @@ static void fail(const char *reason) {
 }
 
 static void expect_event(size_t index,
+                         cap_audit_op_t operation,
                          cap_subject_id_t subject,
                          capability_id_t capability,
                          cap_result_t result,
@@ -18,7 +19,8 @@ static void expect_event(size_t index,
     fail(reason);
   }
 
-  if (event.subject_id != subject || event.capability_id != capability || event.result != result) {
+  if (event.operation != operation || event.subject_id != subject ||
+      event.capability_id != capability || event.result != result) {
     fail(reason);
   }
 }
@@ -31,25 +33,57 @@ int main(void) {
   if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
     fail("default_deny_result");
   }
-  expect_event(0u, 1u, CAP_CONSOLE_WRITE, CAP_ERR_MISSING, "default_deny_event");
+  expect_event(0u,
+               CAP_AUDIT_OP_CHECK,
+               1u,
+               CAP_CONSOLE_WRITE,
+               CAP_ERR_MISSING,
+               "default_deny_event");
 
   if (cap_grant_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("grant_failed");
   }
+  expect_event(1u,
+               CAP_AUDIT_OP_GRANT,
+               1u,
+               CAP_CONSOLE_WRITE,
+               CAP_OK,
+               "grant_event");
+
   if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("allow_result");
   }
-  expect_event(1u, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
+  expect_event(2u, CAP_AUDIT_OP_CHECK, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
+
+  if (cap_revoke_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_failed");
+  }
+  expect_event(3u,
+               CAP_AUDIT_OP_REVOKE,
+               1u,
+               CAP_CONSOLE_WRITE,
+               CAP_OK,
+               "revoke_event");
 
   if (cap_check(999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
     fail("invalid_subject_result");
   }
-  expect_event(2u, 999u, CAP_CONSOLE_WRITE, CAP_ERR_SUBJECT_INVALID, "invalid_subject_event");
+  expect_event(4u,
+               CAP_AUDIT_OP_CHECK,
+               999u,
+               CAP_CONSOLE_WRITE,
+               CAP_ERR_SUBJECT_INVALID,
+               "invalid_subject_event");
 
   if (cap_check(1u, (capability_id_t)999u) != CAP_ERR_CAP_INVALID) {
     fail("invalid_cap_result");
   }
-  expect_event(3u, 1u, (capability_id_t)999u, CAP_ERR_CAP_INVALID, "invalid_cap_event");
+  expect_event(5u,
+               CAP_AUDIT_OP_CHECK,
+               1u,
+               (capability_id_t)999u,
+               CAP_ERR_CAP_INVALID,
+               "invalid_cap_event");
   printf("TEST:PASS:capability_audit_core_paths\n");
 
   cap_reset_for_tests();
@@ -62,11 +96,13 @@ int main(void) {
   }
 
   expect_event(0u,
+               CAP_AUDIT_OP_CHECK,
                5u,
                CAP_CONSOLE_WRITE,
                CAP_ERR_MISSING,
                "audit_ring_oldest_after_wrap");
   expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
+               CAP_AUDIT_OP_CHECK,
                (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
                CAP_CONSOLE_WRITE,
                CAP_ERR_SUBJECT_INVALID,


### PR DESCRIPTION
## Summary
- add audit operation type metadata (`CHECK`/`GRANT`/`REVOKE`) to capability audit events
- record audit events for `cap_grant_for_tests(...)` and `cap_revoke_for_tests(...)` while preserving existing ring semantics
- extend capability audit tests for mixed operation ordering and update CAP docs/registry for M1-CAP-010

## Validation
- ./build/scripts/test.sh capability_audit
- ./build/scripts/test.sh capability_gate

Closes #53
