### PR TITLE
M1-CAP-015: Attribute capability mutation audit events to actor subject

### DIFF
--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -36,7 +36,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-012 | M1 | Validator-enforced capability audit summary schema guardrail | M1-CAP-011 | `./build/scripts/validate_bundle.sh` | done |
 | M1-CAP-013 | M1 | Admin-gated capability mutation boundary (actor-authorized grant/revoke) | M1-CAP-012 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-014 | M1 | Non-delegable capability-admin grant policy (bootstrap-root only) | M1-CAP-013 | `./build/scripts/test.sh cap_api_contract` | done |
-| M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | todo |
+| M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | in_progress |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -8,10 +8,12 @@ static size_t cap_audit_event_count;
 static size_t cap_audit_dropped_count;
 
 static void cap_audit_record(cap_audit_op_t operation,
+                             cap_subject_id_t actor_subject_id,
                              cap_subject_id_t subject_id,
                              capability_id_t capability_id,
                              cap_result_t result) {
   cap_audit_events[cap_audit_next_index].operation = operation;
+  cap_audit_events[cap_audit_next_index].actor_subject_id = actor_subject_id;
   cap_audit_events[cap_audit_next_index].subject_id = subject_id;
   cap_audit_events[cap_audit_next_index].capability_id = capability_id;
   cap_audit_events[cap_audit_next_index].result = result;
@@ -60,13 +62,13 @@ void cap_reset_for_tests(void) {
 
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
   cap_result_t result = cap_table_grant(subject_id, capability_id);
-  cap_audit_record(CAP_AUDIT_OP_GRANT, subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_GRANT, subject_id, subject_id, capability_id, result);
   return result;
 }
 
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id) {
   cap_result_t result = cap_table_revoke(subject_id, capability_id);
-  cap_audit_record(CAP_AUDIT_OP_REVOKE, subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_REVOKE, subject_id, subject_id, capability_id, result);
   return result;
 }
 
@@ -93,18 +95,30 @@ cap_result_t cap_grant_as_for_tests(cap_subject_id_t actor_subject_id,
     actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
   }
   if (actor_check != CAP_OK) {
-    cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, actor_check);
+    cap_audit_record(CAP_AUDIT_OP_GRANT,
+                     actor_subject_id,
+                     target_subject_id,
+                     capability_id,
+                     actor_check);
     return actor_check;
   }
 
   cap_result_t admin_grant_check = cap_actor_authorized_for_admin_grant(actor_subject_id, capability_id);
   if (admin_grant_check != CAP_OK) {
-    cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, admin_grant_check);
+    cap_audit_record(CAP_AUDIT_OP_GRANT,
+                     actor_subject_id,
+                     target_subject_id,
+                     capability_id,
+                     admin_grant_check);
     return admin_grant_check;
   }
 
   cap_result_t result = cap_table_grant(target_subject_id, capability_id);
-  cap_audit_record(CAP_AUDIT_OP_GRANT, target_subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_GRANT,
+                   actor_subject_id,
+                   target_subject_id,
+                   capability_id,
+                   result);
   return result;
 }
 
