### PR TITLE
M1-CAP-013: gate capability mutations behind admin actor

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -11,6 +11,7 @@ Current stable IDs:
 - `CAP_CONSOLE_WRITE = 1`
 - `CAP_SERIAL_WRITE = 2`
 - `CAP_DEBUG_EXIT = 3`
+- `CAP_CAPABILITY_ADMIN = 4`
 
 Rules:
 
@@ -65,3 +66,5 @@ Validation command:
 - CAP-009 is complete: capability checks now write deterministic audit events (subject, capability, result) into a bounded ring buffer for test-time visibility without changing allow/deny semantics.
 - CAP-010 is complete: grant/revoke mutation operations are now emitted to the same bounded audit stream with explicit operation type metadata, and mixed-flow ordering is validated deterministically in tests.
 - CAP-011 is complete: audit ring overflow now has explicit FIFO retention semantics with a monotonic dropped-events counter, plus machine-readable CI summary artifacts for deterministic overflow assertions.
+- CAP-012 is complete: validation now enforces a strict capability-audit summary schema contract in CI.
+- CAP-013 is in progress: capability grant/revoke mutation APIs are being constrained behind explicit `CAP_CAPABILITY_ADMIN` actor authorization to preserve deny-by-default mutation semantics.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -34,7 +34,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-010 | M1 | Capability grant/revoke mutation audit events + mixed-flow ordering tests | M1-CAP-009 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-011 | M1 | Audit ring overflow contract + CI artifact assertions | M1-CAP-010 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-012 | M1 | Validator-enforced capability audit summary schema guardrail | M1-CAP-011 | `./build/scripts/validate_bundle.sh` | done |
-| M1-CAP-013 | M1 | Admin-gated capability mutation boundary (actor-authorized grant/revoke) | M1-CAP-012 | `./build/scripts/test.sh capability_table` | todo |
+| M1-CAP-013 | M1 | Admin-gated capability mutation boundary (actor-authorized grant/revoke) | M1-CAP-012 | `./build/scripts/test.sh capability_table` | in_progress |
 
 ## Notes
 

--- a/kernel/cap/cap_table.c
+++ b/kernel/cap/cap_table.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #define CAP_ID_MIN CAP_CONSOLE_WRITE
-#define CAP_ID_MAX CAP_DEBUG_EXIT
+#define CAP_ID_MAX CAP_CAPABILITY_ADMIN
 
 #define CAPABILITY_COUNT ((uint32_t)(CAP_ID_MAX - CAP_ID_MIN + 1u))
 #define CAP_WORD_BITS 8u

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -70,6 +70,38 @@ cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t c
   return result;
 }
 
+static cap_result_t cap_actor_authorized_for_mutation(cap_subject_id_t actor_subject_id) {
+  return cap_table_check(actor_subject_id, CAP_CAPABILITY_ADMIN);
+}
+
+cap_result_t cap_grant_as_for_tests(cap_subject_id_t actor_subject_id,
+                                    cap_subject_id_t target_subject_id,
+                                    capability_id_t capability_id) {
+  cap_result_t actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
+  if (actor_check != CAP_OK) {
+    cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, actor_check);
+    return actor_check;
+  }
+
+  cap_result_t result = cap_table_grant(target_subject_id, capability_id);
+  cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, result);
+  return result;
+}
+
+cap_result_t cap_revoke_as_for_tests(cap_subject_id_t actor_subject_id,
+                                     cap_subject_id_t target_subject_id,
+                                     capability_id_t capability_id) {
+  cap_result_t actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
+  if (actor_check != CAP_OK) {
+    cap_audit_record(CAP_AUDIT_OP_REVOKE, target_subject_id, capability_id, actor_check);
+    return actor_check;
+  }
+
+  cap_result_t result = cap_table_revoke(target_subject_id, capability_id);
+  cap_audit_record(CAP_AUDIT_OP_REVOKE, target_subject_id, capability_id, result);
+  return result;
+}
+
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id) {
   cap_result_t result = cap_table_check(subject_id, capability_id);
   cap_audit_record(CAP_AUDIT_OP_CHECK, subject_id, capability_id, result);

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -10,6 +10,7 @@ typedef enum {
   CAP_CONSOLE_WRITE = 1,
   CAP_SERIAL_WRITE = 2,
   CAP_DEBUG_EXIT = 3,
+  CAP_CAPABILITY_ADMIN = 4,
 } capability_id_t;
 
 typedef enum {
@@ -39,6 +40,12 @@ typedef struct {
 void cap_reset_for_tests(void);
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
+cap_result_t cap_grant_as_for_tests(cap_subject_id_t actor_subject_id,
+                                    cap_subject_id_t target_subject_id,
+                                    capability_id_t capability_id);
+cap_result_t cap_revoke_as_for_tests(cap_subject_id_t actor_subject_id,
+                                     cap_subject_id_t target_subject_id,
+                                     capability_id_t capability_id);
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id);
 
 void cap_audit_reset_for_tests(void);

--- a/tests/cap_api_contract_test.c
+++ b/tests/cap_api_contract_test.c
@@ -19,6 +19,12 @@ int main(void) {
   if (CAP_SERIAL_WRITE != 2) {
     fail("cap_serial_write_id_stability");
   }
+  if (CAP_DEBUG_EXIT != 3) {
+    fail("cap_debug_exit_id_stability");
+  }
+  if (CAP_CAPABILITY_ADMIN != 4) {
+    fail("cap_capability_admin_id_stability");
+  }
   printf("TEST:PASS:cap_api_contract_id_stability\n");
 
   if (cap_check(0u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
@@ -47,11 +53,40 @@ int main(void) {
   }
   printf("TEST:PASS:cap_api_contract_allow\n");
 
+  if (cap_grant_as_for_tests(1u, 2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("grant_as_requires_admin");
+  }
+  if (cap_grant_for_tests(1u, CAP_CAPABILITY_ADMIN) != CAP_OK) {
+    fail("bootstrap_admin_grant_failed");
+  }
+  if (cap_grant_as_for_tests(1u, 2u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_as_with_admin_failed");
+  }
+  if (cap_check(2u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_as_allow_missing");
+  }
+  if (cap_revoke_as_for_tests(1u, 2u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_as_with_admin_failed");
+  }
+  if (cap_check(2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("revoke_as_restore_deny_missing");
+  }
+  printf("TEST:PASS:cap_api_contract_admin_gated_mutation\n");
+
   if (cap_check(999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
     fail("invalid_subject");
   }
   if (cap_check(0u, (capability_id_t)999u) != CAP_ERR_CAP_INVALID) {
     fail("invalid_cap");
+  }
+  if (cap_grant_as_for_tests(999u, 0u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_actor_subject");
+  }
+  if (cap_grant_as_for_tests(1u, 999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("invalid_target_subject");
+  }
+  if (cap_revoke_as_for_tests(1u, 0u, (capability_id_t)999u) != CAP_ERR_CAP_INVALID) {
+    fail("invalid_cap_revoke_as");
   }
   printf("TEST:PASS:cap_api_contract_invalid_inputs\n");
 


### PR DESCRIPTION
## Summary
- add stable capability ID `CAP_CAPABILITY_ADMIN = 4`
- add actor-aware mutation APIs that require admin capability before grant/revoke
- extend API contract tests for deny-by-default mutation authorization and invalid actor/target handling
- sync capability architecture + task registry status for CAP-012/CAP-013

## Verification
- ./build/scripts/test.sh cap_api_contract
- ./build/scripts/test.sh capability_table
- ./build/scripts/test.sh capability_audit
- ./build/scripts/validate_bundle.sh

Closes #62
