### PR TITLE
M1-CAP-017: add deterministic audit checkpoints

### DIFF
--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -71,4 +71,4 @@ Validation command:
 - CAP-014 is complete: `CAP_CAPABILITY_ADMIN` grants are non-delegable and restricted to bootstrap root subject `0`.
 - CAP-015 is complete: audit mutation events now carry explicit actor attribution (`actor_subject_id`) for deterministic policy forensics.
 - CAP-016 is complete: capability audit events now carry monotonic `sequence_id` values that preserve strict ordering semantics across ring wrap/overflow windows.
-- CAP-017 is planned: add deterministic tamper-evident audit checkpoints to detect retained-window divergence without changing authorization behavior.
+- CAP-017 is in progress: capability audit now tracks deterministic tamper-evident checkpoint seals to detect retained-window divergence without changing authorization behavior.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -38,7 +38,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-014 | M1 | Non-delegable capability-admin grant policy (bootstrap-root only) | M1-CAP-013 | `./build/scripts/test.sh cap_api_contract` | done |
 | M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-016 | M1 | Capability audit event monotonic sequence integrity across ring wrap | M1-CAP-015 | `./build/scripts/test.sh capability_audit` | done |
-| M1-CAP-017 | M1 | Tamper-evident capability audit checkpoints across retention windows | M1-CAP-016 | `./build/scripts/test.sh capability_audit` | todo |
+| M1-CAP-017 | M1 | Tamper-evident capability audit checkpoints across retention windows | M1-CAP-016 | `./build/scripts/test.sh capability_audit` | in-progress |
 
 ## Notes
 

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -8,12 +8,61 @@ static size_t cap_audit_event_count;
 static size_t cap_audit_dropped_count;
 static uint64_t cap_audit_next_sequence_id;
 
