### PR TITLE
fix #91: harden test.sh dispatch against missing/unreadable validator scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,7 @@ Project-specific expectations include:
 - Keep PowerShell and shell build scripts in sync
 - Add plan documents under `docs/plans` for major implementation work
 - Keep hardware access behind HAL abstractions
+- New validator/build scripts under `build/scripts/` must be committed with the executable bit set (`git update-index --chmod=+x <path>`). The harness in `build/scripts/test.sh` now invokes scripts via `bash <path>` so a missing bit will not silently fail CI, but it will still surface a `TEST:FAIL:harness_missing_script:` marker and a `harness_error` status in the validator JSON report; do not rely on that path for shipping changes. See issues #90 and #91.
 
 ## Pull Request Checklist
 

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -5,6 +5,40 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_NAME="${1:-hello_boot}"
 IMAGE_TAG="${SECUREOS_TOOLCHAIN_IMAGE:-secureos/toolchain:bookworm-2026-02-12}"
 
+# Directory containing subordinate validator/build scripts. Overridable so the
+# harness dispatch behavior can be exercised by a fixture without mutating the
+# real tree. Defaults to the canonical build/scripts directory.
+SCRIPTS_DIR="${SECUREOS_SCRIPTS_DIR:-$ROOT_DIR/build/scripts}"
+
+# Distinct exit code reserved for harness-level dispatch failures (missing or
+# unreadable subordinate scripts). Anything else from a child is treated as a
+# normal test failure. Kept in EX_CONFIG range (78) to avoid colliding with
+# common test exit codes.
+HARNESS_ERROR_EXIT=78
+
+# run_validator <relative_script> [args...]
+#
+# Invokes the named subordinate script via `bash <path>` so that a missing
+# executable bit (see issue #90) cannot silently break CI: we only need the
+# file to exist and be readable. If either precondition fails, we emit a
+# deterministic, parseable marker on stderr and exit with HARNESS_ERROR_EXIT
+# so callers (validate_bundle.sh, CI) can distinguish infra breakage from a
+# real test regression.
+run_validator() {
+  local relpath="$1"
+  shift || true
+  local path="$SCRIPTS_DIR/$relpath"
+  if [[ ! -e "$path" ]]; then
+    echo "TEST:FAIL:harness_missing_script:$path" >&2
+    exit "$HARNESS_ERROR_EXIT"
+  fi
+  if [[ ! -r "$path" ]]; then
+    echo "TEST:FAIL:harness_unreadable_script:$path" >&2
+    exit "$HARNESS_ERROR_EXIT"
+  fi
+  bash "$path" "$@"
+}
+
 stop_secureos_instances() {
   if command -v docker >/dev/null 2>&1; then
     mapfile -t IDS < <(docker ps --filter "ancestor=$IMAGE_TAG" --format "{{.ID}}")
@@ -23,7 +57,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|harness_dispatch]
 
 Runs SecureOS test targets.
 EOF
@@ -36,72 +70,75 @@ fi
 
 case "$TEST_NAME" in
   hello_boot)
-    "$ROOT_DIR/build/scripts/test_boot_sector.sh"
-    "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot
+    run_validator test_boot_sector.sh
+    run_validator run_qemu.sh --test hello_boot
     ;;
   hello_boot_negative)
-    "$ROOT_DIR/build/scripts/test_boot_sector_fail.sh"
-    "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail
+    run_validator test_boot_sector_fail.sh
+    run_validator run_qemu.sh --test hello_boot_fail
     ;;
   cap_api_contract)
-    "$ROOT_DIR/build/scripts/test_cap_api_contract.sh"
+    run_validator test_cap_api_contract.sh
     ;;
   capability_table)
-    "$ROOT_DIR/build/scripts/test_capability_table.sh"
+    run_validator test_capability_table.sh
     ;;
   capability_gate)
-    "$ROOT_DIR/build/scripts/test_capability_gate.sh"
+    run_validator test_capability_gate.sh
     ;;
   capability_audit)
-    "$ROOT_DIR/build/scripts/test_capability_audit.sh"
+    run_validator test_capability_audit.sh
     ;;
   event_bus)
-    "$ROOT_DIR/build/scripts/test_event_bus.sh"
+    run_validator test_event_bus.sh
     ;;
   scheduler)
-    "$ROOT_DIR/build/scripts/test_scheduler.sh"
+    run_validator test_scheduler.sh
     ;;
   sof_format)
