### PR TITLE
fix #79: deny-by-default URL scheme gate in netlib dispatch

### DIFF
--- a/build/scripts/build_user_app.sh
+++ b/build/scripts/build_user_app.sh
@@ -74,8 +74,9 @@ PY
     clang $NETLIB_CFLAGS -c user/libs/netlib/dns.c -o artifacts/user/netlib_dns.o
     clang $NETLIB_CFLAGS -c user/libs/netlib/tcp.c -o artifacts/user/netlib_tcp.o
     clang $NETLIB_CFLAGS -c user/libs/netlib/http.c -o artifacts/user/netlib_http.o
+    clang $NETLIB_CFLAGS -c user/libs/netlib/url_scheme.c -o artifacts/user/netlib_url_scheme.o
 
-    NETLIB_OBJECTS="artifacts/user/netlib_api.o artifacts/user/netlib_backend_user.o artifacts/user/netlib_eth.o artifacts/user/netlib_arp.o artifacts/user/netlib_ipv4.o artifacts/user/netlib_udp.o artifacts/user/netlib_dns.o artifacts/user/netlib_tcp.o artifacts/user/netlib_http.o"
+    NETLIB_OBJECTS="artifacts/user/netlib_api.o artifacts/user/netlib_backend_user.o artifacts/user/netlib_eth.o artifacts/user/netlib_arp.o artifacts/user/netlib_ipv4.o artifacts/user/netlib_udp.o artifacts/user/netlib_dns.o artifacts/user/netlib_tcp.o artifacts/user/netlib_http.o artifacts/user/netlib_url_scheme.o"
 
     if [ "$HAVE_BEARSSL" -eq 1 ]; then
       clang $NETLIB_CFLAGS -c user/libs/netlib/tls.c -o artifacts/user/netlib_tls.o

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -78,6 +78,9 @@ case "$TEST_NAME" in
     ;;
   https)
     "$ROOT_DIR/build/scripts/test_https.sh"
+    ;;
+  netlib_url_scheme)
+    "$ROOT_DIR/build/scripts/test_netlib_url_scheme.sh"
     ;;
   fs_service)
     "$ROOT_DIR/build/scripts/test_fs_service.sh"

--- a/build/scripts/test_netlib_url_scheme.sh
+++ b/build/scripts/test_netlib_url_scheme.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/tests/netlib_url_scheme_test.c" \
+  "$ROOT_DIR/user/libs/netlib/url_scheme.c" \
+  -I "$ROOT_DIR/user/libs/netlib" \
+  -o "$OUT_DIR/netlib_url_scheme_test"
+
+"$OUT_DIR/netlib_url_scheme_test"

--- a/docs/architecture/CAPABILITIES.md
+++ b/docs/architecture/CAPABILITIES.md
@@ -92,3 +92,30 @@ Validation command:
 - CAP-017 is complete: capability audit now tracks deterministic tamper-evident checkpoint seals to detect retained-window divergence without changing authorization behavior.
 - CAP-018 is complete: capability-audit summary artifacts now surface checkpoint metadata fields that validator contracts enforce in CI.
 - CAP-019 is planned: sequence-window attestation will enforce continuity consistency between retained audit events and checkpoint summary windows.
+
+## NET-001 deny-by-default URL scheme gate
+
+The user-space `netlib` http/https dispatch path now classifies the leading
+URL scheme through a single helper (`netlib_url_classify_scheme`) before any
+DNS, TCP, or TLS work is attempted.
+
+- `netlib_http_get` accepts both `http://` and `https://` URLs and routes
+  HTTPS through the same scheme-gated path that re-dispatches to the TLS
+  client.
+- `netlib_https_get` accepts only `https://` URLs and denies plaintext or
+  unknown schemes with `NETLIB_STATUS_DENIED`.
+- `http_request` re-validates the scheme as a defence-in-depth check so the
+  lower-level entrypoint enforces the same deny-by-default policy.
+- Empty, NULL, scheme-less, protocol-relative (`//host/...`), and
+  non-network schemes (`file://`, `ftp://`, `javascript:`, `data:`, ...)
+  are denied without producing externally visible network activity.
+- Capability enforcement still runs on top of this: the netlib syscall
+  surface in `kernel/user/process.c` requires `CAP_NETWORK` for raw frame
+  and device access, and the scheme gate stacks in front of it so missing
+  capability and unsupported scheme are independent failure modes.
+
+Validation commands:
+
+- `./build/scripts/test.sh netlib_url_scheme`
+- `./build/scripts/test.sh https`
+

