### PR TITLE
M1-CAP-018: enforce checkpoint metadata in audit summary contract

### DIFF
--- a/build/scripts/test_capability_audit.sh
+++ b/build/scripts/test_capability_audit.sh
@@ -23,7 +23,13 @@ SUMMARY_LINE="$(grep 'TEST:AUDIT_SUMMARY:' "$LOG_PATH" | tail -n 1)"
 COUNT="$(echo "$SUMMARY_LINE" | sed -n 's/.*count=\([0-9][0-9]*\).*/\1/p')"
 DROPPED="$(echo "$SUMMARY_LINE" | sed -n 's/.*dropped=\([0-9][0-9]*\).*/\1/p')"
 
-if [[ -z "$COUNT" || -z "$DROPPED" ]]; then
+CHECKPOINT_SUMMARY_LINE="$(grep 'TEST:AUDIT_CHECKPOINT_SUMMARY:' "$LOG_PATH" | tail -n 1)"
+CHECKPOINT_COUNT="$(echo "$CHECKPOINT_SUMMARY_LINE" | sed -n 's/.*count=\([0-9][0-9]*\).*/\1/p')"
+LATEST_CHECKPOINT_ID="$(echo "$CHECKPOINT_SUMMARY_LINE" | sed -n 's/.*latest_id=\([0-9][0-9]*\).*/\1/p')"
+LATEST_CHECKPOINT_SEAL="$(echo "$CHECKPOINT_SUMMARY_LINE" | sed -n 's/.*latest_seal=\([0-9][0-9]*\).*/\1/p')"
+LATEST_CHECKPOINT_DROPPED="$(echo "$CHECKPOINT_SUMMARY_LINE" | sed -n 's/.*latest_dropped=\([0-9][0-9]*\).*/\1/p')"
+
+if [[ -z "$COUNT" || -z "$DROPPED" || -z "$CHECKPOINT_COUNT" || -z "$LATEST_CHECKPOINT_ID" || -z "$LATEST_CHECKPOINT_SEAL" || -z "$LATEST_CHECKPOINT_DROPPED" ]]; then
   echo "Missing audit summary markers in capability audit output" >&2
   exit 1
 fi
@@ -34,6 +40,10 @@ cat > "$OUT_DIR/capability_audit_summary.json" <<JSON
   "test": "capability_audit",
   "ringCapacity": ${CAP_AUDIT_EVENT_MAX:-32},
   "retainedEvents": $COUNT,
-  "droppedEvents": $DROPPED
+  "droppedEvents": $DROPPED,
+  "checkpointCount": $CHECKPOINT_COUNT,
+  "latestCheckpointId": $LATEST_CHECKPOINT_ID,
+  "latestCheckpointSeal": $LATEST_CHECKPOINT_SEAL,
+  "latestCheckpointDroppedCount": $LATEST_CHECKPOINT_DROPPED
 }
 JSON

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -105,7 +105,16 @@ else:
         summary_check_error = f"invalid JSON in {summary_path}: {exc}"
 
 if summary is not None:
-    required_int_fields = ["schemaVersion", "ringCapacity", "retainedEvents", "droppedEvents"]
+    required_int_fields = [
+        "schemaVersion",
+        "ringCapacity",
+        "retainedEvents",
+        "droppedEvents",
+        "checkpointCount",
+        "latestCheckpointId",
+        "latestCheckpointSeal",
+        "latestCheckpointDroppedCount",
+    ]
     for field in required_int_fields:
         value = summary.get(field)
         if not isinstance(value, int):
@@ -127,6 +136,20 @@ if summary is not None:
             summary_check_error = "retainedEvents must be <= ringCapacity"
         elif summary.get("retainedEvents", 0) + summary.get("droppedEvents", 0) < summary.get("ringCapacity", 0):
             summary_check_error = "retainedEvents + droppedEvents must be >= ringCapacity"