-    "$ROOT_DIR/build/scripts/test_sof_format.sh"
+    run_validator test_sof_format.sh
     ;;
   ed25519)
-    "$ROOT_DIR/build/scripts/test_ed25519.sh"
+    run_validator test_ed25519.sh
     ;;
   cert_chain)
-    "$ROOT_DIR/build/scripts/test_cert_chain.sh"
+    run_validator test_cert_chain.sh
     ;;
   codesign)
-    "$ROOT_DIR/build/scripts/test_codesign.sh"
+    run_validator test_codesign.sh
     ;;
   tls)
-    "$ROOT_DIR/build/scripts/test_tls.sh"
+    run_validator test_tls.sh
     ;;
   https)
-    "$ROOT_DIR/build/scripts/test_https.sh"
+    run_validator test_https.sh
     ;;
   fs_service)
-    "$ROOT_DIR/build/scripts/test_fs_service.sh"
+    run_validator test_fs_service.sh
     ;;
   app_runtime)
-    "$ROOT_DIR/build/scripts/test_app_runtime.sh"
+    run_validator test_app_runtime.sh
     ;;
   kernel_console)
-    "$ROOT_DIR/build/scripts/build_kernel_image.sh"
-    "$ROOT_DIR/build/scripts/build_disk_image.sh"
-    "$ROOT_DIR/build/scripts/run_qemu.sh" --test kernel_console
+    run_validator build_kernel_image.sh
+    run_validator build_disk_image.sh
+    run_validator run_qemu.sh --test kernel_console
     ;;
   kernel_filedemo)
-    "$ROOT_DIR/build/scripts/build_kernel_image.sh"
-    "$ROOT_DIR/build/scripts/build_disk_image.sh"
-    "$ROOT_DIR/build/scripts/run_qemu.sh" --test kernel_filedemo
+    run_validator build_kernel_image.sh
+    run_validator build_disk_image.sh
+    run_validator run_qemu.sh --test kernel_filedemo
     ;;
   kernel_persistence)
-    "$ROOT_DIR/build/scripts/test_kernel_persistence.sh"
+    run_validator test_kernel_persistence.sh
     ;;
   kernel_sessions)
