### PR TITLE
fix #84: structured capability audit log line + non-interference test

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|launcher_fs|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|launcher_fs|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -54,6 +54,9 @@ case "$TEST_NAME" in
     ;;
   capability_audit)
     "$ROOT_DIR/build/scripts/test_capability_audit.sh"
+    ;;
+  capability_audit_log)
+    "$ROOT_DIR/build/scripts/test_capability_audit_log.sh"
     ;;
   launcher_console)
     "$ROOT_DIR/build/scripts/test_launcher_console.sh"

--- a/build/scripts/test_capability_audit_log.sh
+++ b/build/scripts/test_capability_audit_log.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build + run the capability audit-log slice tests.
+#
+# Covers:
+#   - Phase 1: stable capability_audit log line shape
+#   - Phase 2: grant + deny capture
+#   - Phase 4: non-interference (formatting must not alter policy)
+#
+# Outputs deterministic TEST:PASS markers consumed by build/scripts/test.sh and
+# validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/tests/capability_audit_log_test.c" \
+  -o "$OUT_DIR/capability_audit_log_test"
+
+LOG_PATH="$OUT_DIR/capability_audit_log_test.log"
+"$OUT_DIR/capability_audit_log_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:capability_audit_log_grant_and_deny" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_log_invalid_inputs" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_log_non_interference" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_log" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -17,6 +17,7 @@ TEST_TARGETS=(
   capability_table
   capability_gate
   capability_audit
+  capability_audit_log
     event_bus
     sof_format
     fs_service

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -259,3 +259,138 @@ cap_result_t cap_check(cap_subject_id_t subject_id, capability_id_t capability_i
   cap_audit_record(CAP_AUDIT_OP_CHECK, subject_id, subject_id, capability_id, result);
   return result;
 }
