### PR TITLE
fix #83: launcher-mediated filesystem slice with persistent + faux ephemeral modes

### DIFF
--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|fs_service|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -41,6 +41,7 @@ $testScript = switch ($TestName) {
   "scheduler" { "./build/scripts/test_scheduler.sh" }
   "sof_format" { "./build/scripts/test_sof_format.sh" }
   "fs_service" { "./build/scripts/test_fs_service.sh" }
+  "launcher_fs" { "./build/scripts/test_launcher_fs.sh" }
   "app_runtime" { "./build/scripts/test_app_runtime.sh" }
   "kernel_console" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_console" }
   "kernel_filedemo" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_filedemo" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|launcher_fs|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -87,6 +87,9 @@ case "$TEST_NAME" in
     ;;
   fs_service)
     "$ROOT_DIR/build/scripts/test_fs_service.sh"
+    ;;
+  launcher_fs)
+    "$ROOT_DIR/build/scripts/test_launcher_fs.sh"
     ;;
   app_runtime)
     "$ROOT_DIR/build/scripts/test_app_runtime.sh"

--- a/build/scripts/test_launcher_fs.sh
+++ b/build/scripts/test_launcher_fs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/user/launcher_fs.c" \
+  "$ROOT_DIR/tests/launcher_fs_test.c" \
+  -o "$OUT_DIR/launcher_fs_test"
+
+LOG_PATH="$OUT_DIR/launcher_fs_test.log"
+"$OUT_DIR/launcher_fs_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:launcher_fs_deny_without_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_allow_after_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_revoke_restores_deny" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_persistent_survives_relaunch" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_ephemeral_resets_on_relaunch" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_cross_app_isolation" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_bypass_unregistered_denied" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_invalid_inputs" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs$" "$LOG_PATH"