-    "$ROOT_DIR/build/scripts/build_kernel_image.sh"
-    "$ROOT_DIR/build/scripts/build_disk_image.sh"
-    "$ROOT_DIR/build/scripts/run_qemu.sh" --test kernel_sessions
+    run_validator build_kernel_image.sh
+    run_validator build_disk_image.sh
+    run_validator run_qemu.sh --test kernel_sessions
+    ;;
+  harness_dispatch)
+    run_validator test_harness_dispatch.sh
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_harness_dispatch.sh
+++ b/build/scripts/test_harness_dispatch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Fixture for issue #91: validates that build/scripts/test.sh fails
+# deterministically when a subordinate validator script is missing or
+# unreadable, instead of leaking a `Permission denied` line.
+#
+# This test reuses the existing dispatch logic via the SECUREOS_SCRIPTS_DIR
+# override so it can construct a temporary scripts directory without mutating
+# the real tree. It does not require any toolchain or QEMU.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_HARNESS="$ROOT_DIR/build/scripts/test.sh"
+HARNESS_ERROR_EXIT=78
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "TEST:PASS:test_harness_dispatch:$label"
+  else
+    echo "TEST:FAIL:test_harness_dispatch:$label expected=$expected actual=$actual" >&2
+    fail=1
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "TEST:PASS:test_harness_dispatch:$label"
+  else
+    echo "TEST:FAIL:test_harness_dispatch:$label needle=$needle" >&2
+    echo "--- haystack ---" >&2
+    echo "$haystack" >&2
+    echo "--- end ---" >&2
+    fail=1
+  fi
+}
+
+# --- Case 1: missing subordinate script -------------------------------------
+SCRIPTS_DIR_MISSING="$TMP_DIR/missing"
+mkdir -p "$SCRIPTS_DIR_MISSING"
+# Intentionally do NOT create test_event_bus.sh.
+
+set +e
+out="$(SECUREOS_SCRIPTS_DIR="$SCRIPTS_DIR_MISSING" "$TEST_HARNESS" event_bus 2>&1)"
+rc=$?
+set -e
+assert_eq "missing_script_exit_code" "$HARNESS_ERROR_EXIT" "$rc"
+assert_contains "missing_script_marker" "TEST:FAIL:harness_missing_script:" "$out"
+# Must NOT leak the legacy "Permission denied" surface.
+if [[ "$out" == *"Permission denied"* ]]; then
+  echo "TEST:FAIL:test_harness_dispatch:missing_script_no_perm_denied_leak" >&2
+  fail=1
+else
+  echo "TEST:PASS:test_harness_dispatch:missing_script_no_perm_denied_leak"
+fi
+
+# --- Case 2: unreadable subordinate script (chmod 000) ----------------------
+SCRIPTS_DIR_UNREAD="$TMP_DIR/unreadable"
+mkdir -p "$SCRIPTS_DIR_UNREAD"
+echo '#!/usr/bin/env bash' >"$SCRIPTS_DIR_UNREAD/test_event_bus.sh"
+chmod 000 "$SCRIPTS_DIR_UNREAD/test_event_bus.sh"
+# Restore permissions on cleanup so trap rm works.
+trap 'chmod -R u+rw "$TMP_DIR" 2>/dev/null || true; rm -rf "$TMP_DIR"' EXIT
+
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  # Root bypasses the 000 read check; skip this case but record a deterministic
+  # marker so CI logs reflect why.
+  echo "TEST:SKIP:test_harness_dispatch:unreadable_script_marker reason=running_as_root"
+else
+  set +e
+  out="$(SECUREOS_SCRIPTS_DIR="$SCRIPTS_DIR_UNREAD" "$TEST_HARNESS" event_bus 2>&1)"
+  rc=$?
+  set -e
+  assert_eq "unreadable_script_exit_code" "$HARNESS_ERROR_EXIT" "$rc"
+  assert_contains "unreadable_script_marker" "TEST:FAIL:harness_unreadable_script:" "$out"
+fi
+
+# --- Case 3: present-but-non-+x script still runs via `bash <path>` ---------
+SCRIPTS_DIR_OK="$TMP_DIR/no_exec_bit"
+mkdir -p "$SCRIPTS_DIR_OK"
+cat >"$SCRIPTS_DIR_OK/test_event_bus.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "TEST:PASS:stub_event_bus"
+STUB
+chmod 644 "$SCRIPTS_DIR_OK/test_event_bus.sh"  # explicitly no +x
+
+set +e
+out="$(SECUREOS_SCRIPTS_DIR="$SCRIPTS_DIR_OK" "$TEST_HARNESS" event_bus 2>&1)"
+rc=$?
+set -e
+assert_eq "no_exec_bit_exit_code" "0" "$rc"
+assert_contains "no_exec_bit_runs_via_bash" "TEST:PASS:stub_event_bus" "$out"
+
+if [[ $fail -ne 0 ]]; then
+  echo "TEST:FAIL:test_harness_dispatch" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:test_harness_dispatch"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -24,15 +24,29 @@ TEST_TARGETS=(
     kernel_console
     kernel_filedemo
     kernel_persistence
+    harness_dispatch
 )
 
 STATUS_LINES=()
 FAILED_TESTS=()
+HARNESS_ERRORS=()
+
+# Exit code reserved by build/scripts/test.sh for harness-level dispatch
+# failures (missing/unreadable subordinate scripts). Keep in sync with
+# HARNESS_ERROR_EXIT in test.sh.
+HARNESS_ERROR_EXIT=78
 
 for target in "${TEST_TARGETS[@]}"; do
   test_started="$(date +%s)"
-  if "$ROOT_DIR/build/scripts/test.sh" "$target"; then
+  set +e
+  "$ROOT_DIR/build/scripts/test.sh" "$target"
+  rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
     status="pass"
+  elif [[ $rc -eq $HARNESS_ERROR_EXIT ]]; then
+    status="harness_error"
+    HARNESS_ERRORS+=("$target")
   else
     status="fail"
     FAILED_TESTS+=("$target")
@@ -96,6 +110,7 @@ for line in status_lines:
         "name": name,
         "status": status,
         "pass": status == "pass",
+        "harnessError": status == "harness_error",
         "durationSeconds": int(duration),
     })
     if status != "pass":
