### PR TITLE
docs: ABI reference for syscalls, capabilities, manifest, versioning (#93)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,7 @@ After successful builds, key outputs include:
 Before opening a PR, review:
 - `AGENTS.md`
 - `docs/CODING_CONVENTIONS.md`
+- `docs/abi/` — ABI reference (syscall surface, capability IDs, manifest schema, versioning policy). Update the relevant page in the same PR when you change ABI surface.
 
 Project-specific expectations include:
 - Keep PowerShell and shell build scripts in sync

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - Roadmap: `BUILD_ROADMAP.md`
 - M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
+- ABI reference: `docs/abi/` (syscalls, capabilities, manifest, versioning)
 - ADRs: `docs/adr/`
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -1,0 +1,31 @@
+# SecureOS ABI Reference
+
+This directory is the authoritative reference for the SecureOS Application
+Binary Interface (ABI) surface that user-space code, modules, and launcher
+manifests depend on.
+
+Per `BUILD_ROADMAP.md` §7 ("ABI and Interface Freeze Plan"), we publish ABI
+docs early — while we are still at `OS_ABI_VERSION=0` — so that interface
+changes are deliberate and reviewable rather than emergent.
+
+## Index
+
+- [syscalls.md](syscalls.md) — User-facing `os_*` syscall / API surface, the
+  capability each call requires, and the documented error/status model.
+- [capabilities.md](capabilities.md) — Capability identifiers, handle
+  representation, grant/revoke semantics, admin-gate, non-delegability, and
+  audit/sequence guarantees. Cross-references the deeper architecture notes
+  in `docs/architecture/CAPABILITIES.md`.
+- [manifest.md](manifest.md) — Launcher manifest schema: how an app declares
+  the capabilities it needs and how the launcher mediates grants today.
+- [versioning.md](versioning.md) — `OS_ABI_VERSION` policy, compat-shim
+  window, and the process for adding / removing ABI surface.
+
+## Provenance
+
+Each document carries a `Last verified against commit: <sha>` line. When you
+touch the underlying surface (a syscall signature, a capability ID, the
+launcher API, the manifest layout), bump the verification line in the
+corresponding doc in the same change.
+
+Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -1,0 +1,103 @@
+# SecureOS Capability ABI
+
+This document is the ABI-level summary of the capability subsystem. For
+implementation history and per-CAP-NNN deltas, see
+[`docs/architecture/CAPABILITIES.md`](../architecture/CAPABILITIES.md).
+
+## Capability IDs
+
+`capability_id_t` is a stable, append-only enum
+(`kernel/cap/capability.h`):
+
+| ID | Name | Gates |
+| -- | ---- | ----- |
+| 1  | `CAP_CONSOLE_WRITE` | `os_console_write`, `cap_console_write_gate` |
+| 2  | `CAP_SERIAL_WRITE` | `cap_serial_write_gate` |
+| 3  | `CAP_DEBUG_EXIT` | `cap_debug_exit_gate` |
+| 4  | `CAP_CAPABILITY_ADMIN` | grant/revoke mutation actor authority |
+| 5  | `CAP_DISK_IO_REQUEST` | raw block I/O |
+| 6  | `CAP_FS_READ` | `os_fs_list_*`, `os_fs_read_file` |
+| 7  | `CAP_FS_WRITE` | `os_fs_write_file`, `os_fs_mkdir` |
+| 8  | `CAP_EVENT_SUBSCRIBE` | event-bus subscribe |
+| 9  | `CAP_EVENT_PUBLISH` | event-bus publish |
+| 10 | `CAP_APP_EXEC` | dynamic library load / app launch |
+| 11 | `CAP_CODESIGN_BYPASS` | sealed-build only; never granted in prod |
+| 12 | `CAP_NETWORK` | all `os_net_*` (incl. HTTPS) |
+
+Rules (all enforced today):
+
+- IDs are **append-only** once merged. Numeric IDs are never reused or
+  renumbered.
+- Unknown capability IDs **must** return `CAP_ERR_CAP_INVALID` from
+  `cap_check` and from grant/revoke. They are never treated as success.
+- Unknown subject IDs **must** return `CAP_ERR_SUBJECT_INVALID`. The maximum
+  subject is `CAP_TABLE_MAX_SUBJECTS = 8` at `OS_ABI_VERSION=0`.
+
+## Handle representation
+
+A "capability handle" at this stage of the project is the pair
+`(cap_subject_id_t, capability_id_t)` stored in the per-subject packed
+bitset table (`kernel/cap/cap_table.{h,c}`). There is no separate
+opaque-handle type yet; that is intentional until the broker slice (#85)
+lands and demands sharable, revocable references.
+
+When the broker slice ships, the handle type will:
+
+- be opaque to user-space (no kernel pointer dereference required),
+- carry the originating subject so revocation is total,
+- be observable in audit events under their existing `subject_id` /
+  `capability_id` fields plus a new handle-id column.
+
+Until then, code that needs to refer to a "grant" refers to the
+`(subject, capability)` pair directly.
+
+## Result codes
+
+`cap_result_t`:
+
+| Value | Name | Meaning |
+| ----- | ---- | ------- |
+| 0 | `CAP_OK` | Explicit grant present. |
+| 1 | `CAP_ERR_MISSING` | Subject is valid, capability is valid, no grant. |
+| 2 | `CAP_ERR_SUBJECT_INVALID` | Subject out of range / unknown. |
+| 3 | `CAP_ERR_CAP_INVALID` | Capability ID out of range / unknown. |
+
+Syscall-layer wrappers translate `CAP_OK → OS_STATUS_OK` and any other
+`cap_result_t` into `OS_STATUS_DENIED`. Calls that *can* succeed without
+the capability but degrade (none today) must document that explicitly.
+
+## Grant / revoke semantics
+
+- All mutation goes through `cap_grant_as_for_tests` /
+  `cap_revoke_as_for_tests` (test names — the runtime path is the same code
+  behind a sealed entry). Every mutation requires an `actor_subject_id`
+  that itself holds `CAP_CAPABILITY_ADMIN`.
+- `CAP_CAPABILITY_ADMIN` is **non-delegable** (CAP-014): only the bootstrap
+  root subject `0` may hold it, and attempts to grant it to any other
+  subject return `CAP_ERR_MISSING` against the actor.
+- Revocation is immediate. The next `cap_check` after a revoke must return
+  `CAP_ERR_MISSING`.
+- There is no "expiry" or "TTL" on a grant at `OS_ABI_VERSION=0`.
+
+## Audit and sequence guarantees
+
+The capability audit ring (`cap_audit_event_t`) is part of the ABI for
+validators and the broker:
+
+- Every check, grant, and revoke emits an event with a strictly monotonic
+  `sequence_id` (CAP-016). The sequence never repeats, even across ring
+  wrap.
+- Mutation events include `actor_subject_id` (CAP-015).
+- The ring has a fixed retained window (`CAP_AUDIT_EVENT_MAX = 32`) with
+  FIFO eviction and a separately tracked `dropped` counter (CAP-011).
+- Periodic checkpoints (`CAP_AUDIT_CHECKPOINT_INTERVAL = 8`) summarize each
+  window with a tamper-evident `seal` (CAP-017/018). Validators enforce a
+  strict schema for the checkpoint summary in CI (CAP-012/018).
+- CAP-019 (sequence-window attestation) is in progress; it will tie the
+  retained event window to the checkpoint window continuity invariant.
+
+Consumers may read `cap_audit_get_for_tests` / `cap_audit_count_for_tests`
+to walk the retained ring in test/validator contexts. In production the
+broker (#85) will be the single consumer.
+
+Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -1,0 +1,105 @@
+# SecureOS Launcher Manifest
+
+Status: **draft, `OS_ABI_VERSION=0`**.
+
+At this milestone, the "manifest" is the in-code launcher registration
+API plus the explicit grant calls it exposes. The on-disk JSON form is
+sketched below but not yet load-bearing; it is the target shape we will
+freeze once the launcher-mediated console slice (#82) and filesystem
+slice (#83) close.
+
+The launcher is the **only** sanctioned path that widens an app's
+capability set. The kernel capability gates do the enforcement, but the
+launcher decides whether a given app subject ever gets a grant in the
+first place.
+
+## In-code surface (today)
+
+From [`kernel/user/launcher.h`](../../kernel/user/launcher.h):
+
+- `launcher_register_app(app_id, subject_id)` — register an app subject
+  with the launcher. Apps not registered cannot be granted any capability
+  through the launcher.
+- `launcher_grant_console_write(app_id)` /
+  `launcher_revoke_console_write(app_id)` — the only sanctioned path to
+  widen / narrow `CAP_CONSOLE_WRITE`.
+- `launcher_app_console_write(app_id, msg, *bytes_written)` — single app
+  output entrypoint; routes through `cap_console_write_gate` so
+  deny-by-default still holds.
+- `launcher_app_has_console_write(app_id)` — read-only inspection; never
+  widens access.
+
+A non-launcher subject that calls the underlying gate directly without
+its own explicit grant is denied. The bypass-regression test in
+`tests/launcher_console_test.c` proves this.
+
+## Target manifest schema (sketch)
+
+```jsonc
+{
+  "manifest_version": 0,
+  "app": {
+    "id": "helloapp",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signature": "apps/helloapp.bin.sig"
+  },
+  "capabilities": {
+    "request": [
+      "CAP_CONSOLE_WRITE"
+    ],
+    "optional": []
+  },
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  }
+}
+```
+
+Field semantics we are committing to:
+
+- `manifest_version` is required and must match the current
+  `OS_ABI_VERSION` family. Unknown fields are an error, not a warning —
+  zero-trust applies to manifest parsing too.
+- `app.subject_id` is the `cap_subject_id_t` the launcher will register
+  for this app. It must be unique across loaded apps.
+- `capabilities.request` lists capabilities the app *may* use. The
+  launcher will refuse to grant anything not listed here.
+- `capabilities.optional` are capabilities the app can tolerate being
+  denied (it must check the `OS_STATUS_DENIED` result and degrade).
+- `launcher.auto_grant_at_launch` is the subset the launcher will grant
+  unconditionally at startup. Anything in `request` but not in
+  `auto_grant_at_launch` must go through `require_user_confirm` (future
+  broker slice, #85) or be explicitly granted by an admin.
+- Signatures are required for any non-bootstrap app once `CAP_APP_EXEC`
+  is enforced end-to-end; today this is bypassable only behind
+  `CAP_CODESIGN_BYPASS` in sealed-build mode.
+
+## Worked example: HelloApp (M2)
+
+The HelloApp slice (#82) registers a subject with the launcher, requests
+`CAP_CONSOLE_WRITE`, and is exercised under two manifests:
+
+- **Allow manifest** — `auto_grant_at_launch: ["CAP_CONSOLE_WRITE"]`.
+  The app prints its banner; the validator emits
+  `TEST:PASS:helloapp_console_write_allowed`.
+- **Deny manifest** — `auto_grant_at_launch: []`.
+  The app's `os_console_write` returns `OS_STATUS_DENIED`; the validator
+  emits `TEST:PASS:helloapp_denied_console_write` and a capability-audit
+  deny event is recorded (see #92 for the dedicated negative-path test
+  and #84 for the audit assertion).
+
+## Compatibility policy
+
+Until `OS_ABI_VERSION` bumps to 1:
+
+- Adding new optional manifest fields is allowed; loaders **must** reject
+  unknown fields on `manifest_version: 0` so behavior cannot silently
+  drift.
+- Adding new capability IDs to `request` is allowed (subject to the rules
+  in [capabilities.md](capabilities.md)).
+- Renaming a field is **not** allowed without bumping
+  `manifest_version`.
+
+Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -1,0 +1,105 @@
+# SecureOS Syscall / User API Surface
+
+Status: **draft, `OS_ABI_VERSION=0`** — surface is still iterating. Adding new
+calls is allowed; signatures of listed calls are append-only-with-care (see
+[versioning.md](versioning.md)).
+
+User-space applications call into the kernel through the prototypes declared
+in [`user/include/secureos_api.h`](../../user/include/secureos_api.h). On
+real hardware these will eventually trap into the kernel; today many are
+serviced through the native bridge stub (`user/runtime/secureos_api_stubs.c`)
+or wired directly to kernel services for in-kernel tests.
+
+## Status / error model
+
+All calls return `os_status_t`:
+
+| Value | Name | Meaning |
+| ----- | ---- | ------- |
+| 0 | `OS_STATUS_OK` | Call succeeded; out-buffers are populated. |
+| 1 | `OS_STATUS_DENIED` | Caller lacks the required capability (or admin-gate failed). |
+| 2 | `OS_STATUS_NOT_FOUND` | Target resource (file, env key, lib, etc.) does not exist. |
+| 3 | `OS_STATUS_ERROR` | Generic failure (bad args, out-of-space, transport error). |
+
+`OS_STATUS_DENIED` is the only success-shaped result an unprivileged caller
+should ever observe for a missing capability — it is **never** silently
+treated as success and is **never** collapsed into `OS_STATUS_ERROR`. This
+guarantee is what makes zero-trust regression tests deterministic.
+
+Buffer-returning calls take `(out_buffer, out_buffer_size)`; truncation is
+reported as `OS_STATUS_ERROR` and the contents of `out_buffer` are
+unspecified in that case.
+
+## Surface (current)
+
+### Console
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_console_write(message)` | `CAP_CONSOLE_WRITE` | Goes through `cap_console_write_gate` in the kernel. Apps must be routed through the launcher (see [manifest.md](manifest.md)); direct subjects without an explicit grant get `OS_STATUS_DENIED`. |
+
+### Filesystem
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_fs_list_root(out, len)` | `CAP_FS_READ` | |
+| `os_fs_list_dir(path, out, len)` | `CAP_FS_READ` | |
+| `os_fs_read_file(path, out, len)` | `CAP_FS_READ` | |
+| `os_fs_write_file(path, content, append)` | `CAP_FS_WRITE` | `append == 0` truncates, non-zero appends. |
+| `os_fs_mkdir(path)` | `CAP_FS_WRITE` | |
+
+### Process / environment
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_process_chdir(path)` | (none — bound to caller) | |
+| `os_process_getcwd(out, len)` | (none) | |
+| `os_env_get/set/list(...)` | (none) | Per-process env. |
+
+### Libraries
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_lib_list(out, len)` | (none) | Discovery only. |
+| `os_lib_load(path, out, len)` | `CAP_APP_EXEC` | Loads a shared library into the caller's process image. |
+| `os_lib_unload(handle)` | `CAP_APP_EXEC` | |
+
+### Network (M1 surface, see #79)
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_net_device_ready()` | `CAP_NETWORK` | |
+| `os_net_device_backend(out, len)` | `CAP_NETWORK` | |
+| `os_net_device_get_mac(out, len)` | `CAP_NETWORK` | |
+| `os_net_frame_send(frame, len)` | `CAP_NETWORK` | Raw L2 send. |
+| `os_net_frame_recv(out, len, *out_len)` | `CAP_NETWORK` | Raw L2 recv. |
+| `os_net_ifconfig(out, len)` | `CAP_NETWORK` | Diagnostic. |
+| `os_net_http_get(url, out, len)` | `CAP_NETWORK` | Convenience HTTP/1.1 client. Subject to URL-scheme gate (#79). |
+| `os_net_https_get(url, out, len)` | `CAP_NETWORK` | TLS 1.2 via BearSSL in user-space; no separate capability. |
+| `os_net_ping(host, out, len)` | `CAP_NETWORK` | ICMP via netlib. |
+
+`CAP_NETWORK` is a single coarse capability today; finer-grained network
+policy (per-host, per-scheme) is tracked under #79 and lives inside netlib /
+the dispatch shim, not as new capability IDs at this layer.
+
+### Apps / system
+
+| Call | Required cap | Notes |
+| ---- | ------------ | ----- |
+| `os_apps_list(out, len)` | (none) | Discovery. |
+| `os_storage_info(out, len)` | (none) | Read-only. |
+| `os_get_args(out, len)` | (none) | Caller's argv. |
+
+## Adding a syscall
+
+1. Declare the prototype in `user/include/secureos_api.h`.
+2. Add the in-kernel implementation behind the appropriate `cap_*_gate` (or
+   add a new gate if there is no capability covering it — and update
+   [capabilities.md](capabilities.md)).
+3. If the call is sensitive, add a launcher manifest field that controls the
+   grant (see [manifest.md](manifest.md)) rather than auto-granting to the
+   bootstrap subject.
+4. Add an allow-path and a deny-path test under `build/scripts/test_*.sh`.
+5. Update this table and bump the verification line below.
+
+Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/docs/abi/versioning.md
+++ b/docs/abi/versioning.md
@@ -1,0 +1,51 @@
+# SecureOS ABI Versioning Policy
+
+This restates `BUILD_ROADMAP.md` §7 in operational terms.
+
+## States
+
+- `OS_ABI_VERSION = 0` — **current.** Rapid iteration. Surface listed in
+  this directory is the working set; signatures may change with a single
+  PR that updates every caller in-tree. Out-of-tree consumers do not
+  exist yet.
+- `OS_ABI_VERSION = 1` — frozen at SDK beta announcement. After freeze:
+  - No removal or signature change of any documented call/field without
+    a major bump.
+  - New additions are allowed and remain at version `1`.
+  - Compatibility shims for the previous major are maintained for **at
+    least one major version** (i.e. when we move to `2`, `1` callers
+    still work for that release line).
+- `OS_ABI_VERSION = N (N ≥ 2)` — same rules as `1`, with the rolling
+  one-major-version shim window.
+
+## What counts as ABI
+
+- Anything declared in `user/include/secureos_api.h`.
+- Anything in `kernel/cap/capability.h` that is exposed by name to user
+  space or to validators (capability IDs, result codes, audit event
+  layout, checkpoint layout).
+- The launcher manifest schema in [manifest.md](manifest.md).
+- The validator JSON report schema (`build/scripts/validate_bundle.sh`)
+  and the `TEST:PASS:` / `TEST:FAIL:` marker contract — validators and
+  CI depend on these.
+
+## Process for an ABI change
+
+1. Open an issue describing the change and the user impact.
+2. Update the relevant doc under `docs/abi/`.
+3. Bump the `Last verified against commit` line in the same PR as the
+   code change.
+4. After SDK beta freeze, add a shim or a `manifest_version` bump if the
+   change is not strictly additive.
+
+## What is *not* ABI yet
+
+- Internal kernel APIs (`kernel/cap/cap_table.h` internals beyond the
+  documented enum, scheduler interfaces, HAL details).
+- The on-disk app binary format (`docs/plans/2026-03-16-secureos-file-format.md`)
+  — still in design.
+- The native bridge layout in `user/runtime/secureos_api_stubs.c` — this
+  is an implementation detail of the M1 host bridge and will be
+  replaced by real syscalls.
+
+Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785


### PR DESCRIPTION
Closes #93.

Adds `docs/abi/` per BUILD_ROADMAP.md §7 ("ABI and Interface Freeze Plan"), while we are still at `OS_ABI_VERSION=0` — the cheapest moment to write this down before the M2 launcher/HelloApp slice (#82) crosses the manifest + capability + syscall boundary together.

## What landed

- `docs/abi/README.md` — index + provenance convention ("Last verified against commit").
- `docs/abi/syscalls.md` — full `os_*` surface from `user/include/secureos_api.h` with the required capability per call and the `os_status_t` error model. Adding-a-syscall checklist included.
- `docs/abi/capabilities.md` — capability ID table (CAP_CONSOLE_WRITE..CAP_NETWORK), result codes, append-only rule, handle representation (today and after broker slice #85), grant/revoke semantics, admin-gate (CAP-013), non-delegability (CAP-014), and the audit/sequence/checkpoint guarantees (CAP-009..018).
- `docs/abi/manifest.md` — in-code launcher API today (`kernel/user/launcher.h`) plus the target JSON manifest schema sketch (`manifest_version`, `capabilities.request`/`optional`, `launcher.auto_grant_at_launch`) and the HelloApp allow/deny worked example tied to #82/#92.
- `docs/abi/versioning.md` — `OS_ABI_VERSION` policy, what counts as ABI, change process, and what is explicitly *not* ABI yet (kernel internals, native bridge layout, file format).
- README.md + CONTRIBUTING.md link the new index.

## Acceptance bullets from #93

- [x] `docs/abi/` directory created with syscalls.md, capabilities.md, manifest.md, versioning.md.
- [x] Each doc has a "Last verified against commit" line (pinned to `9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785`).
- [x] README.md and CONTRIBUTING.md link the new index.

## Validation

Docs-only change; no code paths touched. Markdown renders locally. No `build/scripts/test.sh` targets are affected.

## Follow-ups

- Bump the verification lines at the end of each milestone (or whenever the underlying surface changes) — called out in versioning.md.
- Once the broker slice (#85) introduces an opaque handle type, refresh capabilities.md "Handle representation".
- Once the on-disk manifest loader lands alongside #82/#83, promote manifest.md from sketch to canonical and add a JSON schema.