### PR TITLE
M1-CAP-016: add monotonic audit sequence IDs

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -67,4 +67,7 @@ Validation command:
 - CAP-010 is complete: grant/revoke mutation operations are now emitted to the same bounded audit stream with explicit operation type metadata, and mixed-flow ordering is validated deterministically in tests.
 - CAP-011 is complete: audit ring overflow now has explicit FIFO retention semantics with a monotonic dropped-events counter, plus machine-readable CI summary artifacts for deterministic overflow assertions.
 - CAP-012 is complete: validation now enforces a strict capability-audit summary schema contract in CI.
-- CAP-013 is in progress: capability grant/revoke mutation APIs are being constrained behind explicit `CAP_CAPABILITY_ADMIN` actor authorization to preserve deny-by-default mutation semantics.
+- CAP-013 is complete: capability grant/revoke mutation APIs are constrained behind explicit `CAP_CAPABILITY_ADMIN` actor authorization to preserve deny-by-default mutation semantics.
+- CAP-014 is complete: `CAP_CAPABILITY_ADMIN` grants are non-delegable and restricted to bootstrap root subject `0`.
+- CAP-015 is complete: audit mutation events now carry explicit actor attribution (`actor_subject_id`) for deterministic policy forensics.
+- CAP-016 is in progress: capability audit events are gaining monotonic `sequence_id` integrity to prove strict event ordering across ring wrap/overflow windows.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -36,7 +36,8 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-012 | M1 | Validator-enforced capability audit summary schema guardrail | M1-CAP-011 | `./build/scripts/validate_bundle.sh` | done |
 | M1-CAP-013 | M1 | Admin-gated capability mutation boundary (actor-authorized grant/revoke) | M1-CAP-012 | `./build/scripts/test.sh capability_table` | done |
 | M1-CAP-014 | M1 | Non-delegable capability-admin grant policy (bootstrap-root only) | M1-CAP-013 | `./build/scripts/test.sh cap_api_contract` | done |
-| M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | in_progress |
+| M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | done |
+| M1-CAP-016 | M1 | Capability audit event monotonic sequence integrity across ring wrap | M1-CAP-015 | `./build/scripts/test.sh capability_audit` | in_progress |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -6,18 +6,21 @@ static cap_audit_event_t cap_audit_events[CAP_AUDIT_EVENT_MAX];
 static size_t cap_audit_next_index;
 static size_t cap_audit_event_count;
 static size_t cap_audit_dropped_count;