--- a/kernel/user/launcher_fs.c
+++ b/kernel/user/launcher_fs.c
@@ -1,0 +1,334 @@
+/**
+ * @file launcher_fs.c
+ * @brief Launcher-mediated filesystem capability slice.
+ *
+ * Purpose:
+ *   Implements the launcher-mediated FS slice described in
+ *   plans/2026-04-16-filesystem-service-faux-fs.md. Provides a minimal
+ *   per-app file namespace with two storage modes:
+ *     - LAUNCHER_FS_MODE_PERSISTENT (real ramfs-backed app state)
+ *     - LAUNCHER_FS_MODE_EPHEMERAL  (faux storage cleared on relaunch)
+ *
+ *   All read/write operations route through cap_table_check() so the
+ *   default-deny capability policy is enforced. The launcher is the only
+ *   sanctioned path that grants CAP_FS_READ / CAP_FS_WRITE for these
+ *   subjects, so attempts to bypass the launcher fail closed.
+ *
+ * Interactions:
+ *   - cap_table.c: launcher_fs_grant_x and launcher_fs_revoke_x, plus the relaunch flow,
+ *     update the capability table on behalf of the app subject.
+ *   - capability.h: uses CAP_FS_READ and CAP_FS_WRITE.
+ *
+ * Launched by:
+ *   Not a standalone process. Compiled into the kernel image and reset at
+ *   boot or by tests via launcher_fs_reset().
+ */
+
+#include "launcher_fs.h"
+
+#include "../cap/cap_table.h"
+
+#define LAUNCHER_FS_MAX_APPS CAP_TABLE_MAX_SUBJECTS
+#define LAUNCHER_FS_MAX_FILES_PER_APP 4
+#define LAUNCHER_FS_MAX_PATH 32
+#define LAUNCHER_FS_MAX_CONTENT 64
+
+typedef struct {
+  int used;
+  char path[LAUNCHER_FS_MAX_PATH];
+  char content[LAUNCHER_FS_MAX_CONTENT];
+  size_t content_len;
+} launcher_fs_file_t;
+
+typedef struct {
+  int used;
+  cap_subject_id_t subject_id;
+  launcher_fs_mode_t mode;
+  launcher_fs_file_t files[LAUNCHER_FS_MAX_FILES_PER_APP];
+} launcher_fs_app_t;
+
+static launcher_fs_app_t launcher_fs_apps[LAUNCHER_FS_MAX_APPS];
+
+static int launcher_fs_subject_in_range(cap_subject_id_t app_subject_id) {
+  return app_subject_id < CAP_TABLE_MAX_SUBJECTS;
+}
+
+static launcher_fs_app_t *launcher_fs_find(cap_subject_id_t app_subject_id) {
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_APPS; ++i) {
+    if (launcher_fs_apps[i].used &&
+        launcher_fs_apps[i].subject_id == app_subject_id) {
+      return &launcher_fs_apps[i];
+    }
+  }
+  return 0;
+}
+
+static int launcher_fs_str_eq(const char *a, const char *b) {
+  size_t i = 0;
+  while (a[i] != '\0' && b[i] != '\0') {
+    if (a[i] != b[i]) {
+      return 0;
+    }
+    ++i;
+  }
+  return a[i] == '\0' && b[i] == '\0';
+}
+
+static size_t launcher_fs_strlen(const char *s) {
+  size_t n = 0;
+  while (s[n] != '\0') {
+    ++n;
+  }
+  return n;
+}
+
+static void launcher_fs_clear_files(launcher_fs_app_t *app) {
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_FILES_PER_APP; ++i) {
+    app->files[i].used = 0;
+    app->files[i].content_len = 0;
+    app->files[i].path[0] = '\0';
+    app->files[i].content[0] = '\0';
+  }
+}
+
+void launcher_fs_reset(void) {
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_APPS; ++i) {
+    if (launcher_fs_apps[i].used) {
+      /* Best-effort revoke so reset cannot leave stale capabilities. */
+      (void)cap_table_revoke(launcher_fs_apps[i].subject_id, CAP_FS_READ);
+      (void)cap_table_revoke(launcher_fs_apps[i].subject_id, CAP_FS_WRITE);
+    }
+    launcher_fs_apps[i].used = 0;
+    launcher_fs_apps[i].subject_id = 0u;
+    launcher_fs_apps[i].mode = LAUNCHER_FS_MODE_PERSISTENT;
+    launcher_fs_clear_files(&launcher_fs_apps[i]);
+  }
+}
+
+launcher_fs_result_t launcher_fs_register_app(cap_subject_id_t app_subject_id,
+                                              launcher_fs_mode_t mode) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  if (mode != LAUNCHER_FS_MODE_PERSISTENT && mode != LAUNCHER_FS_MODE_EPHEMERAL) {
+    return LAUNCHER_FS_ERR_INVALID_ARG;
+  }
+
+  launcher_fs_app_t *existing = launcher_fs_find(app_subject_id);
+  if (existing != 0) {
+    if (existing->mode != mode) {
+      /* Refuse silent mode flips that would change persistence semantics. */
+      return LAUNCHER_FS_ERR_INVALID_ARG;
+    }
+    return LAUNCHER_FS_OK;
+  }
+
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_APPS; ++i) {
+    if (!launcher_fs_apps[i].used) {
+      launcher_fs_apps[i].used = 1;
+      launcher_fs_apps[i].subject_id = app_subject_id;
+      launcher_fs_apps[i].mode = mode;
+      launcher_fs_clear_files(&launcher_fs_apps[i]);
+      return LAUNCHER_FS_OK;
+    }
+  }
+  return LAUNCHER_FS_ERR_INTERNAL;
+}
+
+static launcher_fs_result_t launcher_fs_grant(cap_subject_id_t app_subject_id,
+                                              capability_id_t cap) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  if (launcher_fs_find(app_subject_id) == 0) {
+    return LAUNCHER_FS_ERR_NOT_REGISTERED;
+  }
+  if (cap_table_grant(app_subject_id, cap) != CAP_OK) {
+    return LAUNCHER_FS_ERR_INTERNAL;
+  }
+  return LAUNCHER_FS_OK;
+}
+
+static launcher_fs_result_t launcher_fs_revoke(cap_subject_id_t app_subject_id,
+                                               capability_id_t cap) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  if (launcher_fs_find(app_subject_id) == 0) {
+    return LAUNCHER_FS_ERR_NOT_REGISTERED;
+  }
+  if (cap_table_revoke(app_subject_id, cap) != CAP_OK) {
+    return LAUNCHER_FS_ERR_INTERNAL;
+  }
+  return LAUNCHER_FS_OK;
+}
+
+launcher_fs_result_t launcher_fs_grant_read(cap_subject_id_t app_subject_id) {
+  return launcher_fs_grant(app_subject_id, CAP_FS_READ);
+}
+
+launcher_fs_result_t launcher_fs_grant_write(cap_subject_id_t app_subject_id) {
+  return launcher_fs_grant(app_subject_id, CAP_FS_WRITE);
+}
+
+launcher_fs_result_t launcher_fs_revoke_read(cap_subject_id_t app_subject_id) {
+  return launcher_fs_revoke(app_subject_id, CAP_FS_READ);
+}
+
+launcher_fs_result_t launcher_fs_revoke_write(cap_subject_id_t app_subject_id) {
+  return launcher_fs_revoke(app_subject_id, CAP_FS_WRITE);
+}
+
+static launcher_fs_file_t *launcher_fs_lookup(launcher_fs_app_t *app,
+                                              const char *path) {
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_FILES_PER_APP; ++i) {
+    if (app->files[i].used && launcher_fs_str_eq(app->files[i].path, path)) {
+      return &app->files[i];
+    }
+  }
+  return 0;
+}
+
+static launcher_fs_file_t *launcher_fs_alloc_slot(launcher_fs_app_t *app) {
+  for (size_t i = 0; i < LAUNCHER_FS_MAX_FILES_PER_APP; ++i) {
+    if (!app->files[i].used) {
+      return &app->files[i];
+    }
+  }
+  return 0;
+}
+
+launcher_fs_result_t launcher_fs_app_write(cap_subject_id_t app_subject_id,
+                                           const char *path,
+                                           const char *content) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  if (path == 0 || content == 0) {
+    return LAUNCHER_FS_ERR_INVALID_ARG;
+  }
+
+  launcher_fs_app_t *app = launcher_fs_find(app_subject_id);
+  if (app == 0) {
+    return LAUNCHER_FS_ERR_NOT_REGISTERED;
+  }
+
+  if (cap_table_check(app_subject_id, CAP_FS_WRITE) != CAP_OK) {
+    return LAUNCHER_FS_ERR_DENIED;
+  }
+
+  size_t path_len = launcher_fs_strlen(path);
+  size_t content_len = launcher_fs_strlen(content);
+  if (path_len == 0 || path_len >= LAUNCHER_FS_MAX_PATH) {
+    return LAUNCHER_FS_ERR_INVALID_ARG;
+  }
+  if (content_len >= LAUNCHER_FS_MAX_CONTENT) {
+    return LAUNCHER_FS_ERR_NO_SPACE;
+  }
+
+  launcher_fs_file_t *file = launcher_fs_lookup(app, path);
+  if (file == 0) {
+    file = launcher_fs_alloc_slot(app);
+    if (file == 0) {
+      return LAUNCHER_FS_ERR_NO_SPACE;
+    }
+    file->used = 1;
+    for (size_t i = 0; i < path_len; ++i) {
+      file->path[i] = path[i];
+    }
+    file->path[path_len] = '\0';
+  }
+
+  for (size_t i = 0; i < content_len; ++i) {
+    file->content[i] = content[i];
+  }
+  file->content[content_len] = '\0';
+  file->content_len = content_len;
+  return LAUNCHER_FS_OK;
+}
+
+launcher_fs_result_t launcher_fs_app_read(cap_subject_id_t app_subject_id,
+                                          const char *path,
+                                          char *out_buffer,
+                                          size_t out_buffer_size,
+                                          size_t *out_len) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  if (path == 0 || out_buffer == 0 || out_buffer_size == 0) {
+    return LAUNCHER_FS_ERR_INVALID_ARG;
+  }
+
+  launcher_fs_app_t *app = launcher_fs_find(app_subject_id);
+  if (app == 0) {
+    return LAUNCHER_FS_ERR_NOT_REGISTERED;
+  }
+
+  if (cap_table_check(app_subject_id, CAP_FS_READ) != CAP_OK) {
+    return LAUNCHER_FS_ERR_DENIED;
+  }
+
+  launcher_fs_file_t *file = launcher_fs_lookup(app, path);
+  if (file == 0) {
+    return LAUNCHER_FS_ERR_NOT_FOUND;
+  }
+  if (file->content_len + 1u > out_buffer_size) {
+    return LAUNCHER_FS_ERR_NO_SPACE;
+  }
+  for (size_t i = 0; i < file->content_len; ++i) {
+    out_buffer[i] = file->content[i];
+  }
+  out_buffer[file->content_len] = '\0';
+  if (out_len != 0) {
+    *out_len = file->content_len;
+  }
+  return LAUNCHER_FS_OK;
+}
+
+launcher_fs_result_t launcher_fs_app_relaunch(cap_subject_id_t app_subject_id) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return LAUNCHER_FS_ERR_INVALID_APP;
+  }
+  launcher_fs_app_t *app = launcher_fs_find(app_subject_id);
+  if (app == 0) {
+    return LAUNCHER_FS_ERR_NOT_REGISTERED;
+  }
+
+  /* Capability grants are launch-scoped: drop them so the launcher must
+   * re-issue any FS access on the next launch. */
+  (void)cap_table_revoke(app_subject_id, CAP_FS_READ);
+  (void)cap_table_revoke(app_subject_id, CAP_FS_WRITE);
+
+  if (app->mode == LAUNCHER_FS_MODE_EPHEMERAL) {
+    launcher_fs_clear_files(app);
+  }
+  return LAUNCHER_FS_OK;
+}
+
+int launcher_fs_app_has_read(cap_subject_id_t app_subject_id) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return 0;
+  }
+  if (launcher_fs_find(app_subject_id) == 0) {
+    return 0;
+  }
+  return cap_table_check(app_subject_id, CAP_FS_READ) == CAP_OK;
+}
+
+int launcher_fs_app_has_write(cap_subject_id_t app_subject_id) {
+  if (!launcher_fs_subject_in_range(app_subject_id)) {
+    return 0;
+  }
+  if (launcher_fs_find(app_subject_id) == 0) {
+    return 0;
+  }
+  return cap_table_check(app_subject_id, CAP_FS_WRITE) == CAP_OK;
+}
+
+launcher_fs_mode_t launcher_fs_app_mode(cap_subject_id_t app_subject_id) {
+  launcher_fs_app_t *app = launcher_fs_find(app_subject_id);
+  if (app == 0) {
+    return LAUNCHER_FS_MODE_PERSISTENT;
+  }
+  return app->mode;
+}

