### PR TITLE
fix #81: launcher-mediated console-write capability slice

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -54,6 +54,9 @@ case "$TEST_NAME" in
     ;;
   capability_audit)
     "$ROOT_DIR/build/scripts/test_capability_audit.sh"
+    ;;
+  launcher_console)
+    "$ROOT_DIR/build/scripts/test_launcher_console.sh"
     ;;
   event_bus)
     "$ROOT_DIR/build/scripts/test_event_bus.sh"

--- a/build/scripts/test_launcher_console.sh
+++ b/build/scripts/test_launcher_console.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/tests/launcher_console_test.c" \
+  -o "$OUT_DIR/launcher_console_test"
+
+LOG_PATH="$OUT_DIR/launcher_console_test.log"
+"$OUT_DIR/launcher_console_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:launcher_console_deny_without_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_console_allow_after_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_console_regression_bypass_denied" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_console_revoke_restores_deny" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_console_invalid_app" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_console_reset_clears_state" "$LOG_PATH"

--- a/kernel/user/launcher.c
+++ b/kernel/user/launcher.c
@@ -1,0 +1,140 @@
+/**
+ * @file launcher.c
+ * @brief Launcher-mediated capability slice for console-write.
+ *
+ * Purpose:
+ *   Implements the minimal launcher described in
+ *   plans/2026-04-11-console-launcher-capability-slice.md. Apps must be
+ *   registered with the launcher, and CAP_CONSOLE_WRITE must be granted via
+ *   the launcher before any console output is permitted. Read-only inspection
+ *   never widens access.
+ *
+ * Interactions:
+ *   - cap_table.c: launcher_grant_console_write/launcher_revoke_console_write
+ *     update the capability table on behalf of the app subject.
+ *   - cap_gate.c: launcher_app_console_write routes through
+ *     cap_console_write_gate so the deny-by-default policy is enforced.
+ *
+ * Launched by:
+ *   Not a standalone process. Compiled into the kernel image and reset at
+ *   boot or by tests via launcher_reset().
+ */
+
+#include "launcher.h"
+
+#include "../cap/cap_gate.h"
+#include "../cap/cap_table.h"
+
+#define LAUNCHER_MAX_APPS CAP_TABLE_MAX_SUBJECTS
+
+typedef struct {
+  int used;
+  cap_subject_id_t subject_id;
+} launcher_app_entry_t;
+
+static launcher_app_entry_t launcher_apps[LAUNCHER_MAX_APPS];
+
+static launcher_app_entry_t *launcher_find_entry(cap_subject_id_t app_subject_id) {
+  for (size_t i = 0; i < LAUNCHER_MAX_APPS; ++i) {
+    if (launcher_apps[i].used && launcher_apps[i].subject_id == app_subject_id) {
+      return &launcher_apps[i];
+    }
+  }
+  return 0;
+}
+
+static int launcher_subject_in_range(cap_subject_id_t app_subject_id) {
+  return app_subject_id < CAP_TABLE_MAX_SUBJECTS;
+}
+
+void launcher_reset(void) {
+  for (size_t i = 0; i < LAUNCHER_MAX_APPS; ++i) {
+    if (launcher_apps[i].used) {
+      /* Best-effort revoke so a reset cannot leave stale capabilities. */
+      (void)cap_table_revoke(launcher_apps[i].subject_id, CAP_CONSOLE_WRITE);
+    }
+    launcher_apps[i].used = 0;
+    launcher_apps[i].subject_id = 0u;
+  }
+}
+
+launcher_result_t launcher_register_app(cap_subject_id_t app_subject_id) {
+  if (!launcher_subject_in_range(app_subject_id)) {
+    return LAUNCHER_ERR_INVALID_APP;
+  }
+
+  if (launcher_find_entry(app_subject_id) != 0) {
+    return LAUNCHER_OK;
+  }
+
+  for (size_t i = 0; i < LAUNCHER_MAX_APPS; ++i) {
+    if (!launcher_apps[i].used) {
+      launcher_apps[i].used = 1;
+      launcher_apps[i].subject_id = app_subject_id;
+      return LAUNCHER_OK;
+    }
+  }
+
+  return LAUNCHER_ERR_INTERNAL;
+}
+
+launcher_result_t launcher_grant_console_write(cap_subject_id_t app_subject_id) {
+  if (!launcher_subject_in_range(app_subject_id)) {
+    return LAUNCHER_ERR_INVALID_APP;
+  }
+
+  if (launcher_find_entry(app_subject_id) == 0) {
+    return LAUNCHER_ERR_NOT_REGISTERED;
+  }
+
+  if (cap_table_grant(app_subject_id, CAP_CONSOLE_WRITE) != CAP_OK) {
+    return LAUNCHER_ERR_INTERNAL;
+  }
+
+  return LAUNCHER_OK;
+}
+
+launcher_result_t launcher_revoke_console_write(cap_subject_id_t app_subject_id) {
+  if (!launcher_subject_in_range(app_subject_id)) {
+    return LAUNCHER_ERR_INVALID_APP;
+  }
+
+  if (launcher_find_entry(app_subject_id) == 0) {
+    return LAUNCHER_ERR_NOT_REGISTERED;
+  }
+
+  if (cap_table_revoke(app_subject_id, CAP_CONSOLE_WRITE) != CAP_OK) {
+    return LAUNCHER_ERR_INTERNAL;
+  }
+
+  return LAUNCHER_OK;
+}
+
+launcher_result_t launcher_app_console_write(cap_subject_id_t app_subject_id,
+                                             const char *message,
+                                             size_t *bytes_written_out) {
+  if (!launcher_subject_in_range(app_subject_id)) {
+    return LAUNCHER_ERR_INVALID_APP;
+  }
+
+  if (launcher_find_entry(app_subject_id) == 0) {
+    return LAUNCHER_ERR_NOT_REGISTERED;
+  }
+
+  cap_result_t gate_result = cap_console_write_gate(app_subject_id, message, bytes_written_out);
+  if (gate_result != CAP_OK) {
+    return LAUNCHER_ERR_DENIED;
+  }
+
+  return LAUNCHER_OK;
+}
+
+int launcher_app_has_console_write(cap_subject_id_t app_subject_id) {
+  if (!launcher_subject_in_range(app_subject_id)) {
+    return 0;
+  }
+  if (launcher_find_entry(app_subject_id) == 0) {
+    return 0;
+  }
+  return cap_table_check(app_subject_id, CAP_CONSOLE_WRITE) == CAP_OK;
+}