+static uint64_t cap_audit_next_sequence_id;
 
 static void cap_audit_record(cap_audit_op_t operation,
                              cap_subject_id_t actor_subject_id,
                              cap_subject_id_t subject_id,
                              capability_id_t capability_id,
                              cap_result_t result) {
+  cap_audit_events[cap_audit_next_index].sequence_id = cap_audit_next_sequence_id;
   cap_audit_events[cap_audit_next_index].operation = operation;
   cap_audit_events[cap_audit_next_index].actor_subject_id = actor_subject_id;
   cap_audit_events[cap_audit_next_index].subject_id = subject_id;
   cap_audit_events[cap_audit_next_index].capability_id = capability_id;
   cap_audit_events[cap_audit_next_index].result = result;
 
+  cap_audit_next_sequence_id++;
   cap_audit_next_index = (cap_audit_next_index + 1u) % CAP_AUDIT_EVENT_MAX;
   if (cap_audit_event_count < CAP_AUDIT_EVENT_MAX) {
     cap_audit_event_count++;
@@ -30,6 +33,7 @@ void cap_audit_reset_for_tests(void) {
   cap_audit_next_index = 0u;
   cap_audit_event_count = 0u;
   cap_audit_dropped_count = 0u;
+  cap_audit_next_sequence_id = 0u;
 }
 
 size_t cap_audit_count_for_tests(void) {

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -31,6 +31,7 @@ typedef enum {
 } cap_audit_op_t;
 
 typedef struct {
+  uint64_t sequence_id;
   cap_audit_op_t operation;
   cap_subject_id_t actor_subject_id;
   cap_subject_id_t subject_id;

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -9,6 +9,7 @@ static void fail(const char *reason) {
 }
 
 static void expect_event(size_t index,
+                         uint64_t sequence_id,
                          cap_audit_op_t operation,
                          cap_subject_id_t actor,
                          cap_subject_id_t subject,
@@ -20,9 +21,9 @@ static void expect_event(size_t index,
     fail(reason);
   }
 
-  if (event.operation != operation || event.actor_subject_id != actor ||
-      event.subject_id != subject || event.capability_id != capability ||
-      event.result != result) {
+  if (event.sequence_id != sequence_id || event.operation != operation ||
+      event.actor_subject_id != actor || event.subject_id != subject ||
+      event.capability_id != capability || event.result != result) {
     fail(reason);
   }
 }
@@ -36,6 +37,7 @@ int main(void) {
     fail("default_deny_result");
   }
   expect_event(0u,
+               0u,
                CAP_AUDIT_OP_CHECK,
                1u,
                1u,
@@ -47,6 +49,7 @@ int main(void) {
     fail("grant_failed");
   }
   expect_event(1u,
+               1u,
                CAP_AUDIT_OP_GRANT,
                1u,
                1u,
@@ -57,12 +60,13 @@ int main(void) {
   if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("allow_result");
   }
-  expect_event(2u, CAP_AUDIT_OP_CHECK, 1u, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
+  expect_event(2u, 2u, CAP_AUDIT_OP_CHECK, 1u, 1u, CAP_CONSOLE_WRITE, CAP_OK, "allow_event");
 
   if (cap_revoke_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
     fail("revoke_failed");
   }
   expect_event(3u,
+               3u,
                CAP_AUDIT_OP_REVOKE,
                1u,
                1u,
@@ -74,6 +78,7 @@ int main(void) {
     fail("invalid_subject_result");
   }
   expect_event(4u,
+               4u,
                CAP_AUDIT_OP_CHECK,
                999u,
                999u,
@@ -85,6 +90,7 @@ int main(void) {
     fail("invalid_cap_result");
   }
   expect_event(5u,
+               5u,
                CAP_AUDIT_OP_CHECK,
                1u,
                1u,
@@ -108,6 +114,7 @@ int main(void) {
   }
 
   expect_event(0u,
+               0u,
                CAP_AUDIT_OP_GRANT,
                0u,
                2u,
@@ -115,6 +122,7 @@ int main(void) {
                CAP_OK,
                "grant_as_root_actor_attribution");
   expect_event(1u,
+               1u,
                CAP_AUDIT_OP_GRANT,
                2u,
                3u,
@@ -122,6 +130,7 @@ int main(void) {
                CAP_OK,
                "grant_as_actor_attribution");
   expect_event(2u,
+               2u,
                CAP_AUDIT_OP_REVOKE,
                2u,
                3u,
@@ -129,6 +138,7 @@ int main(void) {
                CAP_OK,
                "revoke_as_actor_attribution");
   expect_event(3u,
+               3u,
                CAP_AUDIT_OP_GRANT,
                2u,
                4u,
@@ -150,6 +160,7 @@ int main(void) {
   }
 
   expect_event(0u,
+               5u,
                CAP_AUDIT_OP_CHECK,
                5u,
                5u,
@@ -157,6 +168,7 @@ int main(void) {
                CAP_ERR_MISSING,
                "audit_ring_oldest_after_wrap");
   expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
+               (uint64_t)CAP_AUDIT_EVENT_MAX + 4u,
                CAP_AUDIT_OP_CHECK,
                (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
                (cap_subject_id_t)(CAP_AUDIT_EVENT_MAX + 4u),
@@ -187,6 +199,7 @@ int main(void) {
   }
 
   expect_event(0u,
+               4u,
                CAP_AUDIT_OP_CHECK,
                1u,
                1u,
@@ -194,6 +207,7 @@ int main(void) {
                CAP_OK,
                "mixed_oldest_expected");
   expect_event((size_t)CAP_AUDIT_EVENT_MAX - 1u,
+               35u,
                CAP_AUDIT_OP_REVOKE,
                11u,
                11u,


### PR DESCRIPTION
## Summary
- add monotonic `sequence_id` to capability audit events
- stamp every audit record with strictly increasing sequence IDs, including across ring wrap
- extend capability audit assertions to verify sequence ordering in core, wrap, and mixed overflow flows
- align planning/architecture docs for CAP-015 done and CAP-016 in progress

## Validation
- ./build/scripts/test.sh capability_audit
- ./build/scripts/test.sh cap_api_contract

Closes #68