@@ -249,6 +264,7 @@ report = {
     "overallStatus": "pass" if not failed else "fail",
     "pass": len(failed) == 0,
     "failedChecks": failed,
+    "harnessErrors": [c["name"] for c in checks if c.get("harnessError")],
     "checks": checks,
     "image": {
       "path": "experiments/bootloader/boot.bin",
@@ -276,8 +292,14 @@ if summary_check_error is not None:
     raise SystemExit(2)
 PY
 
-if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
-  echo "VALIDATION_FAIL:${FAILED_TESTS[*]}"
+if [[ ${#HARNESS_ERRORS[@]} -gt 0 ]]; then
+  echo "VALIDATION_HARNESS_ERROR:${HARNESS_ERRORS[*]}"
+fi
+
+if [[ ${#FAILED_TESTS[@]} -gt 0 || ${#HARNESS_ERRORS[@]} -gt 0 ]]; then
+  if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
+    echo "VALIDATION_FAIL:${FAILED_TESTS[*]}"
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
Closes #91 (defensive harness follow-up to #90 / PR #95).

## Summary

Routes every subordinate validator/build script invocation in `build/scripts/test.sh` through a `run_validator` helper that pre-checks existence and readability, invokes via `bash <path>` (so a missing `+x` bit alone no longer breaks dispatch), and emits a deterministic, parseable failure marker plus a distinct exit code (`78`) when the precondition fails. `validate_bundle.sh` now distinguishes `harness_error` from `fail` in both the JSON report and the stdout markers.

## Changes

- **`build/scripts/test.sh`**: new `run_validator` helper; every `case` arm goes through it. Failure modes emit `TEST:FAIL:harness_missing_script:<path>` or `TEST:FAIL:harness_unreadable_script:<path>` on stderr and exit with `HARNESS_ERROR_EXIT=78`. New `harness_dispatch` target. `SECUREOS_SCRIPTS_DIR` override for fixture testing.
- **`build/scripts/validate_bundle.sh`**: detects rc=78, records `status=harness_error` (separate from `fail`), adds `harnessError` flag per check and top-level `harnessErrors` list to `validator_report.json`, prints `VALIDATION_HARNESS_ERROR:<targets>` alongside (or instead of) `VALIDATION_FAIL:`. `harness_dispatch` added to the run set.
- **`build/scripts/test_harness_dispatch.sh`** (new, +x): fixture covering three cases:
  1. missing subordinate script → rc=78, `harness_missing_script` marker, no `Permission denied` leak.
  2. unreadable script (`chmod 000`) → rc=78, `harness_unreadable_script` marker (skipped under root).
  3. present-but-non-+x script → rc=0, runs via `bash <path>`.
- **`CONTRIBUTING.md`**: documents the `+x` expectation and the new harness fallback contract.

## Validation

```
$ bash build/scripts/test.sh harness_dispatch
TEST:PASS:test_harness_dispatch:missing_script_exit_code
TEST:PASS:test_harness_dispatch:missing_script_marker
TEST:PASS:test_harness_dispatch:missing_script_no_perm_denied_leak
TEST:PASS:test_harness_dispatch:unreadable_script_exit_code
TEST:PASS:test_harness_dispatch:unreadable_script_marker
TEST:PASS:test_harness_dispatch:no_exec_bit_exit_code
TEST:PASS:test_harness_dispatch:no_exec_bit_runs_via_bash
TEST:PASS:test_harness_dispatch
EXIT=0
```

`bash -n build/scripts/validate_bundle.sh` clean.

## Acceptance mapping (issue #91)

- [x] `test.sh` invokes each subordinate validator via `bash <path>` instead of executing it directly.
- [x] Harness checks each script exists and is readable at dispatch time; emits `TEST:FAIL:harness_missing_script:<path>` (or `harness_unreadable_script`) and a non-zero exit code (78). No `Permission denied` leak.
- [x] Validator JSON report distinguishes `harness_error` from `test_fail` (per-check `status`/`harnessError` + top-level `harnessErrors` + stdout `VALIDATION_HARNESS_ERROR:` marker).
- [x] Fixture (`test_harness_dispatch.sh`) removes the executable bit and removes the script and asserts both surfaces deterministically; wired into `test.sh` and `validate_bundle.sh`.

## Follow-ups

- Stack atop #95 once that's merged (PR #95 restores the `+x` baseline). This PR is independently testable but the full CI green run is gated on #95.
- Consider mirroring the same dispatch helper into `build/scripts/test.ps1` for Windows runners (not in scope here).