+
+/*
+ * Audit event serialization.
+ *
+ * These helpers do not touch any module-level audit state. They translate the
+ * already-recorded event tuple into a stable textual form for serial logs and
+ * tests. Non-interference: callers can format an event any number of times
+ * without affecting capability decisions or the audit ring.
+ */
+
+cap_audit_outcome_t cap_audit_event_outcome(const cap_audit_event_t *event) {
+  if (event == 0) {
+    return CAP_AUDIT_OUTCOME_DENY;
+  }
+
+  switch (event->operation) {
+    case CAP_AUDIT_OP_CHECK:
+      return (event->result == CAP_OK) ? CAP_AUDIT_OUTCOME_ALLOW
+                                       : CAP_AUDIT_OUTCOME_DENY;
+    case CAP_AUDIT_OP_GRANT:
+      return (event->result == CAP_OK) ? CAP_AUDIT_OUTCOME_GRANTED
+                                       : CAP_AUDIT_OUTCOME_GRANT_DENIED;
+    case CAP_AUDIT_OP_REVOKE:
+      return (event->result == CAP_OK) ? CAP_AUDIT_OUTCOME_REVOKED
+                                       : CAP_AUDIT_OUTCOME_REVOKE_DENIED;
+  }
+
+  return CAP_AUDIT_OUTCOME_DENY;
+}
+
+static const char *cap_audit_op_name(cap_audit_op_t op) {
+  switch (op) {
+    case CAP_AUDIT_OP_CHECK:  return "CHECK";
+    case CAP_AUDIT_OP_GRANT:  return "GRANT";
+    case CAP_AUDIT_OP_REVOKE: return "REVOKE";
+  }
+  return "UNKNOWN";
+}
+
+static const char *cap_audit_result_name(cap_result_t result) {
+  switch (result) {
+    case CAP_OK:                  return "OK";
+    case CAP_ERR_MISSING:         return "MISSING";
+    case CAP_ERR_SUBJECT_INVALID: return "SUBJECT_INVALID";
+    case CAP_ERR_CAP_INVALID:     return "CAP_INVALID";
+  }
+  return "UNKNOWN";
+}
+
+static const char *cap_audit_outcome_name(cap_audit_outcome_t outcome) {
+  switch (outcome) {
+    case CAP_AUDIT_OUTCOME_ALLOW:          return "ALLOW";
+    case CAP_AUDIT_OUTCOME_DENY:           return "DENY";
+    case CAP_AUDIT_OUTCOME_GRANTED:        return "GRANTED";
+    case CAP_AUDIT_OUTCOME_GRANT_DENIED:   return "GRANT_DENIED";
+    case CAP_AUDIT_OUTCOME_REVOKED:        return "REVOKED";
+    case CAP_AUDIT_OUTCOME_REVOKE_DENIED:  return "REVOKE_DENIED";
+  }
+  return "UNKNOWN";
+}
+
+/* Minimal freestanding decimal writer. Writes `value` into `buf` and returns
+ * the number of bytes written, or -1 if `buf_size` is too small. */
+static int cap_audit_write_u64(uint64_t value, char *buf, size_t buf_size) {
+  char tmp[21];
+  size_t n = 0u;
+  if (value == 0u) {
+    tmp[n++] = '0';
+  } else {
+    while (value > 0u && n < sizeof(tmp)) {
+      tmp[n++] = (char)('0' + (int)(value % 10u));
+      value /= 10u;
+    }
+  }
+  if (n > buf_size) {
+    return -1;
+  }
+  for (size_t i = 0; i < n; ++i) {
+    buf[i] = tmp[n - 1u - i];
+  }
+  return (int)n;
+}
+
+static int cap_audit_write_str(const char *s, char *buf, size_t buf_size) {
+  size_t n = 0u;
+  while (s[n] != '\0') {
+    if (n >= buf_size) {
+      return -1;
+    }
+    buf[n] = s[n];
+    ++n;
+  }
+  return (int)n;
+}
+
+#define CAP_AUDIT_APPEND_STR(literal)                                          \
+  do {                                                                         \
+    int w = cap_audit_write_str((literal), buf + pos, buf_size - 1u - pos);   \
+    if (w < 0) return -1;                                                      \
+    pos += (size_t)w;                                                          \
+  } while (0)
+
+#define CAP_AUDIT_APPEND_U64(value)                                            \
+  do {                                                                         \
+    int w = cap_audit_write_u64((value), buf + pos, buf_size - 1u - pos);     \
+    if (w < 0) return -1;                                                      \
+    pos += (size_t)w;                                                          \
+  } while (0)
+
+int cap_audit_format_event(const cap_audit_event_t *event,
+                           char *buf,
+                           size_t buf_size) {
+  if (event == 0 || buf == 0 || buf_size == 0u) {
+    return -1;
+  }
+
+  size_t pos = 0u;
+  CAP_AUDIT_APPEND_STR("CAP_AUDIT:seq=");
+  CAP_AUDIT_APPEND_U64(event->sequence_id);
+  CAP_AUDIT_APPEND_STR(":op=");
+  CAP_AUDIT_APPEND_STR(cap_audit_op_name(event->operation));
+  CAP_AUDIT_APPEND_STR(":actor=");
+  CAP_AUDIT_APPEND_U64((uint64_t)event->actor_subject_id);
+  CAP_AUDIT_APPEND_STR(":subject=");
+  CAP_AUDIT_APPEND_U64((uint64_t)event->subject_id);
+  CAP_AUDIT_APPEND_STR(":cap=");
+  CAP_AUDIT_APPEND_U64((uint64_t)event->capability_id);
+  CAP_AUDIT_APPEND_STR(":result=");
+  CAP_AUDIT_APPEND_STR(cap_audit_result_name(event->result));
+  CAP_AUDIT_APPEND_STR(":outcome=");
+  CAP_AUDIT_APPEND_STR(cap_audit_outcome_name(cap_audit_event_outcome(event)));
+
+  buf[pos] = '\0';
+  return (int)pos;
+}

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -63,6 +63,36 @@ typedef struct {
   size_t dropped_count;
 } cap_audit_checkpoint_t;
 