@@ -113,17 +127,25 @@ cap_result_t cap_revoke_as_for_tests(cap_subject_id_t actor_subject_id,
                                      capability_id_t capability_id) {
   cap_result_t actor_check = cap_actor_authorized_for_mutation(actor_subject_id);
   if (actor_check != CAP_OK) {
-    cap_audit_record(CAP_AUDIT_OP_REVOKE, target_subject_id, capability_id, actor_check);
+    cap_audit_record(CAP_AUDIT_OP_REVOKE,
+                     actor_subject_id,
+                     target_subject_id,
+                     capability_id,
+                     actor_check);
     return actor_check;
   }
 
   cap_result_t result = cap_table_revoke(target_subject_id, capability_id);
-  cap_audit_record(CAP_AUDIT_OP_REVOKE, target_subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_REVOKE,
+                   actor_subject_id,
+                   target_subject_id,
+                   capability_id,
+                   result);
   return result;
 }
 
 cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_id) {
   cap_result_t result = cap_table_check(subject_id, capability_id);
-  cap_audit_record(CAP_AUDIT_OP_CHECK, subject_id, capability_id, result);
+  cap_audit_record(CAP_AUDIT_OP_CHECK, subject_id, subject_id, capability_id, result);
   return result;
 }

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -32,6 +32,7 @@ typedef enum {
 
 typedef struct {
   cap_audit_op_t operation;
+  cap_subject_id_t actor_subject_id;
   cap_subject_id_t subject_id;
   capability_id_t capability_id;
   cap_result_t result;

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -10,6 +10,7 @@ static void fail(const char *reason) {
 
 static void expect_event(size_t index,
                          cap_audit_op_t operation,
+                         cap_subject_id_t actor,
                          cap_subject_id_t subject,
                          capability_id_t capability,
                          cap_result_t result,
@@ -19,8 +20,9 @@ static void expect_event(size_t index,
     fail(reason);
   }
 
-  if (event.operation != operation || event.subject_id != subject ||
-      event.capability_id != capability || event.result != result) {
+  if (event.operation != operation || event.actor_subject_id != actor ||
+      event.subject_id != subject || event.capability_id != capability ||
+      event.result != result) {
     fail(reason);
   }
 }
@@ -36,6 +38,7 @@ int main(void) {
   expect_event(0u,
                CAP_AUDIT_OP_CHECK,
                1u,
+               1u,
                CAP_CONSOLE_WRITE,
                CAP_ERR_MISSING,
                "default_deny_event");
@@ -46,6 +49,7 @@ int main(void) {
   expect_event(1u,
                CAP_AUDIT_OP_GRANT,
                1u,
+               1u,
                CAP_CONSOLE_WRITE,
                CAP_OK,
                "grant_event");
@@ -53,13 +57,14 @@ int main(void) {
   if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("allow_result");
   }
-  expect_event(2u, CAP_AUDIT_OP_CHECK, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
+  expect_event(2u, CAP_AUDIT_OP_CHECK, 1u, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
 
   if (cap_revoke_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("revoke_failed");
   }
   expect_event(3u,
                CAP_AUDIT_OP_REVOKE,
+               1u,
                1u,
                CAP_CONSOLE_WRITE,
                CAP_OK,
@@ -71,6 +76,7 @@ int main(void) {
   expect_event(4u,
                CAP_AUDIT_OP_CHECK,
                999u,
+               999u,
                CAP_CONSOLE_WRITE,
                CAP_ERR_SUBJECT_INVALID,
                "invalid_subject_event");
@@ -81,10 +87,55 @@ int main(void) {
   expect_event(5u,
                CAP_AUDIT_OP_CHECK,
                1u,
+               1u,
                (capability_id_t)999u,
                CAP_ERR_CAP_INVALID,
                "invalid_cap_event");
   printf("TEST:PASS:capability_audit_core_paths\n");
+
+  cap_reset_for_tests();
+  if (cap_grant_as_for_tests(0u, 2u, CAP_CAPABILITY_ADMIN) != CAP_OK) {
+    fail("grant_as_bootstrap_root_admin_grant");
+  }
+  if (cap_grant_as_for_tests(2u, 3u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_as_delegated_admin_serial_grant");
+  }
+  if (cap_revoke_as_for_tests(2u, 3u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("revoke_as_delegated_admin_serial_revoke");
+  }
+  if (cap_grant_as_for_tests(2u, 4u, CAP_CAPABILITY_ADMIN) != CAP_ERR_MISSING) {
+    fail("grant_as_non_root_admin_grant_denied");
+  }
+
+  expect_event(0u,
+               CAP_AUDIT_OP_GRANT,
+               0u,
+               2u,
+               CAP_CAPABILITY_ADMIN,
+               CAP_OK,
+               "grant_as_root_actor_attribution");
+  expect_event(1u,
+               CAP_AUDIT_OP_GRANT,
+               2u,
+               3u,
+               CAP_SERIAL_WRITE,
+               CAP_OK,
+               "grant_as_actor_attribution");
+  expect_event(2u,
+               CAP_AUDIT_OP_REVOKE,
+               2u,
+               3u,
+               CAP_SERIAL_WRITE,
+               CAP_OK,
+               "revoke_as_actor_attribution");
+  expect_event(3u,
+               CAP_AUDIT_OP_GRANT,
+               2u,
+               4u,
+               CAP_CAPABILITY_ADMIN,
+               CAP_ERR_MISSING,
+               "grant_as_denied_actor_attribution");
+  printf("TEST:PASS:capability_audit_actor_attribution\n");
 
   cap_reset_for_tests();
   for (size_t i = 0; i < (size_t)CAP_AUDIT_EVENT_MAX + 5u; ++i) {
@@ -101,11 +152,13 @@ int main(void) {
   expect_event(0u,
                CAP_AUDIT_OP_CHECK,
                5u,
+               5u,
                CAP_CONSOLE_WRITE,
                CAP_ERR_MISSING,
                "audit_ring_oldest_after_wrap");
   expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
                CAP_AUDIT_OP_CHECK,
+               (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
                (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
                CAP_CONSOLE_WRITE,
                CAP_ERR_SUBJECT_INVALID,
@@ -136,11 +189,13 @@ int main(void) {
   expect_event(0u,
                CAP_AUDIT_OP_CHECK,
                1u,
+               1u,
                CAP_SERIAL_WRITE,
                CAP_OK,
                "mixed_oldest_expected");
   expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
                CAP_AUDIT_OP_REVOKE,
+               11u,
                11u,
                CAP_SERIAL_WRITE,
                CAP_ERR_SUBJECT_INVALID,


### PR DESCRIPTION
## Summary
- add `actor_subject_id` to `cap_audit_event_t` so each audit record attributes actor + target
- thread actor identity through audit recording for grant/revoke/check flows
- extend capability audit tests with explicit actor-attribution assertions, including denied mutation paths
- mark M1-CAP-015 as `in_progress` in the task registry

## Validation
- `./build/scripts/test.sh capability_audit`
- `./build/scripts/test.sh cap_api_contract`
- `./build/scripts/validate_bundle.sh`

Closes #66