+static cap_audit_checkpoint_t cap_audit_checkpoints[CAP_AUDIT_CHECKPOINT_MAX];
+static size_t cap_audit_checkpoint_next_index;
+static size_t cap_audit_checkpoint_count;
+static uint64_t cap_audit_next_checkpoint_id;
+static uint64_t cap_audit_seal;
+
+static uint64_t cap_audit_mix_u64(uint64_t acc, uint64_t value) {
+  const uint64_t prime = 1099511628211ull;
+  return (acc ^ value) * prime;
+}
+
+static uint64_t cap_audit_event_digest(uint64_t sequence_id,
+                                       cap_audit_op_t operation,
+                                       cap_subject_id_t actor_subject_id,
+                                       cap_subject_id_t subject_id,
+                                       capability_id_t capability_id,
+                                       cap_result_t result) {
+  uint64_t digest = 1469598103934665603ull;
+  digest = cap_audit_mix_u64(digest, sequence_id);
+  digest = cap_audit_mix_u64(digest, (uint64_t)operation);
+  digest = cap_audit_mix_u64(digest, (uint64_t)actor_subject_id);
+  digest = cap_audit_mix_u64(digest, (uint64_t)subject_id);
+  digest = cap_audit_mix_u64(digest, (uint64_t)capability_id);
+  digest = cap_audit_mix_u64(digest, (uint64_t)result);
+  return digest;
+}
+
+static void cap_audit_maybe_emit_checkpoint(uint64_t sequence_id) {
+  if ((sequence_id + 1u) % CAP_AUDIT_CHECKPOINT_INTERVAL != 0u) {
+    return;
+  }
+
+  cap_audit_checkpoint_t *checkpoint = &cap_audit_checkpoints[cap_audit_checkpoint_next_index];
+  checkpoint->checkpoint_id = cap_audit_next_checkpoint_id;
+  checkpoint->start_sequence_id = (sequence_id + 1u) - CAP_AUDIT_CHECKPOINT_INTERVAL;
+  checkpoint->end_sequence_id = sequence_id;
+  checkpoint->seal = cap_audit_seal;
+  checkpoint->dropped_count = cap_audit_dropped_count;
+
+  cap_audit_next_checkpoint_id++;
+  cap_audit_checkpoint_next_index =
+      (cap_audit_checkpoint_next_index + 1u) % CAP_AUDIT_CHECKPOINT_MAX;
+  if (cap_audit_checkpoint_count < CAP_AUDIT_CHECKPOINT_MAX) {
+    cap_audit_checkpoint_count++;
+  }
+}
+
 static void cap_audit_record(cap_audit_op_t operation,
                              cap_subject_id_t actor_subject_id,
                              cap_subject_id_t subject_id,
                              capability_id_t capability_id,
                              cap_result_t result) {
-  cap_audit_events[cap_audit_next_index].sequence_id = cap_audit_next_sequence_id;
+  const uint64_t sequence_id = cap_audit_next_sequence_id;
+
+  cap_audit_events[cap_audit_next_index].sequence_id = sequence_id;
   cap_audit_events[cap_audit_next_index].operation = operation;
   cap_audit_events[cap_audit_next_index].actor_subject_id = actor_subject_id;
   cap_audit_events[cap_audit_next_index].subject_id = subject_id;
@@ -27,6 +76,17 @@ static void cap_audit_record(cap_audit_op_t operation,
   } else {
     cap_audit_dropped_count++;
   }
+
+  cap_audit_seal = cap_audit_mix_u64(cap_audit_seal,
+                                     cap_audit_event_digest(sequence_id,
+                                                            operation,
+                                                            actor_subject_id,
+                                                            subject_id,
+                                                            capability_id,
+                                                            result));
+  cap_audit_seal = cap_audit_mix_u64(cap_audit_seal, (uint64_t)cap_audit_dropped_count);
+
+  cap_audit_maybe_emit_checkpoint(sequence_id);
 }
 
 void cap_audit_reset_for_tests(void) {
@@ -34,6 +94,11 @@ void cap_audit_reset_for_tests(void) {
   cap_audit_event_count = 0u;
   cap_audit_dropped_count = 0u;
   cap_audit_next_sequence_id = 0u;
+
+  cap_audit_checkpoint_next_index = 0u;
+  cap_audit_checkpoint_count = 0u;
+  cap_audit_next_checkpoint_id = 0u;
+  cap_audit_seal = 1469598103934665603ull;
 }
 
 size_t cap_audit_count_for_tests(void) {
@@ -56,6 +121,26 @@ cap_result_t cap_audit_get_for_tests(size_t index, cap_audit_event_t *out_event)
 
   const size_t slot = (start + index) % CAP_AUDIT_EVENT_MAX;
   *out_event = cap_audit_events[slot];
+  return CAP_OK;
+}
+
+size_t cap_audit_checkpoint_count_for_tests(void) {
+  return cap_audit_checkpoint_count;
+}
+
+cap_result_t cap_audit_checkpoint_get_for_tests(size_t index,
+                                                cap_audit_checkpoint_t *out_checkpoint) {
+  if (out_checkpoint == 0 || index >= cap_audit_checkpoint_count) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  size_t start = 0u;
+  if (cap_audit_checkpoint_count == CAP_AUDIT_CHECKPOINT_MAX) {
+    start = cap_audit_checkpoint_next_index;
+  }
+
+  const size_t slot = (start + index) % CAP_AUDIT_CHECKPOINT_MAX;
+  *out_checkpoint = cap_audit_checkpoints[slot];
   return CAP_OK;
 }
 

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -22,6 +22,8 @@ typedef enum {
 
 enum {
   CAP_AUDIT_EVENT_MAX = 32,
+  CAP_AUDIT_CHECKPOINT_INTERVAL = 8,
+  CAP_AUDIT_CHECKPOINT_MAX = 8,
 };
 
 typedef enum {
@@ -39,6 +41,14 @@ typedef struct {
   cap_result_t result;
 } cap_audit_event_t;
 
+typedef struct {
+  uint64_t checkpoint_id;
+  uint64_t start_sequence_id;
+  uint64_t end_sequence_id;
+  uint64_t seal;
+  size_t dropped_count;
+} cap_audit_checkpoint_t;
+
 void cap_reset_for_tests(void);
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
@@ -54,5 +64,8 @@ void cap_audit_reset_for_tests(void);
 size_t cap_audit_count_for_tests(void);
 size_t cap_audit_dropped_for_tests(void);
 cap_result_t cap_audit_get_for_tests(size_t index, cap_audit_event_t *out_event);
+size_t cap_audit_checkpoint_count_for_tests(void);
+cap_result_t cap_audit_checkpoint_get_for_tests(size_t index,
+                                                cap_audit_checkpoint_t *out_checkpoint);
 
 #endif

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -216,6 +216,57 @@ int main(void) {
                "mixed_latest_expected");
 
   printf("TEST:PASS:capability_audit_mixed_overflow\n");
+
+  cap_reset_for_tests();
+  for (size_t i = 0; i < 20u; ++i) {
+    (void)cap_check((cap_subject_id_t)(i % 8u), CAP_CONSOLE_WRITE);
+  }
+
+  if (cap_audit_checkpoint_count_for_tests() != 2u) {
+    fail("checkpoint_count_expected_two");
+  }
+
+  cap_audit_checkpoint_t checkpoint0 = {0};
+  cap_audit_checkpoint_t checkpoint1 = {0};
+  if (cap_audit_checkpoint_get_for_tests(0u, &checkpoint0) != CAP_OK) {
+    fail("checkpoint0_read");
+  }
+  if (cap_audit_checkpoint_get_for_tests(1u, &checkpoint1) != CAP_OK) {
+    fail("checkpoint1_read");
+  }
+
+  if (checkpoint0.checkpoint_id != 0u || checkpoint0.start_sequence_id != 0u ||
+      checkpoint0.end_sequence_id != 7u || checkpoint0.dropped_count != 0u) {
+    fail("checkpoint0_metadata");
+  }
+  if (checkpoint1.checkpoint_id != 1u || checkpoint1.start_sequence_id != 8u ||
+      checkpoint1.end_sequence_id != 15u || checkpoint1.dropped_count != 0u) {
+    fail("checkpoint1_metadata");
+  }
+  if (checkpoint0.seal == checkpoint1.seal) {
+    fail("checkpoint_seal_progression");
+  }
+
+  cap_reset_for_tests();
+  for (size_t i = 0; i < (size_t)CAP_AUDIT_EVENT_MAX + CAP_AUDIT_CHECKPOINT_INTERVAL; ++i) {
+    (void)cap_check((cap_subject_id_t)i, CAP_CONSOLE_WRITE);
+  }
+
+  if (cap_audit_checkpoint_count_for_tests() == 0u) {
+    fail("checkpoint_count_wrap_nonzero");
+  }
+
+  cap_audit_checkpoint_t checkpoint_last = {0};
+  if (cap_audit_checkpoint_get_for_tests(cap_audit_checkpoint_count_for_tests() - 1u,
+                                         &checkpoint_last) != CAP_OK) {
+    fail("checkpoint_last_read");
+  }
+
+  if (checkpoint_last.dropped_count == 0u) {
+    fail("checkpoint_dropped_count_reflects_wrap");
+  }
+
+  printf("TEST:PASS:capability_audit_checkpoints\n");
   printf("TEST:AUDIT_SUMMARY:count=%zu:dropped=%zu\n",
          cap_audit_count_for_tests(),
          cap_audit_dropped_for_tests());


### PR DESCRIPTION
## Summary
Implements the first M1-CAP-017 slice by adding deterministic, tamper-evident checkpoint seals to capability audit flow.

Closes #70

## What changed
- Added checkpoint constants and test-facing checkpoint struct/API in `capability.h`
- Added rolling deterministic seal accumulation in `capability.c`
- Added periodic checkpoint emission every 8 events, with sequence ranges and dropped-count snapshots
- Added checkpoint retrieval ring helpers for deterministic validation
- Extended `capability_audit_test` with checkpoint progression + wrap/overflow assertions
- Updated architecture and planning docs to mark CAP-017 in progress

## Validation
- `./build/scripts/test.sh capability_audit`