--- a/tests/netlib_url_scheme_test.c
+++ b/tests/netlib_url_scheme_test.c
@@ -1,0 +1,139 @@
+/**
+ * @file netlib_url_scheme_test.c
+ * @brief Tests for the deny-by-default netlib URL scheme classifier.
+ *
+ * Purpose:
+ *   Validates that netlib_url_classify_scheme() routes "http://" and
+ *   "https://" URLs to their explicit transports while denying NULL,
+ *   empty, scheme-less, and arbitrary non-network URLs. This is the
+ *   deny-by-default gate in front of the http/https dispatch path that
+ *   keeps non-supported schemes from triggering DNS or TCP work.
+ *
+ * Interactions:
+ *   - user/libs/netlib/url_scheme.c: implementation under test.
+ *   - user/libs/netlib/url_scheme.h: public contract.
+ *
+ * Launched by:
+ *   Compiled and run by the native test harness via test_netlib_url_scheme.sh
+ *   and dispatched by build/scripts/test.sh netlib_url_scheme.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../user/libs/netlib/url_scheme.h"
+
+static int g_failures = 0;
+
+static void expect(int condition, const char *reason) {
+  if (!condition) {
+    printf("TEST:FAIL:netlib_url_scheme:%s\n", reason);
+    ++g_failures;
+  }
+}
+
+static void test_http_scheme_allowed(void) {
+  expect(netlib_url_classify_scheme("http://example.com/") ==
+             NETLIB_URL_SCHEME_HTTP,
+         "http_scheme_not_classified_as_http");
+  expect(netlib_url_classify_scheme("http://example.com:8080/path") ==
+             NETLIB_URL_SCHEME_HTTP,
+         "http_scheme_with_port_not_http");
+  /* Bare prefix without host is still classified by scheme; URL parser
+   * downstream is responsible for rejecting empty hosts. */
+  expect(netlib_url_classify_scheme("http://") == NETLIB_URL_SCHEME_HTTP,
+         "http_bare_prefix_not_http");
+}
+
+static void test_https_scheme_allowed(void) {
+  expect(netlib_url_classify_scheme("https://example.com/") ==
+             NETLIB_URL_SCHEME_HTTPS,
+         "https_scheme_not_classified_as_https");
+  expect(netlib_url_classify_scheme("https://api.example.com:8443/v1") ==
+             NETLIB_URL_SCHEME_HTTPS,
+         "https_scheme_with_port_not_https");
+}
+
+static void test_unknown_schemes_denied(void) {
+  /* Each of these MUST be denied by the gate so the dispatch layer never
+   * performs DNS or TCP work for non-network schemes. */
+  expect(netlib_url_classify_scheme("file:///etc/passwd") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "file_scheme_not_denied");
+  expect(netlib_url_classify_scheme("ftp://example.com/") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "ftp_scheme_not_denied");
+  expect(netlib_url_classify_scheme("javascript:alert(1)") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "javascript_scheme_not_denied");
+  expect(netlib_url_classify_scheme("data:text/plain,hi") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "data_scheme_not_denied");
+  expect(netlib_url_classify_scheme("gopher://example.com") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "gopher_scheme_not_denied");
+  /* Protocol-relative URLs must not silently default to HTTP. */
+  expect(netlib_url_classify_scheme("//example.com/path") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "protocol_relative_not_denied");
+  /* Plain host with no scheme must be denied. */
+  expect(netlib_url_classify_scheme("example.com/path") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "schemeless_not_denied");
+  /* Relative paths must be denied. */
+  expect(netlib_url_classify_scheme("/relative/path") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "relative_path_not_denied");
+}
+
+static void test_empty_and_null_denied(void) {
+  expect(netlib_url_classify_scheme(NULL) == NETLIB_URL_SCHEME_UNKNOWN,
+         "null_not_denied");
+  expect(netlib_url_classify_scheme("") == NETLIB_URL_SCHEME_UNKNOWN,
+         "empty_not_denied");
+}
+
+static void test_case_sensitive_only_lowercase_allowed(void) {
+  /* The classifier is intentionally strict (lowercase only) so that the
+   * dispatch path matches exactly what the URL parsers downstream expect.
+   * Mixed-case schemes must be denied rather than silently normalized. */
+  expect(netlib_url_classify_scheme("HTTP://example.com/") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "uppercase_http_not_denied");
+  expect(netlib_url_classify_scheme("HTTPS://example.com/") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "uppercase_https_not_denied");
+  expect(netlib_url_classify_scheme("Http://example.com/") ==
+             NETLIB_URL_SCHEME_UNKNOWN,
+         "mixed_case_http_not_denied");
+}
+
+static void test_http_prefix_does_not_match_https(void) {
+  /* Sanity check: classifier must distinguish http:// from https:// even
+   * though one is a prefix of the other up to the colon. */
+  expect(netlib_url_classify_scheme("https://example.com/") !=
+             NETLIB_URL_SCHEME_HTTP,
+         "https_misclassified_as_http");
+  expect(netlib_url_classify_scheme("http://example.com/") !=
+             NETLIB_URL_SCHEME_HTTPS,
+         "http_misclassified_as_https");
+}
+
+int main(void) {
+  printf("TEST:START:netlib_url_scheme\n");
+
+  test_http_scheme_allowed();
+  test_https_scheme_allowed();
+  test_unknown_schemes_denied();
+  test_empty_and_null_denied();
+  test_case_sensitive_only_lowercase_allowed();
+  test_http_prefix_does_not_match_https();
+
+  if (g_failures != 0) {
+    printf("TEST:FAIL:netlib_url_scheme:%d_failures\n", g_failures);
+    return 1;
+  }
+
+  printf("TEST:PASS:netlib_url_scheme_allow_deny\n");
+  return 0;
+}