+typedef enum {
+  CAP_AUDIT_OUTCOME_ALLOW = 0,
+  CAP_AUDIT_OUTCOME_DENY = 1,
+  CAP_AUDIT_OUTCOME_GRANTED = 2,
+  CAP_AUDIT_OUTCOME_GRANT_DENIED = 3,
+  CAP_AUDIT_OUTCOME_REVOKED = 4,
+  CAP_AUDIT_OUTCOME_REVOKE_DENIED = 5,
+} cap_audit_outcome_t;
+
+/*
+ * Stable, serial-first textual serialization for capability audit events.
+ *
+ * Lines are deterministic and human/machine readable, e.g.:
+ *   CAP_AUDIT:seq=3:op=CHECK:actor=1:subject=1:cap=1:result=MISSING:outcome=DENY
+ *
+ * The formatter is a pure function of its inputs and must not mutate the
+ * audit ring, the checkpoint state, or any capability table state. This is
+ * the non-interference contract enforced by the audit-log tests.
+ */
+cap_audit_outcome_t cap_audit_event_outcome(const cap_audit_event_t *event);
+
+/*
+ * Format a single audit event into `buf` (NUL-terminated on success). Returns
+ * the number of bytes written excluding the terminator on success, or a
+ * negative value on error (NULL inputs, zero-size buffer, truncation).
+ */
+int cap_audit_format_event(const cap_audit_event_t *event,
+                           char *buf,
+                           size_t buf_size);
+
 void cap_reset_for_tests(void);
 cap_result_t cap_grant_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);
 cap_result_t cap_revoke_for_tests(cap_subject_id_t subject_id, capability_id_t capability_id);

