### PR TITLE
docs: add zero-trust workflow rule hardening plan (#77)

### DIFF
--- a/plans/2026-04-08-zero-trust-workflow-rule-hardening.md
+++ b/plans/2026-04-08-zero-trust-workflow-rule-hardening.md
@@ -1,0 +1,76 @@
+# 2026-04-08 Zero-Trust Workflow Rule Hardening
+
+## Goal
+Tighten the workflow rule layer so every rule evaluation is tenant-scoped,
+explicitly scoped for read or write, and deny-by-default. This is the planning
+companion to issue #77 and predates the network ABI hardening slice
+(plan 2026-04-09) so the broader zero-trust posture stays consistent across
+subsystems.
+
+## Scope
+- Persisted workflow rules are bound to a tenant identifier and never evaluated
+  outside of that tenant.
+- Every rule declares an explicit read or write scope; missing scope means
+  deny.
+- Evaluation helpers fail closed when any required field is missing,
+  ambiguous, or cross-tenant.
+- Existing console, capability, and audit semantics stay unchanged; this slice
+  only narrows the workflow rule surface.
+- Validation lands as small, deterministic tests focused on tenant isolation
+  and scope enforcement.
+
+## Plan
+
+### Phase 1, rule shape
+- Define the minimal persisted workflow rule record:
+  - tenant id (required, non-zero).
+  - rule id (stable, unique per tenant).
+  - scope (`READ` or `WRITE`, no implicit `READ_WRITE`).
+  - subject + capability the rule applies to.
+  - reason code for audit, no free-form text.
+- Reject rule construction when any required field is missing or zero.
+- Keep the schema small enough to be embedded in existing capability metadata
+  without introducing a new persistence layer in this slice.
+
+### Phase 2, evaluation helpers
+- Add `workflow_rule_eval_read` and `workflow_rule_eval_write` helpers that:
+  - Take the calling tenant id and the rule id.
+  - Look up the rule in the caller's tenant only; cross-tenant lookups return
+    `CAP_ERR_MISSING` without leaking existence.
+  - Require the requested scope to match the rule's declared scope; mismatch
+    returns `CAP_ERR_MISSING`, not a softer error.
+  - Default to deny when the rule is absent, malformed, or scope-mismatched.
+- Provide a single `workflow_rule_reset_for_tests` helper to keep tests
+  deterministic and serial-first.
+
+### Phase 3, audit + non-interference
+- Route allow and deny decisions into the existing capability audit ring with
+  a dedicated `CAP_AUDIT_OP_WORKFLOW_*` operation tag.
+- Logging must not change the deny result and must not widen access on the
+  allow path.
+- Keep audit volume bounded: one record per evaluation, no hot-path
+  amplification.
+
+### Phase 4, validation
+- Add one allow-path test: same tenant, matching scope, expected `CAP_OK`.
+- Add one deny-path test: cross-tenant lookup returns `CAP_ERR_MISSING` and is
+  recorded as a deny in audit.
+- Add one scope-mismatch test: read request against a write-only rule (and
+  vice versa) returns `CAP_ERR_MISSING`.
+- Add one regression test proving audit logging does not flip a deny into an
+  allow.
+
+## Exit Criteria
+- Workflow rules are tenant-scoped end to end; no ambient rule lookups.
+- Read and write scopes are explicit, with no implicit widening.
+- Default-deny holds for missing, malformed, or mismatched rules.
+- Tenant-isolation, scope-mismatch, and non-interference tests pass
+  deterministically under `build/scripts/test.sh`.
+- The slice stays small enough to land in one PR without touching the console,
+  filesystem, or network slices.
+
+## Follow-ups (out of scope for this plan)
+- Persist rules across reboots once the filesystem service slice
+  (plan 2026-04-16) is wired in.
+- Surface workflow decisions through the capability broker share workflow
+  (plan 2026-04-21) once that slice lands.


### PR DESCRIPTION
Closes the docs gap called out in #77.

The issue body notes the planning file at `plans/2026-04-08-zero-trust-workflow-rule-hardening.md` could not be pushed to `main` at the time the issue was filed. The other recent slices (#79 network ABI, #82 console+helloapp, #83 filesystem, #84 audit, #85 broker) all have their plan committed under `plans/`; this PR brings #77 in line with that pattern.

## What changed
- Add `plans/2026-04-08-zero-trust-workflow-rule-hardening.md` describing the slice in the same shape as the other plans:
  - **Phase 1, rule shape** — tenant id, rule id, explicit `READ` or `WRITE` scope, no implicit `READ_WRITE`, deny on missing/zero fields.
  - **Phase 2, evaluation helpers** — `workflow_rule_eval_read` / `workflow_rule_eval_write`, tenant-scoped lookup that returns `CAP_ERR_MISSING` for cross-tenant or scope-mismatched requests (no existence leak), default-deny.
  - **Phase 3, audit + non-interference** — reuse the existing capability audit ring with a workflow op tag; logging cannot flip a deny.
  - **Phase 4, validation** — allow, cross-tenant deny, scope-mismatch, and audit non-interference tests.
- Calls out follow-ups (persistence via the FS slice, broker integration via #85) so the slice stays small.

## Validation
Docs-only change. No build or test impact:
- `git status` clean apart from the new plan file.
- No source under `kernel/`, `user/`, or `tests/` touched.

## Follow-ups
- Implementation PR will land the helpers and tests under the existing `build/scripts/test.sh` harness, mirroring how #84's audit slice was wired in.

Refs #77