### PR TITLE
docs: close CAP-010 bookkeeping and register CAP-011 task

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -63,4 +63,4 @@ Validation command:
 - CAP-007 is complete: serial-write capability boundary and dual-cap isolation tests are merged.
 - CAP-008 is complete: debug-exit authorization is gated behind explicit capability checks and marker-backed validation.
 - CAP-009 is complete: capability checks now write deterministic audit events (subject, capability, result) into a bounded ring buffer for test-time visibility without changing allow/deny semantics.
-- CAP-010 is in progress: grant/revoke mutation operations are being added to the same bounded audit stream with explicit operation type metadata so tests can verify mixed ordering deterministically.
+- CAP-010 is complete: grant/revoke mutation operations are now emitted to the same bounded audit stream with explicit operation type metadata, and mixed-flow ordering is validated deterministically in tests.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -31,7 +31,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-007 | M1 | Serial-write capability boundary + dual-cap isolation tests | M1-CAP-006 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-008 | M1 | Debug-exit capability boundary + authorization gate tests | M1-CAP-007 | `./build/scripts/test.sh capability_gate` | done |
 | M1-CAP-009 | M1 | Capability-check audit log + deterministic ring-buffer tests | M1-CAP-008 | `./build/scripts/test.sh capability_audit` | done |
-| M1-CAP-010 | M1 | Capability grant/revoke mutation audit events + mixed-flow ordering tests | M1-CAP-009 | `./build/scripts/test.sh capability_audit` | in-progress |
+| M1-CAP-010 | M1 | Capability grant/revoke mutation audit events + mixed-flow ordering tests | M1-CAP-009 | `./build/scripts/test.sh capability_audit` | done |
+| M1-CAP-011 | M1 | Audit ring overflow contract + CI artifact assertions | M1-CAP-010 | `./build/scripts/test.sh capability_audit` | todo |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- mark `M1-CAP-010` as `done` in `docs/planning/M0-M1-task-registry.md`
- update `docs/architecture/CAPABILITIES.md` to reflect CAP-010 completion
- add `M1-CAP-011` registry row as `todo` aligned with the new CAP-011 plan

## Validation
- `./build/scripts/test.sh capability_audit`

Closes #56