--- a/tests/capability_audit_log_test.c
+++ b/tests/capability_audit_log_test.c
@@ -1,0 +1,217 @@
+/**
+ * @file capability_audit_log_test.c
+ * @brief Deterministic tests for the capability audit log slice.
+ *
+ * Purpose:
+ *   Exercises the audit-log serialization slice described in
+ *   plans/2026-04-18-capability-audit-deny-log.md and tracked by issue #84:
+ *     - Phase 1: stable record shape + single serialization format.
+ *     - Phase 2: capture for grant + deny paths.
+ *     - Phase 4: non-interference (formatting/logging does not alter policy).
+ *
+ *   These tests do not depend on any device or serial sink. They operate on
+ *   the audit events captured by cap_audit_get_for_tests() and on the pure
+ *   cap_audit_format_event() helper, which is also what the kernel-side
+ *   serial log path will use to emit audit lines.
+ *
+ * Interactions:
+ *   - kernel/cap/capability.{h,c}: audit ring + formatter under test.
+ *   - kernel/cap/cap_table.c: capability decisions used to populate the ring.
+ *
+ * Launched by:
+ *   Compiled and executed by build/scripts/test_capability_audit_log.sh,
+ *   wired into build/scripts/test.sh as the `capability_audit_log` target.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+
+static int fail_count;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:capability_audit_log:%s\n", reason);
+  fail_count++;
+}
+
+static cap_audit_event_t get_event(size_t index, const char *reason) {
+  cap_audit_event_t event = {0};
+  if (cap_audit_get_for_tests(index, &event) != CAP_OK) {
+    fail(reason);
+  }
+  return event;
+}
+
+/*
+ * Phase 1 + Phase 2: grant + deny capture, structured + stable.
+ *
+ * Walks a representative sequence (deny check, grant, allow check, revoke,
+ * denied recheck) and asserts each emitted line exactly matches the contract
+ * documented in capability.h.
+ */
+static void test_format_grant_and_deny_lines(void) {
+  cap_reset_for_tests();
+
+  /* Phase 2 capture: deny path at the syscall/gate boundary. */
+  if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("deny_check_result");
+  }
+  /* Phase 2 capture: launcher-style grant. */
+  if (cap_grant_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_failed");
+  }
+  /* Allow path after grant. */
+  if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("allow_check_result");
+  }
+  /* Revoke + post-revoke deny. */
+  if (cap_revoke_for_tests(1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_failed");
+  }
+  if (cap_check(1u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("post_revoke_deny_result");
+  }
+
+  const char *expected[] = {
+    "CAP_AUDIT:seq=0:op=CHECK:actor=1:subject=1:cap=1:result=MISSING:outcome=DENY",
+    "CAP_AUDIT:seq=1:op=GRANT:actor=1:subject=1:cap=1:result=OK:outcome=GRANTED",
+    "CAP_AUDIT:seq=2:op=CHECK:actor=1:subject=1:cap=1:result=OK:outcome=ALLOW",
+    "CAP_AUDIT:seq=3:op=REVOKE:actor=1:subject=1:cap=1:result=OK:outcome=REVOKED",
+    "CAP_AUDIT:seq=4:op=CHECK:actor=1:subject=1:cap=1:result=MISSING:outcome=DENY",
+  };
+
+  for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+    cap_audit_event_t event = get_event(i, "missing_event");
+    char line[160];
+    int n = cap_audit_format_event(&event, line, sizeof(line));
+    if (n < 0) {
+      fail("format_failed");
+      continue;
+    }
+    if (strcmp(line, expected[i]) != 0) {
+      printf("TEST:FAIL:capability_audit_log:line_mismatch:idx=%zu:got=%s:want=%s\n",
+             i, line, expected[i]);
+      fail_count++;
+      continue;
+    }
+    /* Surface the formatted record so CI captures the deny-log shape. */
+    printf("AUDIT_LOG:%s\n", line);
+  }
+
+  printf("TEST:PASS:capability_audit_log_grant_and_deny\n");
+}
+
+/*
+ * Phase 1: invalid-input handling on the formatter (deny-by-default).
+ */
+static void test_format_invalid_inputs(void) {
+  char buf[64];
+  cap_audit_event_t event = {0};
+
+  if (cap_audit_format_event(0, buf, sizeof(buf)) != -1) {
+    fail("format_null_event_should_fail");
+  }
+  if (cap_audit_format_event(&event, 0, sizeof(buf)) != -1) {
+    fail("format_null_buf_should_fail");
+  }
+  if (cap_audit_format_event(&event, buf, 0u) != -1) {
+    fail("format_zero_size_should_fail");
+  }
+  /* Tiny buffer should not write past the end. */
+  char tiny[8];
+  memset(tiny, 0x55, sizeof(tiny));
+  if (cap_audit_format_event(&event, tiny, sizeof(tiny)) != -1) {
+    fail("format_tiny_buf_should_fail");
+  }
+
+  printf("TEST:PASS:capability_audit_log_invalid_inputs\n");
+}
+
+/*
+ * Phase 4: non-interference. Formatting any number of audit events must not
+ * change capability decisions, the audit ring, the dropped count, the ring
+ * sequence cursor, or the checkpoint state. This is the contract that lets
+ * the serial-first audit sink be added without altering policy.
+ */
+static void test_format_does_not_alter_policy(void) {
+  cap_reset_for_tests();
+
+  /* Build a small mixed history. */
+  (void)cap_check(2u, CAP_SERIAL_WRITE);            /* deny */
+  (void)cap_grant_for_tests(2u, CAP_SERIAL_WRITE);
+  (void)cap_check(2u, CAP_SERIAL_WRITE);            /* allow */
+  (void)cap_revoke_for_tests(2u, CAP_SERIAL_WRITE);
+  (void)cap_check(2u, CAP_SERIAL_WRITE);            /* deny again */
+
+  size_t before_count = cap_audit_count_for_tests();
+  size_t before_dropped = cap_audit_dropped_for_tests();
+  size_t before_checkpoints = cap_audit_checkpoint_count_for_tests();
+
+  cap_audit_event_t before_events[CAP_AUDIT_EVENT_MAX];
+  for (size_t i = 0; i < before_count; ++i) {
+    before_events[i] = get_event(i, "snapshot_failed");
+  }
+
+  /* Format every event many times. If any of this leaked into the ring or
+   * the table, the post-format state would diverge. */
+  for (int round = 0; round < 4; ++round) {
+    for (size_t i = 0; i < before_count; ++i) {
+      char line[160];
+      if (cap_audit_format_event(&before_events[i], line, sizeof(line)) < 0) {
+        fail("format_round_failed");
+      }
+    }
+  }
+
+  if (cap_audit_count_for_tests() != before_count) {
+    fail("ring_count_changed_by_format");
+  }
+  if (cap_audit_dropped_for_tests() != before_dropped) {
+    fail("dropped_count_changed_by_format");
+  }
+  if (cap_audit_checkpoint_count_for_tests() != before_checkpoints) {
+    fail("checkpoint_count_changed_by_format");
+  }
+  for (size_t i = 0; i < before_count; ++i) {
+    cap_audit_event_t after = get_event(i, "post_format_snapshot_failed");
+    if (after.sequence_id      != before_events[i].sequence_id      ||
+        after.operation        != before_events[i].operation        ||
+        after.actor_subject_id != before_events[i].actor_subject_id ||
+        after.subject_id       != before_events[i].subject_id       ||
+        after.capability_id    != before_events[i].capability_id    ||
+        after.result           != before_events[i].result) {
+      fail("event_mutated_by_format");
+    }
+  }
+
+  /* Capability decisions must still match the same history. */
+  if (cap_check(2u, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("post_format_deny_changed");
+  }
+  if (cap_grant_for_tests(2u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("post_format_grant_changed");
+  }
+  if (cap_check(2u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("post_format_allow_changed");
+  }
+
+  printf("TEST:PASS:capability_audit_log_non_interference\n");
+}
+
+int main(void) {
+  printf("TEST:START:capability_audit_log\n");
+
+  test_format_grant_and_deny_lines();
+  test_format_invalid_inputs();
+  test_format_does_not_alter_policy();
+
+  if (fail_count != 0) {
+    printf("TEST:FAIL:capability_audit_log:fail_count=%d\n", fail_count);
+    return 1;
+  }
+
+  printf("TEST:PASS:capability_audit_log\n");
+  return 0;
+}


### PR DESCRIPTION
Implements the audit/deny-log slice from `plans/2026-04-18-capability-audit-deny-log.md` (issue #84).

## What changed

- `kernel/cap/capability.{h,c}`: new `cap_audit_outcome_t` and pure `cap_audit_format_event()` helper that renders a captured audit event into a stable, serial-first line:
  ```
  CAP_AUDIT:seq=<n>:op=<CHECK|GRANT|REVOKE>:actor=<id>:subject=<id>:cap=<id>:result=<OK|MISSING|SUBJECT_INVALID|CAP_INVALID>:outcome=<ALLOW|DENY|GRANTED|GRANT_DENIED|REVOKED|REVOKE_DENIED>
  ```
  The formatter is a pure function of its inputs — it does not touch the audit ring, checkpoint state, or cap table. That is the contract the kernel serial sink will rely on when it starts emitting these lines.
- `tests/capability_audit_log_test.c` + `build/scripts/test_capability_audit_log.sh`: new deterministic test target wired into `build/scripts/test.sh` and `build/scripts/validate_bundle.sh`.

## Exit criteria mapping (from the plan)

- [x] Phase 1 — stable record shape + single serialization format: exact `CAP_AUDIT:...` string asserted for a grant+deny sequence.
- [x] Phase 2 — grant + deny capture: launcher-style grant and gate-side deny each produce their own audit line.
- [x] Phase 4 — non-interference: formatting any number of events does not change `cap_audit_count_for_tests()`, dropped count, checkpoint count, captured event tuples, or subsequent capability decisions.
- [x] Deny-by-default semantics unchanged (the underlying `capability_audit` test still passes).

## Validation

```
build/scripts/test_capability_audit_log.sh
  TEST:PASS:capability_audit_log_grant_and_deny
  TEST:PASS:capability_audit_log_invalid_inputs
  TEST:PASS:capability_audit_log_non_interference
  TEST:PASS:capability_audit_log

build/scripts/test_capability_audit.sh
  TEST:PASS:capability_audit_core_paths
  TEST:PASS:capability_audit_actor_attribution
  TEST:PASS:capability_audit_ring_wrap
  TEST:PASS:capability_audit_mixed_overflow
  TEST:PASS:capability_audit_checkpoints
```

## Follow-ups

- Phase 3 (serial-first sink): route `cap_audit_format_event()` output through the serial driver at the audit capture point. Kept out of scope here so this slice stays small and reviewable; the formatter contract is the only thing the sink needs.
- Optional: a `test.ps1` mirror once the Windows harness is otherwise in sync.
- Best landed after #95 (restore +x) / #96 (harden harness) so the new validator target runs cleanly in CI.