### PR TITLE
M1-CAP-014: make CAP_CAPABILITY_ADMIN grants non-delegable

### DIFF
--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -35,7 +35,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-011 | M1 | Audit ring overflow contract + CI artifact assertions | M1-CAP-010 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-012 | M1 | Validator-enforced capability audit summary schema guardrail | M1-CAP-011 | `./build/scripts/validate_bundle.sh` | done |
 | M1-CAP-013 | M1 | Admin-gated capability mutation boundary (actor-authorized grant/revoke) | M1-CAP-012 | `./build/scripts/test.sh capability_table` | done |
-| M1-CAP-014 | M1 | Non-delegable capability-admin grant policy (bootstrap-root only) | M1-CAP-013 | `./build/scripts/test.sh cap_api_contract` | todo |
+| M1-CAP-014 | M1 | Non-delegable capability-admin grant policy (bootstrap-root only) | M1-CAP-013 | `./build/scripts/test.sh cap_api_contract` | in_progress |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -70,17 +70,37 @@ cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t c
   return result;
 }
 
+static const cap_subject_id_t CAP_BOOTSTRAP_ROOT_SUBJECT_ID = 0u;
+
 static cap_result_t cap_actor_authorized_for_mutation(cap_subject_id_t actor_subject_id) {
   return cap_table_check(actor_subject_id, CAP_CAPABILITY_ADMIN);
+}
+
+static cap_result_t cap_actor_authorized_for_admin_grant(cap_subject_id_t actor_subject_id,
+                                                          capability_id_t capability_id) {
+  if (capability_id == CAP_CAPABILITY_ADMIN && actor_subject_id != CAP_BOOTSTRAP_ROOT_SUBJECT_ID) {
+    return CAP_ERR_MISSING;
+  }
+
+  return CAP_OK;
 }
 
 cap_result_t cap_grant_as_for_tests(cap_subject_id_t actor_subject_id,
                                     cap_subject_id_t target_subject_id,
                                     capability_id_t capability_id) {
-  cap_result_t actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
+  cap_result_t actor_check = CAP_OK;
+  if (!(capability_id == CAP_CAPABILITY_ADMIN && actor_subject_id == CAP_BOOTSTRAP_ROOT_SUBJECT_ID)) {
+    actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
+  }
   if (actor_check != CAP_OK) {
     cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, actor_check);
     return actor_check;
+  }
+
+  cap_result_t admin_grant_check = cap_actor_authorized_for_admin_grant(actor_subject_id, capability_id);
+  if (admin_grant_check != CAP_OK) {
+    cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, admin_grant_check);
+    return admin_grant_check;
   }
 
   cap_result_t result = cap_table_grant(target_subject_id, capability_id);

--- a/tests/cap_api_contract_test.c
+++ b/tests/cap_api_contract_test.c
@@ -71,6 +71,18 @@ int main(void) {
   if (cap_check(2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
     fail("revoke_as_restore_deny_missing");
   }
+  if (cap_grant_as_for_tests(1u, 3u, CAP_CAPABILITY_ADMIN) != CAP_ERR_MISSING) {
+    fail("delegated_admin_grant_denied");
+  }
+  if (cap_check(3u, CAP_CAPABILITY_ADMIN) != CAP_ERR_MISSING) {
+    fail("delegated_admin_grant_leaked");
+  }
+  if (cap_grant_as_for_tests(0u, 3u, CAP_CAPABILITY_ADMIN) != CAP_OK) {
+    fail("bootstrap_root_admin_grant_failed");
+  }
+  if (cap_check(3u, CAP_CAPABILITY_ADMIN) != CAP_OK) {
+    fail("bootstrap_root_admin_grant_missing");
+  }
   printf("TEST:PASS:cap_api_contract_admin_gated_mutation\n");
 
   if (cap_check(999u, CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {


### PR DESCRIPTION
## Summary
- enforce non-delegable admin capability grants
- allow bootstrap root subject (`0`) to grant `CAP_CAPABILITY_ADMIN`
- deny delegated admin-to-admin grant propagation
- add cap API contract coverage for both denied delegated and allowed bootstrap-root paths
- mark task registry entry `M1-CAP-014` as in progress

## Validation
- ./build/scripts/test.sh cap_api_contract
- ./build/scripts/test.sh capability_table
- ./build/scripts/validate_bundle.sh

Closes #64