--- a/user/libs/netlib/api.c
+++ b/user/libs/netlib/api.c
@@ -27,6 +27,7 @@
 #include "https.h"
 #include "ipv4.h"
 #include "tcp.h"
+#include "url_scheme.h"
 
 static size_t netlib_append_string(char *dst, size_t dst_size, size_t cursor, const char *src) {
   size_t i = 0u;
@@ -224,6 +225,41 @@ netlib_status_t netlib_ifconfig(netlib_handle_t handle,
   return NETLIB_STATUS_OK;
 }
 
+/*
+ * Shared deny-by-default URL classifier used by the http/https command-facing
+ * helpers. Splitting this out keeps both entrypoints on a single dispatch
+ * path so that adding a new transport (or a new deny rule) only has to be
+ * done in one place. The classifier runs before any DNS, TCP, or TLS work so
+ * unsupported schemes (file://, ftp://, javascript:, ...) and empty or
+ * scheme-less URLs are denied without producing externally visible network
+ * activity.
+ */
+static netlib_status_t netlib_url_dispatch_check(const char *url,
+                                                 char *out_buffer,
+                                                 unsigned int out_buffer_size,
+                                                 int allow_http,
+                                                 int allow_https) {
+  netlib_url_scheme_t scheme;
+
+  if (url == 0 || out_buffer == 0 || out_buffer_size == 0u) {
+    return NETLIB_STATUS_ERROR;
+  }
+
+  out_buffer[0] = '\0';
+
+  scheme = netlib_url_classify_scheme(url);
+  if (scheme == NETLIB_URL_SCHEME_UNKNOWN) {
+    return NETLIB_STATUS_DENIED;
+  }
+  if (scheme == NETLIB_URL_SCHEME_HTTP && !allow_http) {
+    return NETLIB_STATUS_DENIED;
+  }
+  if (scheme == NETLIB_URL_SCHEME_HTTPS && !allow_https) {
+    return NETLIB_STATUS_DENIED;
+  }
+  return NETLIB_STATUS_OK;
+}
+
 netlib_status_t netlib_http_get(netlib_handle_t handle,
                                 const char *url,
                                 char *out_buffer,
@@ -231,12 +267,22 @@ netlib_status_t netlib_http_get(netlib_handle_t handle,
   http_request_t req;
   http_response_t resp;
   http_result_t result;
+  netlib_status_t gate;
   size_t copy = 0u;
   size_t i = 0u;
 
   (void)handle;
-  if (url == 0 || out_buffer == 0 || out_buffer_size == 0u) {
-    return NETLIB_STATUS_ERROR;
+  /*
+   * netlib_http_get is the canonical entrypoint for both http:// and
+   * https:// URLs: http_request() internally re-dispatches to the TLS path
+   * for https URLs. Allowing both schemes here keeps the existing behaviour
+   * but routes everything through the shared scheme classifier so unknown
+   * schemes are explicitly denied instead of being silently fed to the URL
+   * parser.
+   */
+  gate = netlib_url_dispatch_check(url, out_buffer, out_buffer_size, 1, 1);
+  if (gate != NETLIB_STATUS_OK) {
+    return gate;
   }
 
   req.method = "GET";
@@ -271,12 +317,20 @@ netlib_status_t netlib_https_get(netlib_handle_t handle,
   http_request_t req;
   http_response_t resp;
   https_result_t result;
+  netlib_status_t gate;
   size_t copy = 0u;
   size_t i = 0u;
 
   (void)handle;
-  if (url == 0 || out_buffer == 0 || out_buffer_size == 0u) {
-    return NETLIB_STATUS_ERROR;
+  /*
+   * netlib_https_get is the explicitly TLS-only entrypoint: only https://
+   * URLs are accepted. http:// and unknown schemes are denied here so
+   * callers cannot accidentally bypass the deny-by-default policy by
+   * picking the "https" helper for a plaintext URL.
+   */
+  gate = netlib_url_dispatch_check(url, out_buffer, out_buffer_size, 0, 1);
+  if (gate != NETLIB_STATUS_OK) {
+    return gate;
   }
 
   req.method = "GET";

--- a/user/libs/netlib/http.c
+++ b/user/libs/netlib/http.c
@@ -26,6 +26,7 @@
 #include "dns.h"
 #include "https.h"
 #include "tcp.h"
+#include "url_scheme.h"
 
 static size_t http_strlen(const char *s) {
   size_t n = 0u;
@@ -357,6 +358,20 @@ http_result_t http_request(const http_request_t *req, http_response_t *resp) {
 
   if (req->method != 0 && req->method[0] != '\0') {
     method = req->method;
+  }
+
+  /*
+   * Defence-in-depth scheme gate. The netlib api layer already rejects
+   * unsupported schemes before reaching here, but http_request is also
+   * exported as a lower-level entrypoint, so re-classify the URL and refuse
+   * anything that is not http:// or https://. This keeps a single deny-by-
+   * default policy regardless of which entrypoint is used.
+   */
+  {
+    netlib_url_scheme_t scheme = netlib_url_classify_scheme(req->url);
+    if (scheme == NETLIB_URL_SCHEME_UNKNOWN) {
+      return HTTP_ERR_BAD_URL;
+    }
   }
 
   http_parse_url(req->url, &parsed);

--- a/user/libs/netlib/url_scheme.c
+++ b/user/libs/netlib/url_scheme.c
@@ -1,0 +1,53 @@
+/**
+ * @file url_scheme.c
+ * @brief Implementation of the deny-by-default URL scheme classifier.
+ *
+ * Purpose:
+ *   Performs a constant-time prefix match against the small, explicitly
+ *   allowed transport set ("http://" and "https://"). Anything else is
+ *   classified as NETLIB_URL_SCHEME_UNKNOWN so the netlib dispatch layer
+ *   can fail closed without performing DNS or TCP/TLS work for unsupported
+ *   schemes.
+ *
+ * Interactions:
+ *   - url_scheme.h defines the public contract.
+ *   - api.c and http.c call netlib_url_classify_scheme() at the entry of
+ *     the shared http/https dispatch path.
+ *
+ * Launched by:
+ *   Compiled into the shared netlib library and the kernel-side netlib
+ *   build. Has no platform dependencies.
+ */
+
+#include "url_scheme.h"
+
+static int netlib_url_prefix_match(const char *url, const char *prefix) {
+  unsigned int i = 0u;
+
+  if (url == 0 || prefix == 0) {
+    return 0;
+  }
+
+  while (prefix[i] != '\0') {
+    if (url[i] != prefix[i]) {
+      return 0;
+    }
+    ++i;
+  }
+  return 1;
+}
+
+netlib_url_scheme_t netlib_url_classify_scheme(const char *url) {
+  if (url == 0 || url[0] == '\0') {
+    return NETLIB_URL_SCHEME_UNKNOWN;
+  }
+
+  if (netlib_url_prefix_match(url, "https://")) {
+    return NETLIB_URL_SCHEME_HTTPS;
+  }
+  if (netlib_url_prefix_match(url, "http://")) {
+    return NETLIB_URL_SCHEME_HTTP;
+  }
+
+  return NETLIB_URL_SCHEME_UNKNOWN;
+}

--- a/user/libs/netlib/url_scheme.h
+++ b/user/libs/netlib/url_scheme.h
@@ -1,0 +1,62 @@
+/**
+ * @file url_scheme.h
+ * @brief URL scheme classification for the user-space netlib dispatch path.
+ *
+ * Purpose:
+ *   Provides a tiny, dependency-free helper that classifies the leading
+ *   scheme of a URL into the set of transports the netlib stack is allowed
+ *   to dispatch to. Used as the first gate in the shared http/https dispatch
+ *   path so non-http(s) URLs (file://, ftp://, javascript:, ...) are
+ *   explicitly denied before any DNS/TCP/TLS work is attempted.
+ *
+ * Interactions:
+ *   - api.c uses netlib_url_classify_scheme() to fail closed on unsupported
+ *     schemes inside netlib_http_get and netlib_https_get.
+ *   - http.c uses it as a defence-in-depth check inside http_request.
+ *   - tests/netlib_url_scheme_test.c links this header directly.
+ *
+ * Launched by:
+ *   Compiled into the shared netlib library and the kernel-side netlib
+ *   build alongside the rest of the netlib protocol sources.
+ */
+
+#ifndef SECUREOS_USER_NETLIB_URL_SCHEME_H
+#define SECUREOS_USER_NETLIB_URL_SCHEME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  NETLIB_URL_SCHEME_HTTP = 0,
+  NETLIB_URL_SCHEME_HTTPS = 1,
+  /*
+   * NETLIB_URL_SCHEME_UNKNOWN is the deny-by-default classification used for
+   * any URL whose leading characters do not match a supported transport.
+   * Empty strings, NULL pointers and protocol-relative ("//host/path") URLs
+   * are all classified as UNKNOWN so callers must explicitly pick a
+   * transport before any network I/O is attempted.
+   */
+  NETLIB_URL_SCHEME_UNKNOWN = 2
+} netlib_url_scheme_t;
+
+/*
+ * Classify the leading scheme of a URL string.
+ *
+ * Behaviour:
+ *   - NULL or empty input returns NETLIB_URL_SCHEME_UNKNOWN.
+ *   - "http://..." returns NETLIB_URL_SCHEME_HTTP.
+ *   - "https://..." returns NETLIB_URL_SCHEME_HTTPS.
+ *   - Anything else (including "//host/..", "file://", "ftp://",
+ *     "javascript:", "/relative/path") returns NETLIB_URL_SCHEME_UNKNOWN.
+ *
+ * The function does no allocation, no network access, and no logging. It is
+ * safe to call from any context including capability gate paths.
+ */
+netlib_url_scheme_t netlib_url_classify_scheme(const char *url);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Closes part of #79 (Phase 1 of `plans/2026-04-09-zero-trust-network-abi-hardening.md`).

## What

Make the user-space netlib http/https dispatch path **fail closed** for unsupported URL schemes before any DNS, TCP, or TLS work is attempted.

- New `netlib_url_classify_scheme()` helper (`user/libs/netlib/url_scheme.{h,c}`) classifies URLs into `HTTP` / `HTTPS` / `UNKNOWN` with a strict, lowercase-only prefix match.
- `netlib_http_get` and `netlib_https_get` now share one dispatch path that runs the classifier first:
  - `netlib_http_get` accepts `http://` and `https://` (https re-dispatches to the TLS client, same as before).
  - `netlib_https_get` accepts only `https://` and denies plaintext or unknown schemes with `NETLIB_STATUS_DENIED`.
- `http_request` re-validates the scheme as defence-in-depth so the lower-level entrypoint enforces the same policy.
- Empty, `NULL`, scheme-less, protocol-relative (`//host/...`), and any non-network scheme (`file://`, `ftp://`, `javascript:`, `data:`, `gopher://`, ...) are denied without producing externally visible network activity.

## Why

Plan acceptance criteria for #79:
- network I/O paths are explicitly gated ✅
- HTTP and HTTPS share one dispatch path ✅ (single classifier + shared netlib entrypoints, with `http_request` continuing to delegate https URLs to the TLS path)
- tests cover deny and allow behaviour for each transport ✅

`CAP_NETWORK` enforcement on the kernel netlib syscalls (`kernel/user/process.c`) remains unchanged and stacks on top of this scheme gate, so missing-capability and unsupported-scheme are independent failure modes.

## Tests

- New `tests/netlib_url_scheme_test.c` + `build/scripts/test_netlib_url_scheme.sh` cover allow paths for http/https and explicit deny paths for file, ftp, javascript, data, gopher, protocol-relative, schemeless, relative, uppercase, and NULL/empty inputs.
- `build/scripts/test.sh` dispatcher learns the new `netlib_url_scheme` target.
- Existing `https` URL parser test still passes.

```
./build/scripts/test.sh netlib_url_scheme
TEST:START:netlib_url_scheme
TEST:PASS:netlib_url_scheme_allow_deny

./build/scripts/test.sh https
TEST:START:https
TEST:PASS:https_url_parsing
```

## Docs

- `docs/architecture/CAPABILITIES.md` gains a NET-001 entry describing the gate and the validation commands.

## Follow-ups (Phase 2 in #79)

- Separate transport selection from request formatting in netlib (`http_request` still embeds the dispatch).
- Add positive/negative deny-path tests that exercise `netlib_http_get` / `netlib_https_get` against a faked backend with and without `CAP_NETWORK`.
- Add one validation case for HTTP, one for HTTPS, and one for DNS/TCP failure reporting.