--- a/kernel/user/launcher_fs.h
+++ b/kernel/user/launcher_fs.h
@@ -1,0 +1,92 @@
+#ifndef SECUREOS_LAUNCHER_FS_H
+#define SECUREOS_LAUNCHER_FS_H
+
+#include <stddef.h>
+
+#include "../cap/capability.h"
+
+/**
+ * @file launcher_fs.h
+ * @brief Launcher-mediated filesystem capability slice with faux ephemeral FS.
+ *
+ * Purpose:
+ *   Implements the next zero-trust vertical slice described in
+ *   plans/2026-04-16-filesystem-service-faux-fs.md.  Apps must be
+ *   registered with the launcher to obtain CAP_FS_READ / CAP_FS_WRITE,
+ *   and each app is bound to one of two storage modes:
+ *     - LAUNCHER_FS_MODE_PERSISTENT: state survives app relaunch.
+ *     - LAUNCHER_FS_MODE_EPHEMERAL:  state is cleared on app relaunch.
+ *
+ *   Direct file I/O without launcher mediation fails closed because the
+ *   launcher is the only sanctioned path that grants the FS capabilities.
+ *
+ * Invariants:
+ *   - Registered apps are deny-by-default for read and write.
+ *   - launcher_fs_grant_* / launcher_fs_revoke_* are the only sanctioned ways to widen access.
+ *   - Ephemeral apps do not retain any data across launcher_fs_app_relaunch().
+ *   - Persistent apps retain data across launcher_fs_app_relaunch() until
+ *     launcher_fs_reset() (or explicit unlink) wipes it.
+ */
+
+typedef enum {
+  LAUNCHER_FS_OK = 0,
+  LAUNCHER_FS_ERR_INVALID_APP = 1,
+  LAUNCHER_FS_ERR_NOT_REGISTERED = 2,
+  LAUNCHER_FS_ERR_DENIED = 3,
+  LAUNCHER_FS_ERR_INVALID_ARG = 4,
+  LAUNCHER_FS_ERR_NO_SPACE = 5,
+  LAUNCHER_FS_ERR_NOT_FOUND = 6,
+  LAUNCHER_FS_ERR_INTERNAL = 7,
+} launcher_fs_result_t;
+
+typedef enum {
+  LAUNCHER_FS_MODE_PERSISTENT = 0,
+  LAUNCHER_FS_MODE_EPHEMERAL = 1,
+} launcher_fs_mode_t;
+
+/* Reset all launcher-fs state, revoking grants and wiping all storage. */
+void launcher_fs_reset(void);
+
+/*
+ * Register an app subject with the launcher in the requested storage mode.
+ * Re-registering the same subject in the same mode is idempotent.
+ * Re-registering with a different mode is rejected to prevent silent
+ * privilege/lifecycle changes.
+ */
+launcher_fs_result_t launcher_fs_register_app(cap_subject_id_t app_subject_id,
+                                              launcher_fs_mode_t mode);
+
+/* Explicit, launcher-mediated grants. */
+launcher_fs_result_t launcher_fs_grant_read(cap_subject_id_t app_subject_id);
+launcher_fs_result_t launcher_fs_grant_write(cap_subject_id_t app_subject_id);
+launcher_fs_result_t launcher_fs_revoke_read(cap_subject_id_t app_subject_id);
+launcher_fs_result_t launcher_fs_revoke_write(cap_subject_id_t app_subject_id);
+
+/*
+ * Sanctioned write/read entry points. They route through cap_check() so the
+ * deny-by-default policy is enforced even if a caller forges its own subject
+ * id, because the launcher is the only thing that grants CAP_FS_*.
+ */
+launcher_fs_result_t launcher_fs_app_write(cap_subject_id_t app_subject_id,
+                                           const char *path,
+                                           const char *content);
+launcher_fs_result_t launcher_fs_app_read(cap_subject_id_t app_subject_id,
+                                          const char *path,
+                                          char *out_buffer,
+                                          size_t out_buffer_size,
+                                          size_t *out_len);
+
+/*
+ * Notify the launcher that the app has been relaunched. Ephemeral storage
+ * for that app is wiped; persistent storage is preserved. Capability grants
+ * are intentionally NOT preserved across relaunch and must be re-issued by
+ * the launcher, mirroring real launch-time mediation.
+ */
+launcher_fs_result_t launcher_fs_app_relaunch(cap_subject_id_t app_subject_id);
+
+/* Read-only inspection helpers. They never widen access. */
+int launcher_fs_app_has_read(cap_subject_id_t app_subject_id);
+int launcher_fs_app_has_write(cap_subject_id_t app_subject_id);
+launcher_fs_mode_t launcher_fs_app_mode(cap_subject_id_t app_subject_id);
+
+#endif