+        elif summary.get("checkpointCount", -1) < 0:
+            summary_check_error = "checkpointCount must be >= 0"
+        elif summary.get("latestCheckpointId", -1) < 0:
+            summary_check_error = "latestCheckpointId must be >= 0"
+        elif summary.get("latestCheckpointSeal", -1) < 0:
+            summary_check_error = "latestCheckpointSeal must be >= 0"
+        elif summary.get("latestCheckpointDroppedCount", -1) < 0:
+            summary_check_error = "latestCheckpointDroppedCount must be >= 0"
+        elif summary.get("checkpointCount", 0) == 0 and (
+            summary.get("latestCheckpointId", 0) != 0
+            or summary.get("latestCheckpointSeal", 0) != 0
+            or summary.get("latestCheckpointDroppedCount", 0) != 0
+        ):
+            summary_check_error = "latest checkpoint fields must be 0 when checkpointCount is 0"
 
 checks.append({
     "name": "capability_audit_summary_contract",

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -71,4 +71,5 @@ Validation command:
 - CAP-014 is complete: `CAP_CAPABILITY_ADMIN` grants are non-delegable and restricted to bootstrap root subject `0`.
 - CAP-015 is complete: audit mutation events now carry explicit actor attribution (`actor_subject_id`) for deterministic policy forensics.
 - CAP-016 is complete: capability audit events now carry monotonic `sequence_id` values that preserve strict ordering semantics across ring wrap/overflow windows.
-- CAP-017 is in progress: capability audit now tracks deterministic tamper-evident checkpoint seals to detect retained-window divergence without changing authorization behavior.
+- CAP-017 is complete: capability audit now tracks deterministic tamper-evident checkpoint seals to detect retained-window divergence without changing authorization behavior.
+- CAP-018 is in progress: capability-audit summary artifacts now surface checkpoint metadata fields that validator contracts enforce in CI.

--- a/docs/planning/M0-M1-task-registry.md
+++ b/docs/planning/M0-M1-task-registry.md
@@ -39,7 +39,7 @@ This registry tracks the concrete, ordered tasks to move SecureOS from the curre
 | M1-CAP-015 | M1 | Capability mutation actor attribution in audit events | M1-CAP-014 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-016 | M1 | Capability audit event monotonic sequence integrity across ring wrap | M1-CAP-015 | `./build/scripts/test.sh capability_audit` | done |
 | M1-CAP-017 | M1 | Tamper-evident capability audit checkpoints across retention windows | M1-CAP-016 | `./build/scripts/test.sh capability_audit` | done |
-| M1-CAP-018 | M1 | Enforce capability audit checkpoint summary contract in validator artifacts | M1-CAP-017 | `./build/scripts/validate_bundle.sh` | todo |
+| M1-CAP-018 | M1 | Enforce capability audit checkpoint summary contract in validator artifacts | M1-CAP-017 | `./build/scripts/validate_bundle.sh` | in-progress |
 
 ## Notes
 

--- a/tests/capability_audit_test.c
+++ b/tests/capability_audit_test.c
@@ -267,6 +267,27 @@ int main(void) {
   }
 
   printf("TEST:PASS:capability_audit_checkpoints\n");
+
+  size_t checkpoint_count = cap_audit_checkpoint_count_for_tests();
+  uint64_t latest_checkpoint_id = 0u;
+  uint64_t latest_checkpoint_seal = 0u;
+  size_t latest_checkpoint_dropped = 0u;
+  if (checkpoint_count > 0u) {
+    cap_audit_checkpoint_t latest_checkpoint = {0};
+    if (cap_audit_checkpoint_get_for_tests(checkpoint_count - 1u, &latest_checkpoint) != CAP_OK) {
+      fail("checkpoint_latest_summary_read");
+    }
+    latest_checkpoint_id = latest_checkpoint.checkpoint_id;
+    latest_checkpoint_seal = latest_checkpoint.seal;
+    latest_checkpoint_dropped = latest_checkpoint.dropped_count;
+  }
+
+  printf("TEST:AUDIT_CHECKPOINT_SUMMARY:count=%zu:latest_id=%llu:latest_seal=%llu:latest_dropped=%zu\n",
+         checkpoint_count,
+         (unsigned long long)latest_checkpoint_id,
+         (unsigned long long)latest_checkpoint_seal,
+         latest_checkpoint_dropped);
+
   printf("TEST:AUDIT_SUMMARY:count=%zu:dropped=%zu\n",
          cap_audit_count_for_tests(),
          cap_audit_dropped_for_tests());


### PR DESCRIPTION
## Summary
- emit deterministic `TEST:AUDIT_CHECKPOINT_SUMMARY` marker in capability audit tests
- include checkpoint metadata fields in `artifacts/tests/capability_audit_summary.json`
- enforce checkpoint summary contract invariants in `validate_bundle.sh`
- update capability docs and task registry status for CAP-018

## Validation
- `./build/scripts/test.sh capability_audit` ✅
- `./build/scripts/validate_bundle.sh` ⚠️ fails locally on `hello_boot`/`hello_boot_negative` because `nasm` is missing in this environment; capability contract checks pass and emit `VALIDATION_REPORT`

Closes #72