--- a/kernel/user/launcher.h
+++ b/kernel/user/launcher.h
@@ -1,0 +1,71 @@
+#ifndef SECUREOS_LAUNCHER_H
+#define SECUREOS_LAUNCHER_H
+
+#include <stddef.h>
+
+#include "../cap/capability.h"
+
+/**
+ * @file launcher.h
+ * @brief Minimal launcher service that mediates app capability grants.
+ *
+ * Purpose:
+ *   Provides the single launcher-mediated entry point for granting and
+ *   exercising the console-write capability on behalf of an app subject.
+ *   This is the first vertical slice of the zero-trust launcher described
+ *   in plans/2026-04-11-console-launcher-capability-slice.md.
+ *
+ * Invariants:
+ *   - Apps registered with the launcher are deny-by-default for
+ *     console output.
+ *   - Console output is only authorized when the launcher has explicitly
+ *     granted CAP_CONSOLE_WRITE to that app via launcher_grant_console_write().
+ *   - Read-only inspection helpers (launcher_app_has_console_write) do not
+ *     widen access and do not emit audit grant events.
+ */
+
+typedef enum {
+  LAUNCHER_OK = 0,
+  LAUNCHER_ERR_INVALID_APP = 1,
+  LAUNCHER_ERR_NOT_REGISTERED = 2,
+  LAUNCHER_ERR_DENIED = 3,
+  LAUNCHER_ERR_INTERNAL = 4,
+} launcher_result_t;
+
+/* Reset launcher state and any registered app grants. Safe for tests. */
+void launcher_reset(void);
+
+/*
+ * Register an app subject with the launcher so it can later be granted
+ * console-write. Registration alone never confers any capability.
+ */
+launcher_result_t launcher_register_app(cap_subject_id_t app_subject_id);
+
+/*
+ * Explicit, launcher-mediated grant of CAP_CONSOLE_WRITE on the app subject.
+ * This is the only sanctioned path to widen console output access in this
+ * slice. Returns LAUNCHER_ERR_NOT_REGISTERED if the app was never registered.
+ */
+launcher_result_t launcher_grant_console_write(cap_subject_id_t app_subject_id);
+
+/*
+ * Explicit, launcher-mediated revoke. Restores deny-by-default for the app.
+ */
+launcher_result_t launcher_revoke_console_write(cap_subject_id_t app_subject_id);
+
+/*
+ * Sanctioned app output path: routes a console write through the capability
+ * gate on behalf of the app subject. Apps that try to bypass this entry
+ * point (by writing under their own subject directly) will fail closed
+ * because the launcher is the only thing that grants CAP_CONSOLE_WRITE.
+ *
+ * bytes_written_out may be NULL; on success it is set to the message length.
+ */
+launcher_result_t launcher_app_console_write(cap_subject_id_t app_subject_id,
+                                             const char *message,
+                                             size_t *bytes_written_out);
+
+/* Read-only inspection: returns 1 if the app currently holds console-write. */
+int launcher_app_has_console_write(cap_subject_id_t app_subject_id);
+
+#endif