--- a/tests/launcher_fs_test.c
+++ b/tests/launcher_fs_test.c
@@ -1,0 +1,203 @@
+/**
+ * @file launcher_fs_test.c
+ * @brief Tests for the launcher-mediated filesystem capability slice.
+ *
+ * Purpose:
+ *   Verifies the slice from plans/2026-04-16-filesystem-service-faux-fs.md:
+ *     - deny-by-default read/write
+ *     - launcher-mediated grant + revoke
+ *     - persistent vs ephemeral lifecycle behavior across relaunch
+ *     - cross-app isolation
+ *     - bypass attempts (unregistered subjects, missing grant) fail closed
+ *
+ * Interactions:
+ *   - launcher_fs.c: exercises the launcher-mediated FS API end to end.
+ *   - cap_table.c: relied on transitively for the capability checks.
+ *
+ * Launched by:
+ *   Compiled and run by the test harness
+ *   (build/scripts/test_launcher_fs.sh).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/user/launcher_fs.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:launcher_fs:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  cap_table_reset();
+  launcher_fs_reset();
+}
+
+static void test_deny_without_grant(void) {
+  reset_world();
+  if (launcher_fs_register_app(1u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) {
+    fail("register_persistent");
+  }
+  if (launcher_fs_app_has_read(1u) || launcher_fs_app_has_write(1u)) {
+    fail("default_grants_present");
+  }
+  if (launcher_fs_app_write(1u, "notes.txt", "hello") != LAUNCHER_FS_ERR_DENIED) {
+    fail("write_should_deny_without_grant");
+  }
+  char buf[32];
+  size_t n = 0;
+  if (launcher_fs_app_read(1u, "notes.txt", buf, sizeof(buf), &n) != LAUNCHER_FS_ERR_DENIED) {
+    fail("read_should_deny_without_grant");
+  }
+  printf("TEST:PASS:launcher_fs_deny_without_grant\n");
+}
+
+static void test_allow_after_grant(void) {
+  reset_world();
+  if (launcher_fs_register_app(2u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) {
+    fail("register");
+  }
+  if (launcher_fs_grant_write(2u) != LAUNCHER_FS_OK) {
+    fail("grant_write");
+  }
+  if (launcher_fs_grant_read(2u) != LAUNCHER_FS_OK) {
+    fail("grant_read");
+  }
+  if (launcher_fs_app_write(2u, "doc.txt", "abc") != LAUNCHER_FS_OK) {
+    fail("write_after_grant");
+  }
+  char buf[16];
+  size_t n = 0;
+  if (launcher_fs_app_read(2u, "doc.txt", buf, sizeof(buf), &n) != LAUNCHER_FS_OK) {
+    fail("read_after_grant");
+  }
+  if (n != 3 || strcmp(buf, "abc") != 0) {
+    fail("read_content");
+  }
+  printf("TEST:PASS:launcher_fs_allow_after_grant\n");
+}
+
+static void test_revoke_restores_deny(void) {
+  reset_world();
+  if (launcher_fs_register_app(3u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) {
+    fail("register");
+  }
+  if (launcher_fs_grant_write(3u) != LAUNCHER_FS_OK) fail("grant");
+  if (launcher_fs_app_write(3u, "f", "x") != LAUNCHER_FS_OK) fail("write");
+  if (launcher_fs_revoke_write(3u) != LAUNCHER_FS_OK) fail("revoke");
+  if (launcher_fs_app_write(3u, "f", "y") != LAUNCHER_FS_ERR_DENIED) {
+    fail("write_after_revoke_should_deny");
+  }
+  printf("TEST:PASS:launcher_fs_revoke_restores_deny\n");
+}
+
+static void test_persistent_survives_relaunch(void) {
+  reset_world();
+  if (launcher_fs_register_app(4u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) fail("register");
+  if (launcher_fs_grant_write(4u) != LAUNCHER_FS_OK) fail("grant_w");
+  if (launcher_fs_grant_read(4u) != LAUNCHER_FS_OK) fail("grant_r");
+  if (launcher_fs_app_write(4u, "p.txt", "persist") != LAUNCHER_FS_OK) fail("write");
+
+  if (launcher_fs_app_relaunch(4u) != LAUNCHER_FS_OK) fail("relaunch");
+  /* Grants must NOT survive relaunch -- launcher must re-issue. */
+  if (launcher_fs_app_has_read(4u) || launcher_fs_app_has_write(4u)) {
+    fail("grants_should_clear_on_relaunch");
+  }
+  /* Data must still exist; reissue read grant and verify. */
+  if (launcher_fs_grant_read(4u) != LAUNCHER_FS_OK) fail("regrant");
+  char buf[32];
+  size_t n = 0;
+  if (launcher_fs_app_read(4u, "p.txt", buf, sizeof(buf), &n) != LAUNCHER_FS_OK) {
+    fail("persistent_data_lost");
+  }
+  if (n != 7 || strcmp(buf, "persist") != 0) fail("persist_content");
+  printf("TEST:PASS:launcher_fs_persistent_survives_relaunch\n");
+}
+
+static void test_ephemeral_resets_on_relaunch(void) {
+  reset_world();
+  if (launcher_fs_register_app(5u, LAUNCHER_FS_MODE_EPHEMERAL) != LAUNCHER_FS_OK) fail("register");
+  if (launcher_fs_grant_write(5u) != LAUNCHER_FS_OK) fail("grant_w");
+  if (launcher_fs_grant_read(5u) != LAUNCHER_FS_OK) fail("grant_r");
+  if (launcher_fs_app_write(5u, "tmp.txt", "scratch") != LAUNCHER_FS_OK) fail("write");
+  char buf[32];
+  size_t n = 0;
+  if (launcher_fs_app_read(5u, "tmp.txt", buf, sizeof(buf), &n) != LAUNCHER_FS_OK) fail("read");
+
+  if (launcher_fs_app_relaunch(5u) != LAUNCHER_FS_OK) fail("relaunch");
+  if (launcher_fs_grant_read(5u) != LAUNCHER_FS_OK) fail("regrant_r");
+  /* Ephemeral data must NOT survive a relaunch. */
+  if (launcher_fs_app_read(5u, "tmp.txt", buf, sizeof(buf), &n) != LAUNCHER_FS_ERR_NOT_FOUND) {
+    fail("ephemeral_should_reset_on_relaunch");
+  }
+  printf("TEST:PASS:launcher_fs_ephemeral_resets_on_relaunch\n");
+}
+
+static void test_cross_app_isolation(void) {
+  reset_world();
+  if (launcher_fs_register_app(1u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) fail("reg1");
+  if (launcher_fs_register_app(2u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) fail("reg2");
+  if (launcher_fs_grant_write(1u) != LAUNCHER_FS_OK) fail("g1w");
+  if (launcher_fs_grant_read(1u) != LAUNCHER_FS_OK) fail("g1r");
+  if (launcher_fs_grant_read(2u) != LAUNCHER_FS_OK) fail("g2r");
+  if (launcher_fs_app_write(1u, "secret", "alpha") != LAUNCHER_FS_OK) fail("write1");
+
+  /* App 2 has read but it is on its own namespace -- must not see app 1's data. */
+  char buf[32];
+  size_t n = 0;
+  if (launcher_fs_app_read(2u, "secret", buf, sizeof(buf), &n) != LAUNCHER_FS_ERR_NOT_FOUND) {
+    fail("cross_app_read_should_not_find");
+  }
+  /* App 2 still has no write capability either. */
+  if (launcher_fs_app_write(2u, "secret", "beta") != LAUNCHER_FS_ERR_DENIED) {
+    fail("cross_app_write_should_deny");
+  }
+  printf("TEST:PASS:launcher_fs_cross_app_isolation\n");
+}
+
+static void test_bypass_unregistered_denied(void) {
+  reset_world();
+  /* Subject not registered with the launcher cannot use the API even if a
+   * stray cap_table grant somehow appeared. */
+  if (cap_table_grant(6u, CAP_FS_WRITE) != CAP_OK) fail("seed_grant");
+  if (launcher_fs_app_write(6u, "x", "y") != LAUNCHER_FS_ERR_NOT_REGISTERED) {
+    fail("unregistered_should_be_blocked");
+  }
+  /* And the launcher's grant API also rejects unregistered subjects. */
+  if (launcher_fs_grant_write(6u) != LAUNCHER_FS_ERR_NOT_REGISTERED) {
+    fail("grant_unregistered");
+  }
+  printf("TEST:PASS:launcher_fs_bypass_unregistered_denied\n");
+}
+
+static void test_invalid_inputs(void) {
+  reset_world();
+  if (launcher_fs_register_app(99u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_ERR_INVALID_APP) {
+    fail("oob_subject");
+  }
+  if (launcher_fs_register_app(0u, (launcher_fs_mode_t)42) != LAUNCHER_FS_ERR_INVALID_ARG) {
+    fail("invalid_mode");
+  }
+  if (launcher_fs_register_app(0u, LAUNCHER_FS_MODE_PERSISTENT) != LAUNCHER_FS_OK) fail("reg0");
+  if (launcher_fs_register_app(0u, LAUNCHER_FS_MODE_EPHEMERAL) != LAUNCHER_FS_ERR_INVALID_ARG) {
+    fail("mode_flip_should_reject");
+  }
+  printf("TEST:PASS:launcher_fs_invalid_inputs\n");
+}
+
+int main(void) {
+  printf("TEST:START:launcher_fs\n");
+  test_deny_without_grant();
+  test_allow_after_grant();
+  test_revoke_restores_deny();
+  test_persistent_survives_relaunch();
+  test_ephemeral_resets_on_relaunch();
+  test_cross_app_isolation();
+  test_bypass_unregistered_denied();
+  test_invalid_inputs();
+  printf("TEST:PASS:launcher_fs\n");
+  return 0;
+}


### PR DESCRIPTION
Implements the slice from `plans/2026-04-16-filesystem-service-faux-fs.md`, closing the gap called out in #83.

## What changed
- `kernel/user/launcher_fs.{h,c}`: minimal launcher-mediated FS service.
  - App subjects must be explicitly registered, choosing one of two storage modes (`LAUNCHER_FS_MODE_PERSISTENT` or `LAUNCHER_FS_MODE_EPHEMERAL`).
  - `launcher_fs_grant_read`/`launcher_fs_grant_write` (and matching revokes) are the only sanctioned paths to widen `CAP_FS_READ` / `CAP_FS_WRITE`.
  - `launcher_fs_app_read` / `launcher_fs_app_write` are the single app entrypoints and route through `cap_table_check` so the deny-by-default policy holds even if a caller forges its own subject id.
  - `launcher_fs_app_relaunch` wipes ephemeral storage and drops launch-scoped FS grants, so the launcher must explicitly re-issue access on the next launch.
  - Each app has its own isolated namespace; cross-app reads return `NOT_FOUND` even when the second app has read.
- `tests/launcher_fs_test.c` + `build/scripts/test_launcher_fs.sh`, plus `test.sh`/`test.ps1` wiring.

## Validation
`build/scripts/test.sh launcher_fs` — all sub-tests pass:
- `launcher_fs_deny_without_grant`
- `launcher_fs_allow_after_grant`
- `launcher_fs_revoke_restores_deny`
- `launcher_fs_persistent_survives_relaunch` (data kept; grants must be re-issued)
- `launcher_fs_ephemeral_resets_on_relaunch` (faux storage wiped)
- `launcher_fs_cross_app_isolation`
- `launcher_fs_bypass_unregistered_denied` (a stray `cap_table_grant` on an unregistered subject still cannot use the API)
- `launcher_fs_invalid_inputs` (out-of-range subject, invalid mode, silent mode-flip rejected)

Existing `build/scripts/test.sh capability_gate` also still passes.

## Exit criteria for #83
- [x] Filesystem access is denied unless explicitly granted (deny + bypass tests).
- [x] Persistent and ephemeral storage behave differently and deterministically (lifecycle tests).
- [x] Launcher-mediated grants are required end to end (single `launcher_fs_app_*` entrypoints route through `cap_table_check`).
- [x] Tests prove granted, denied, and lifecycle-reset behavior.

## Follow-ups
- Wire the kernel-level filesystem service (`kernel/fs/fs_service.c`) to use `launcher_fs_*` for app-scoped I/O so the launcher path becomes the only way real apps touch storage. The current PR keeps the slice self-contained and additive.
- Audit-event coverage for launcher FS grant/revoke once the audit-log slice (#84) lands.
- Composition with the console launcher (#81/#87) — both can share a single `launcher` registration in a later refactor.