### PR TITLE
CI: enforce capability audit summary schema contract

### DIFF
--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -33,6 +33,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-009 | M1 | Capability-check audit log + deterministic ring-buffer tests | M1-CAP-008 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-010 | M1 | Capability grant/revoke mutation audit events + mixed-flow ordering tests | M1-CAP-009 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-011 | M1 | Audit ring overflow contract + CI artifact assertions | M1-CAP-010 | `./build/scripts/test.sh capability_audit` | done |
+| M1-CAP-012 | M1 | Validator-enforced capability audit summary schema guardrail | M1-CAP-011 | `./build/scripts/validate_bundle.sh` | in_progress |
 
 ## Notes
 


### PR DESCRIPTION
Closes #60

## Summary
- validate `artifacts/tests/capability_audit_summary.json` inside `validate_bundle.sh`
- fail fast on missing/invalid required fields and invariant violations
- add explicit `capability_audit_summary_contract` check to `validator_report.json`
- register M1-CAP-012 as in-progress in task registry

## Validation
- ./build/scripts/test.sh capability_audit
- ./build/scripts/validate_bundle.sh