--- a/tests/launcher_console_test.c
+++ b/tests/launcher_console_test.c
@@ -1,0 +1,128 @@
+/**
+ * @file launcher_console_test.c
+ * @brief Tests for the launcher-mediated console-write capability slice.
+ *
+ * Covers issue #81 / plan 2026-04-11-console-launcher-capability-slice.md:
+ *   - allow path: launcher grant + launcher write succeeds
+ *   - deny path: app without launcher grant cannot write
+ *   - regression: writes attempted without launcher mediation (direct
+ *     gate call with no launcher grant) are denied by default
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_gate.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/user/launcher.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:launcher_console:%s\n", reason);
+  exit(1);
+}
+
+int main(void) {
+  const cap_subject_id_t app_a = 2u;
+  const cap_subject_id_t app_b = 3u;
+  size_t bytes_written = 0u;
+
+  printf("TEST:START:launcher_console\n");
+
+  cap_table_init();
+  launcher_reset();
+
+  /* Deny-by-default: unregistered app cannot write through the launcher. */
+  if (launcher_app_console_write(app_a, "hi", &bytes_written) != LAUNCHER_ERR_NOT_REGISTERED) {
+    fail("unregistered_write_not_rejected");
+  }
+
+  if (launcher_register_app(app_a) != LAUNCHER_OK) {
+    fail("register_app_a_failed");
+  }
+  if (launcher_register_app(app_b) != LAUNCHER_OK) {
+    fail("register_app_b_failed");
+  }
+
+  /* Deny path: registered but not granted -> launcher denies and gate denies. */
+  if (launcher_app_has_console_write(app_a) != 0) {
+    fail("default_app_has_console_write");
+  }
+  if (launcher_app_console_write(app_a, "hi", &bytes_written) != LAUNCHER_ERR_DENIED) {
+    fail("registered_no_grant_not_denied");
+  }
+  printf("TEST:PASS:launcher_console_deny_without_grant\n");
+
+  /* Allow path: explicit launcher grant -> write succeeds with correct count. */
+  if (launcher_grant_console_write(app_a) != LAUNCHER_OK) {
+    fail("grant_console_write_failed");
+  }
+  if (launcher_app_has_console_write(app_a) != 1) {
+    fail("after_grant_inspection_negative");
+  }
+  bytes_written = 0u;
+  if (launcher_app_console_write(app_a, "secureos", &bytes_written) != LAUNCHER_OK) {
+    fail("granted_write_denied");
+  }
+  if (bytes_written != 8u) {
+    fail("granted_write_wrong_count");
+  }
+  printf("TEST:PASS:launcher_console_allow_after_grant\n");
+
+  /* Regression: launcher grant for app_a must not leak to app_b. */
+  if (launcher_app_has_console_write(app_b) != 0) {
+    fail("grant_leaked_to_other_app");
+  }
+  if (launcher_app_console_write(app_b, "x", &bytes_written) != LAUNCHER_ERR_DENIED) {
+    fail("grant_leaked_write_other_app");
+  }
+
+  /*
+   * Regression: an app attempting to write to the console *without* going
+   * through the launcher path must fail closed. The only way the capability
+   * table holds CAP_CONSOLE_WRITE for an app subject is via the launcher,
+   * so a direct gate call on a non-launcher subject is denied.
+   */
+  const cap_subject_id_t rogue_subject = 4u;
+  if (cap_console_write_gate(rogue_subject, "bypass", &bytes_written) != CAP_ERR_MISSING) {
+    fail("bypass_path_not_denied");
+  }
+  printf("TEST:PASS:launcher_console_regression_bypass_denied\n");
+
+  /* Revoke restores deny-by-default. */
+  if (launcher_revoke_console_write(app_a) != LAUNCHER_OK) {
+    fail("revoke_console_write_failed");
+  }
+  if (launcher_app_has_console_write(app_a) != 0) {
+    fail("after_revoke_still_has_console_write");
+  }
+  if (launcher_app_console_write(app_a, "hi", &bytes_written) != LAUNCHER_ERR_DENIED) {
+    fail("after_revoke_write_not_denied");
+  }
+  printf("TEST:PASS:launcher_console_revoke_restores_deny\n");
+
+  /* Invalid app handling. */
+  if (launcher_register_app(CAP_TABLE_MAX_SUBJECTS) != LAUNCHER_ERR_INVALID_APP) {
+    fail("invalid_app_register_not_rejected");
+  }
+  if (launcher_grant_console_write(CAP_TABLE_MAX_SUBJECTS) != LAUNCHER_ERR_INVALID_APP) {
+    fail("invalid_app_grant_not_rejected");
+  }
+  if (launcher_app_console_write(CAP_TABLE_MAX_SUBJECTS, "x", &bytes_written)
+      != LAUNCHER_ERR_INVALID_APP) {
+    fail("invalid_app_write_not_rejected");
+  }
+  printf("TEST:PASS:launcher_console_invalid_app\n");
+
+  /* Reset clears registrations and grants. */
+  launcher_reset();
+  if (launcher_app_has_console_write(app_a) != 0) {
+    fail("reset_left_grant_intact");
+  }
+  if (launcher_app_console_write(app_a, "x", &bytes_written) != LAUNCHER_ERR_NOT_REGISTERED) {
+    fail("reset_did_not_clear_registration");
+  }
+  printf("TEST:PASS:launcher_console_reset_clears_state\n");
+
+  return 0;
+}


### PR DESCRIPTION
Implements the slice from plans/2026-04-11-console-launcher-capability-slice.md, closing the gap called out in #81.

## What changed
- `kernel/user/launcher.{h,c}`: minimal launcher service.
  - App subjects must be explicitly registered.
  - `launcher_grant_console_write` / `launcher_revoke_console_write` are the only sanctioned paths to widen / narrow `CAP_CONSOLE_WRITE`.
  - `launcher_app_console_write` is the single app output entrypoint and routes through `cap_console_write_gate` so deny-by-default holds.
  - Read-only `launcher_app_has_console_write` never widens access.
- `tests/launcher_console_test.c` + `build/scripts/test_launcher_console.sh` and `test.sh` wiring.

## Validation
`build/scripts/test.sh launcher_console` — all sub-tests pass:
- `launcher_console_deny_without_grant`
- `launcher_console_allow_after_grant`
- `launcher_console_regression_bypass_denied` (a non-launcher subject cannot use the console gate)
- `launcher_console_revoke_restores_deny`
- `launcher_console_invalid_app`
- `launcher_console_reset_clears_state`

Existing `build/scripts/test.sh capability_gate` also still passes (no regression to the underlying gate).

## Exit criteria for #81
- [x] Writes denied unless explicitly granted (deny + bypass regression tests).
- [x] Launcher mediation required for app output (all writes go through `launcher_app_console_write`).
- [x] Both allow and deny paths tested deterministically.

## Follow-ups
- Wire the in-kernel console / app runtime to use `launcher_app_console_write` for real HelloApp-style output (this is the natural next step covered by #82's HelloApp slice and isn't required by #81's exit criteria).
- Audit-event coverage for launcher grant/revoke once the audit-log slice (#84) lands.