### PR TITLE
docs: add docs/test-plans/ milestone + task registry (#109)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,7 @@ Before opening a PR, review:
 - `docs/CODING_CONVENTIONS.md`
 - `docs/abi/` — ABI reference (syscall surface, capability IDs, manifest schema, versioning policy). Update the relevant page in the same PR when you change ABI surface.
 - `docs/abi/capability-deny-contract.md` (if your change touches a capability-gated service or its deny-path test)
+- `docs/test-plans/` (milestone + task registry; update the `status:` and `pr:#…` tags when a CAP-\* / M-\* task lands)
 
 Project-specific expectations include:
 - Keep PowerShell and shell build scripts in sync

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 ## Repo Pointers
 
 - Roadmap: `BUILD_ROADMAP.md`
-- M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
+- Milestone/task registry: `docs/test-plans/` (M0/M1/M2 status + closing PRs)
+- Task DAG schema: `manifests/task-dag.schema.json` (walk-through in `docs/test-plans/task-schema.md`)
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
 - ABI reference: `docs/abi/` (syscalls, capabilities, manifest, ipc-wire, versioning)
 - ADRs: `docs/adr/`

--- a/docs/test-plans/README.md
+++ b/docs/test-plans/README.md
@@ -1,0 +1,87 @@
+# docs/test-plans/
+
+This directory is the human-readable index of SecureOS milestone tasks, their
+execution status, and the schema used to encode them.
+
+It exists to answer one question without scraping `gh issue list` or `git log`:
+
+> "Which CAP-* / M-* tasks are done, which are in flight, and where is the
+> closing artifact?"
+
+## Files
+
+- [`task-schema.md`](task-schema.md) — short walk-through of
+  [`manifests/task-dag.schema.json`](../../manifests/task-dag.schema.json),
+  the normative schema for the task DAG used by validators and agents.
+- [`m0-m1-plan.yaml`](m0-m1-plan.yaml) — milestone/task registry for M0, M1,
+  and the in-flight M2 slice. Validates against
+  [`manifests/task-dag.schema.json`](../../manifests/task-dag.schema.json).
+- [`validator-report.schema.json`](validator-report.schema.json) — schema for
+  the JSON validator report emitted by `build/scripts/validate_bundle.sh` (see
+  issue #110 / PR #112).
+
+## Update cadence
+
+Update [`m0-m1-plan.yaml`](m0-m1-plan.yaml):
+
+1. **When a CAP-\* / M-\* slice closes** — flip its `artifacts[]` `status:`
+   tag from `status:in_progress` / `status:pending` to `status:done` and add
+   the closing PR reference (e.g. `pr:#46`).
+2. **At the end of each milestone** — verify all member tasks are `done`,
+   bump the milestone summary in this README if needed, and roll the
+   `entryTasks` of the next milestone into `pipeline.entryTasks` (or create a
+   `mN-plan.yaml` sibling and update this index).
+3. **When the upstream schema changes** — re-run validation locally:
+
+```bash
+python3 - <<'PY'
+import json, yaml, sys
+try:
+    import jsonschema
+except ImportError:
+    sys.exit("pip install jsonschema pyyaml")
+schema = json.load(open("manifests/task-dag.schema.json"))
+plan   = yaml.safe_load(open("docs/test-plans/m0-m1-plan.yaml"))
+jsonschema.validate(plan, schema)
+print("OK")
+PY
+```
+
+A CI step that runs the same validation is listed as an optional follow-up
+in issue #109 — out of scope for the initial registry.
+
+## Conventions
+
+The DAG schema (`task-dag.schema.json`) is execution-shaped: every task has a
+`run` command and a `passCondition`. The registry uses the same shape so it
+validates, with two documentation conventions layered on top:
+
+- **Status tag** — each task carries an `artifacts[]` entry of the form
+  `status:done`, `status:in_progress`, or `status:pending`.
+- **Closure reference** — closed tasks also carry one or more
+  `pr:#<num>` and/or `issue:#<num>` `artifacts[]` entries pointing at the
+  merged PR and originating issue. Open tasks may carry an `issue:#<num>`
+  entry only.
+
+See [`task-schema.md`](task-schema.md) for an example.
+
+## Milestone summary (as of 2026-05-12)
+
+- **M0 — Tooling & boot smoke** — `done`. Phase-0 toolchain, build/test
+  wrappers, deterministic QEMU harness, COM1 + VGA writers, isa-debug-exit
+  signaling, `hello_boot` target with marker parser, and the negative-path
+  fixture all merged (#1–#33).
+- **M1 — Capability core (CAP-001 .. CAP-020)** — `done`. All twenty CAP-\*
+  tasks merged via PRs #35, #36, #38, #41, #42, #44, #46, #49, #52, #54, #59,
+  #61, #63, #65, #67, #69, #71, #73, #75, and #76's closing PR.
+- **M2 — Console service + launcher + HelloApp** — `in_progress`. Tracking
+  issues: #82 (slice plan), #92 + #100 (deny-path acceptance test), #93 / #97
+  (ABI reference).
+
+## Related
+
+- [`BUILD_ROADMAP.md`](../../BUILD_ROADMAP.md) — §8 items 11 & 12 motivate
+  this directory.
+- [`manifests/task-dag.example.json`](../../manifests/task-dag.example.json)
+  — minimal example of the DAG shape.
+- [`docs/abi/`](../abi/) — ABI reference (issue #93).

--- a/docs/test-plans/m0-m1-plan.yaml
+++ b/docs/test-plans/m0-m1-plan.yaml
@@ -1,0 +1,448 @@
+version: "1.0"
+pipeline:
+  name: m0-m1-m2-secureos
+  entryTasks:
+    - M0_TOOLCHAIN
+    - M0_BUILD_WRAPPERS
+tasks:
+  # ---------------------------------------------------------------------------
+  # M0 — Tooling, harness, and boot smoke (all done)
+  # ---------------------------------------------------------------------------
+  - taskId: M0_TOOLCHAIN
+    ownerRole: implementer
+    run: "docker build -f build/docker/Dockerfile.toolchain ."
+    artifacts:
+      - "status:done"
+      - "pr:#18"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_BUILD_WRAPPERS
+    ownerRole: implementer
+    run: "./build/scripts/build.sh"
+    artifacts:
+      - "status:done"
+      - "pr:#19"
+      - "issue:#5"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_CI_WORKFLOW
+    ownerRole: validator
+    dependsOn: [M0_BUILD_WRAPPERS]
+    run: ".github/workflows pr-build"
+    artifacts:
+      - "status:done"
+      - "pr:#26"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_X86_ENTRY
+    ownerRole: implementer
+    dependsOn: [M0_BUILD_WRAPPERS]
+    run: "./build/scripts/build.sh kernel"
+    artifacts:
+      - "status:done"
+      - "pr:#23"
+      - "issue:#7"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_COM1_SERIAL
+    ownerRole: implementer
+    dependsOn: [M0_X86_ENTRY]
+    run: "./build/scripts/test.sh hello_boot"
+    artifacts:
+      - "status:done"
+      - "pr:#27"
+      - "issue:#10"
+    passCondition:
+      type: log_marker
+      marker: "SecureOS boot sector OK"
+
+  - taskId: M0_VGA_WRITER
+    ownerRole: implementer
+    dependsOn: [M0_X86_ENTRY]
+    run: "./build/scripts/test.sh hello_boot"
+    artifacts:
+      - "status:done"
+      - "pr:#28"
+      - "issue:#11"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_ISA_DEBUG_EXIT
+    ownerRole: implementer
+    dependsOn: [M0_COM1_SERIAL]
+    run: "./build/scripts/test.sh hello_boot"
+    artifacts:
+      - "status:done"
+      - "pr:#29"
+      - "issue:#12"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_HELLO_BOOT_MARKERS
+    ownerRole: test-engineer
+    dependsOn: [M0_COM1_SERIAL, M0_ISA_DEBUG_EXIT]
+    run: "./build/scripts/test.sh hello_boot"
+    artifacts:
+      - "status:done"
+      - "pr:#31"
+      - "issue:#13"
+      - "artifacts/qemu/hello_boot.log"
+    passCondition:
+      type: log_marker
+      marker: "QEMU_PASS:hello_boot"
+
+  - taskId: M0_NEGATIVE_FIXTURE
+    ownerRole: test-engineer
+    dependsOn: [M0_HELLO_BOOT_MARKERS]
+    run: "./build/scripts/test.sh hello_boot_fail_fixture"
+    artifacts:
+      - "status:done"
+      - "pr:#33"
+      - "issue:#14"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M0_PLANNING_DOCS
+    ownerRole: planner
+    run: "true"
+    artifacts:
+      - "status:done"
+      - "pr:#24"
+      - "issue:#17"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  # ---------------------------------------------------------------------------
+  # M1 — Capability core (CAP-001..CAP-020, all done)
+  # ---------------------------------------------------------------------------
+  - taskId: M1_CAP_001
+    ownerRole: implementer
+    dependsOn: [M0_NEGATIVE_FIXTURE]
+    run: "./build/scripts/test.sh capability_api_contract"
+    artifacts:
+      - "status:done"
+      - "pr:#35"
+      - "issue:#32"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_api_contract"
+
+  - taskId: M1_CAP_002
+    ownerRole: implementer
+    dependsOn: [M1_CAP_001]
+    run: "./build/scripts/test.sh capability_subject_table"
+    artifacts:
+      - "status:done"
+      - "pr:#36"
+      - "issue:#34"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_subject_table"
+
+  - taskId: M1_CAP_003
+    ownerRole: implementer
+    dependsOn: [M1_CAP_002]
+    run: "./build/scripts/test.sh capability_console_gate"
+    artifacts:
+      - "status:done"
+      - "pr:#38"
+      - "issue:#37"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_console_gate"
+
+  - taskId: M1_CAP_004
+    ownerRole: validator
+    dependsOn: [M1_CAP_003]
+    run: "./build/scripts/validate_bundle.sh"
+    artifacts:
+      - "status:done"
+      - "pr:#41"
+      - "issue:#40"
+    passCondition:
+      type: log_marker
+      marker: "VALIDATION_PASS"
+
+  - taskId: M1_CAP_005
+    ownerRole: planner
+    dependsOn: [M1_CAP_004]
+    run: "true"
+    artifacts:
+      - "status:done"
+      - "pr:#42"
+      - "issue:#30"
+      - "docs/architecture/ADR-capability-core.md"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M1_CAP_006
+    ownerRole: implementer
+    dependsOn: [M1_CAP_005]
+    run: "./build/scripts/test.sh capability_bitset_storage"
+    artifacts:
+      - "status:done"
+      - "pr:#44"
+      - "issue:#43"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_bitset_storage"
+
+  - taskId: M1_CAP_007
+    ownerRole: implementer
+    dependsOn: [M1_CAP_006]
+    run: "./build/scripts/test.sh capability_serial_gate"
+    artifacts:
+      - "status:done"
+      - "pr:#46"
+      - "issue:#45"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_serial_write_gate"
+
+  - taskId: M1_CAP_008
+    ownerRole: implementer
+    dependsOn: [M1_CAP_007]
+    run: "./build/scripts/test.sh capability_debug_exit_gate"
+    artifacts:
+      - "status:done"
+      - "pr:#49"
+      - "pr:#50"
+      - "issue:#48"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_debug_exit_gate"
+
+  - taskId: M1_CAP_009
+    ownerRole: implementer
+    dependsOn: [M1_CAP_008]
+    run: "./build/scripts/test.sh capability_audit_log"
+    artifacts:
+      - "status:done"
+      - "pr:#52"
+      - "issue:#51"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_audit_log"
+
+  - taskId: M1_CAP_010
+    ownerRole: implementer
+    dependsOn: [M1_CAP_009]
+    run: "./build/scripts/test.sh capability_mutation_audit"
+    artifacts:
+      - "status:done"
+      - "pr:#54"
+      - "pr:#58"
+      - "issue:#53"
+      - "issue:#56"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_mutation_audit"
+
+  - taskId: M1_CAP_011
+    ownerRole: implementer
+    dependsOn: [M1_CAP_010]
+    run: "./build/scripts/test.sh capability_audit_overflow"
+    artifacts:
+      - "status:done"
+      - "pr:#59"
+      - "issue:#55"
+      - "issue:#57"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_audit_overflow_contract"
+
+  - taskId: M1_CAP_012
+    ownerRole: validator
+    dependsOn: [M1_CAP_011]
+    run: "./build/scripts/validate_bundle.sh"
+    artifacts:
+      - "status:done"
+      - "pr:#61"
+      - "issue:#60"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_audit_summary_schema"
+
+  - taskId: M1_CAP_013
+    ownerRole: implementer
+    dependsOn: [M1_CAP_012]
+    run: "./build/scripts/test.sh capability_admin_gate"
+    artifacts:
+      - "status:done"
+      - "pr:#63"
+      - "issue:#62"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_mutation_admin_gate"
+
+  - taskId: M1_CAP_014
+    ownerRole: implementer
+    dependsOn: [M1_CAP_013]
+    run: "./build/scripts/test.sh capability_nondelegable_admin"
+    artifacts:
+      - "status:done"
+      - "pr:#65"
+      - "issue:#64"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_admin_nondelegable"
+
+  - taskId: M1_CAP_015
+    ownerRole: implementer
+    dependsOn: [M1_CAP_014]
+    run: "./build/scripts/test.sh capability_actor_attribution"
+    artifacts:
+      - "status:done"
+      - "pr:#67"
+      - "issue:#66"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_actor_attribution"
+
+  - taskId: M1_CAP_016
+    ownerRole: implementer
+    dependsOn: [M1_CAP_015]
+    run: "./build/scripts/test.sh capability_audit_sequence"
+    artifacts:
+      - "status:done"
+      - "pr:#69"
+      - "issue:#68"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_audit_sequence_integrity"
+
+  - taskId: M1_CAP_017
+    ownerRole: implementer
+    dependsOn: [M1_CAP_016]
+    run: "./build/scripts/test.sh capability_audit_checkpoints"
+    artifacts:
+      - "status:done"
+      - "pr:#71"
+      - "issue:#70"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_audit_checkpoints"
+
+  - taskId: M1_CAP_018
+    ownerRole: implementer
+    dependsOn: [M1_CAP_017]
+    run: "./build/scripts/test.sh capability_checkpoint_summary"
+    artifacts:
+      - "status:done"
+      - "pr:#73"
+      - "issue:#72"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_checkpoint_summary_contract"
+
+  - taskId: M1_CAP_019
+    ownerRole: implementer
+    dependsOn: [M1_CAP_018]
+    run: "./build/scripts/test.sh capability_sequence_window"
+    artifacts:
+      - "status:done"
+      - "pr:#75"
+      - "issue:#74"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_sequence_window_contract"
+
+  - taskId: M1_CAP_020
+    ownerRole: implementer
+    dependsOn: [M1_CAP_019]
+    run: "./build/scripts/test.sh capability_seal_chain"
+    artifacts:
+      - "status:done"
+      - "issue:#76"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_seal_chain_verify"
+
+  # ---------------------------------------------------------------------------
+  # M2 — Console service + Launcher + HelloApp (in flight)
+  # ---------------------------------------------------------------------------
+  - taskId: M2_CONSOLE_SLICE_PLAN
+    ownerRole: planner
+    dependsOn: [M1_CAP_020]
+    run: "true"
+    artifacts:
+      - "status:in_progress"
+      - "issue:#82"
+      - "issue:#81"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M2_HELLOAPP_ALLOW_DENY
+    ownerRole: test-engineer
+    dependsOn: [M2_CONSOLE_SLICE_PLAN]
+    run:
+      - "./build/scripts/test.sh helloapp_allow"
+      - "./build/scripts/test.sh helloapp_deny"
+    artifacts:
+      - "status:in_progress"
+      - "pr:#100"
+      - "issue:#92"
+    passCondition:
+      type: expression
+      expression: "log_has('TEST:PASS:helloapp_allow') && log_has('TEST:PASS:helloapp_deny')"
+
+  - taskId: M2_ABI_REFERENCE
+    ownerRole: planner
+    dependsOn: [M2_CONSOLE_SLICE_PLAN]
+    run: "true"
+    artifacts:
+      - "status:in_progress"
+      - "pr:#97"
+      - "issue:#93"
+      - "docs/abi/README.md"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M2_FS_SLICE_PLAN
+    ownerRole: planner
+    dependsOn: [M2_CONSOLE_SLICE_PLAN]
+    run: "true"
+    artifacts:
+      - "status:pending"
+      - "issue:#83"
+      - "issue:#108"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M2_CAP_AUDIT_DENY_LOG
+    ownerRole: planner
+    dependsOn: [M2_CONSOLE_SLICE_PLAN]
+    run: "true"
+    artifacts:
+      - "status:pending"
+      - "issue:#84"
+    passCondition:
+      type: exit_code
+      expected: 0
+
+  - taskId: M2_CAP_BROKER_SHARE
+    ownerRole: planner
+    dependsOn: [M2_CAP_AUDIT_DENY_LOG]
+    run: "true"
+    artifacts:
+      - "status:pending"
+      - "issue:#85"
+    passCondition:
+      type: exit_code
+      expected: 0

--- a/docs/test-plans/task-schema.md
+++ b/docs/test-plans/task-schema.md
@@ -1,173 +1,90 @@
-# Task DAG Schema
+# Task DAG schema (walk-through)
 
-> Canonical record shape for planner / implementer / test-engineer / validator
-> agents. Anchors `BUILD_ROADMAP.md` §4.1 ("Task model") and §8 item 11.
-> Referenced from `AGENTS.md` and from the milestone task registry in
-> `docs/test-plans/` (see #109).
+The normative schema for SecureOS agent task DAGs lives at
+[`manifests/task-dag.schema.json`](../../manifests/task-dag.schema.json).
+This document is a short, human-readable companion — one page, no
+re-statement of the schema fields, just the shape and the conventions that
+the milestone registry layers on top.
 
-This file defines the **fields**, **types**, and **invariants** of one task
-record. It does **not** define a validator implementation — `os-validate`
-(see `BUILD_ROADMAP.md` §4.3 and issue #162) is the consumer. Reports emitted
-by validators (see `validator_report.json`, issue #110) reuse the same field
-vocabulary so a task and its result can be joined by `task_id` alone.
+## Shape at a glance
 
-## 1. File format
-
-- Registries live under `docs/test-plans/` (e.g.
-  `docs/test-plans/m0-m1-plan.yaml`, see §8 item 12).
-- One file per milestone; each file is a YAML mapping with a single top-level
-  key `tasks:` whose value is a list of task records described below.
-- Comments (`#`) are allowed. No anchors / merge keys — keep registries
-  trivially parseable.
-- Field order in a record is not significant, but the canonical order in
-  examples below should be preferred for readability.
-
-## 2. Required fields
-
-| Field              | Type            | Notes                                                                                              |
-| ------------------ | --------------- | -------------------------------------------------------------------------------------------------- |
-| `task_id`          | string          | Stable identifier. Format: `<MILESTONE>-<AREA>-<NNN>`, e.g. `M1-CAP-009`. ASCII, uppercase, no spaces. |
-| `milestone`        | string          | One of `M0`, `M1`, `M2`, `M3`, `M4`, `M5`, `M6` (matches `BUILD_ROADMAP.md` §5).                   |
-| `owner_role`       | enum            | One of `planner`, `implementer`, `test_engineer`, `validator`. Matches §4.2 role contracts.        |
-| `depends_on`       | list&lt;string&gt;    | Zero or more `task_id` values that must reach `status: done` first. Cycles are an error.           |
-| `run`              | string          | Single shell command. Must be invokable from repo root inside the pinned toolchain container.      |
-| `expected_outputs` | list&lt;string&gt;    | Repo-relative artifact paths the task is expected to produce or update (`artifacts/...`, etc.).     |
-| `pass_condition`   | string          | Boolean expression over `exit_code` and `log_has('<marker>')` (see §3).                           |
-| `status`           | enum            | One of `pending`, `in_progress`, `done`, `blocked`. Validator-writable only.                       |
-
-## 3. `pass_condition` expression DSL
-
-Minimal, total, side-effect-free. A `pass_condition` is a boolean expression
-built from:
-
-- Literals: `true`, `false`, integer literals.
-- Variables:
-  - `exit_code` — the process exit code of `run`.
-- Functions:
-  - `log_has('<marker>')` — true iff the marker substring appears literally in
-    the captured serial log for this task's run.
-- Operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`, parentheses.
-
-The harness already emits the structured markers defined in
-`BUILD_ROADMAP.md` §2.5:
-
-- `TEST:START:<name>`
-- `TEST:PASS:<name>`
-- `TEST:FAIL:<name>:<reason>`
-
-So the canonical positive-path condition is:
-
-```
-exit_code == 0 && log_has('TEST:PASS:<name>')
-```
-
-and the canonical negative-path condition is:
-
-```
-exit_code != 0 && log_has('TEST:FAIL:<name>')
-```
-
-Out of scope for this version of the DSL: regex, arithmetic on `exit_code`,
-multi-line log assertions, JSON path queries. Add them in a follow-up only
-when a concrete task requires them.
-
-## 4. Optional fields
-
-| Field         | Type         | Notes                                                                                  |
-| ------------- | ------------ | -------------------------------------------------------------------------------------- |
-| `description` | string       | One-line human summary. Encouraged on every task.                                      |
-| `issue`       | integer      | Linked GitHub issue number (no `#`).                                                   |
-| `pr`          | integer      | Linked PR number once filed.                                                           |
-| `timeout_s`   | integer      | Wall-clock timeout for `run`. Defaults to harness default if omitted.                  |
-| `notes`       | string       | Free text. Validators must not parse this.                                             |
-
-Unknown fields are an error — registries must round-trip without loss.
-
-## 5. Status transitions
-
-```
-pending ──► in_progress ──► done
-   │             │
-   └────────► blocked ◄──────┘
-```
-
-- Only the **validator** role mutates `status`.
-- `in_progress → done` requires the most recent run to satisfy
-  `pass_condition` and produce every entry in `expected_outputs`.
-- `blocked` is allowed from any state; transition out of `blocked` requires
-  re-running the task.
-
-## 6. Worked example
-
-The example below is **M1-CAP-009 audit ring**, modeled after the existing
-capability-audit slice (PR #98, issue #84). It exercises every required
-field, both kinds of `pass_condition`, and a `depends_on` edge to the
-preceding console-write slice.
+A task-DAG document has three top-level fields:
 
 ```yaml
+version: "1.0"
+pipeline:
+  name: <pipeline-id>
+  entryTasks: [<TASK_ID>, ...]
 tasks:
-  - task_id: M1-CAP-009
-    milestone: M1
-    owner_role: test_engineer
-    description: >
-      Structured capability audit log line + non-interference test for the
-      console-write capability slice.
-    depends_on:
-      - M1-CAP-008          # launcher-mediated console-write slice (#81)
-    run: build/scripts/test.sh capability_audit
-    expected_outputs:
-      - artifacts/qemu/capability_audit.log
-      - artifacts/runs/latest/validator_report.json
-    pass_condition: exit_code == 0 && log_has('TEST:PASS:capability_audit')
-    status: pending
-    issue: 84
-    pr: 98
-    timeout_s: 120
-
-  - task_id: M1-CAP-009-NEG
-    milestone: M1
-    owner_role: test_engineer
-    description: >
-      Negative-path companion: deny console-write and assert the audit ring
-      records a DENY entry with the documented marker.
-    depends_on:
-      - M1-CAP-009
-    run: build/scripts/test.sh capability_audit_deny
-    expected_outputs:
-      - artifacts/qemu/capability_audit_deny.log
-    pass_condition: exit_code != 0 && log_has('TEST:FAIL:capability_audit_deny')
-    status: pending
-    issue: 84
+  - taskId: <TASK_ID>            # ^[A-Z0-9_-]+$
+    ownerRole: planner | implementer | test-engineer | validator
+    dependsOn: [<TASK_ID>, ...]  # optional
+    run: "<command>" | ["<cmd1>", "<cmd2>"]
+    artifacts: ["<path-or-tag>", ...]   # optional
+    passCondition:
+      type: exit_code | log_marker | expression
+      # plus one of: expected | marker | expression
 ```
 
-## 7. Relationship to harness markers and validator reports
+`additionalProperties: false` is enforced on every object level, so the
+registry cannot introduce new top-level keys without a schema bump. The
+registry encodes documentation-only metadata (status, PR/issue refs) inside
+the free-form `artifacts[]` array — see "Conventions" below.
 
-- The `TEST:START` / `TEST:PASS` / `TEST:FAIL` markers from
-  `BUILD_ROADMAP.md` §2.5 are the **only** log-side contract a
-  `pass_condition` should rely on; tasks that need richer assertions should
-  emit additional structured markers from the test program itself rather
-  than parsing free-form output.
-- `validator_report.json` (see #110) re-emits, per task, at minimum:
-  `task_id`, `status`, `exit_code`, the resolved boolean value of
-  `pass_condition`, and the absolute paths of every `expected_outputs`
-  entry that was actually produced. Consumers should treat
-  `validator_report.json` as the canonical post-run view of a task record.
-- `os-validate` (see #162) is the deterministic wrapper that loads a
-  registry, executes selected tasks in dependency order, and writes the
-  report.
+## Pass condition shapes
 
-## 8. Out of scope
+| `type`       | Required sibling | Example                                              |
+| ------------ | ---------------- | ---------------------------------------------------- |
+| `exit_code`  | `expected`       | `expected: 0`                                        |
+| `log_marker` | `marker`         | `marker: "QEMU_PASS:hello_boot"`                     |
+| `expression` | `expression`     | `expression: "exit_code == 0 && log_has('TEST:PASS:cap_model_skeleton')"` |
 
-- A reference loader / validator implementation.
-- Backfilling all historical tasks into a registry (that work is tracked by
-  #109).
-- A richer expression language for `pass_condition` (add fields only as
-  concrete tasks require them).
+Validators consume `passCondition` to decide whether a task is green; agents
+consume `run` to know what to execute and `dependsOn` to topologically order
+work.
 
-## 9. Cross-references
+## Conventions used by `m0-m1-plan.yaml`
 
-- `BUILD_ROADMAP.md` §2.5 (harness markers), §4.1 (task model), §4.3
-  (deterministic wrappers), §4.4 (artifact policy), §8 item 11 (this schema).
-- `AGENTS.md` (agent role conventions).
-- Issues: #109 (registry consumer), #110 (validator JSON report), #162
-  (`os-validate` wrapper), #164 (capability-denied log marker contract).
+The registry is execution-shaped (every entry has a `run` and a
+`passCondition`) so it validates against the schema as-is. Documentation
+metadata is encoded as string tags in `artifacts[]`:
+
+- `status:done` / `status:in_progress` / `status:pending` — current state.
+- `pr:#<num>` — merged or open PR that lands the task.
+- `issue:#<num>` — originating issue.
+- Real artifact paths (e.g. `artifacts/qemu/hello_boot.log`) can co-exist
+  with the tags above.
+
+Example task entry (CAP-007, capability core, done):
+
+```yaml
+- taskId: M1_CAP_007
+  ownerRole: implementer
+  dependsOn: [M1_CAP_006]
+  run: "./build/scripts/test.sh capability_serial_gate"
+  artifacts:
+    - "status:done"
+    - "pr:#46"
+    - "issue:#45"
+  passCondition:
+    type: log_marker
+    marker: "TEST:PASS:cap_serial_write_gate"
+```
+
+## Validating a registry
+
+The schema is plain JSON Schema (draft 2020-12). A registry can be checked
+locally with `jsonschema`:
+
+```bash
+python3 - <<'PY'
+import json, yaml, jsonschema
+schema = json.load(open("manifests/task-dag.schema.json"))
+plan   = yaml.safe_load(open("docs/test-plans/m0-m1-plan.yaml"))
+jsonschema.validate(plan, schema)
+print("OK")
+PY
+```
+
+See [`manifests/task-dag.example.json`](../../manifests/task-dag.example.json)
+for a minimal two-task example.


### PR DESCRIPTION
Closes #109. Implements BUILD_ROADMAP.md §8 items 11 and 12.

## What landed

- `docs/test-plans/task-schema.md` — one-page walk-through of `manifests/task-dag.schema.json` (normative schema), describing the three top-level fields, the three `passCondition` shapes, and the documentation conventions that the registry layers on top (`status:done|in_progress|pending`, `pr:#N`, `issue:#N` tags inside `artifacts[]`).
- `docs/test-plans/m0-m1-plan.yaml` — 36-task registry covering:
  - **M0** (10 tasks): toolchain, build wrappers, CI, x86 entry, COM1 serial, VGA, isa-debug-exit, `hello_boot` markers, negative-path fixture, planning docs — all `status:done` with closing PR refs (#18, #19, #23, #24, #26–#33).
  - **M1 capability core** (20 tasks): CAP-001..CAP-020, all `status:done` with their closing PR / issue refs (#35, #36, #38, #41, #42, #44, #46, #49/#50, #52, #54/#58, #59, #61, #63, #65, #67, #69, #71, #73, #75, #76).
  - **M2 console/launcher/HelloApp slice** (6 tasks): #82 plan (`in_progress`), #92 HelloApp deny-path via #100 (`in_progress`), #93 ABI ref via #97 (`in_progress`), and pending plans #83 (FS slice / #108), #84 (audit deny log), #85 (capability broker + share).
  - Validates against `manifests/task-dag.schema.json` (draft 2020-12, `additionalProperties: false` at every level).
- `docs/test-plans/README.md` — index, update cadence (per-task close + per-milestone), local `jsonschema` validation snippet, milestone summary as of 2026-05-12.
- `README.md` — replace the stale `docs/planning/M0-M1-task-registry.md` pointer (which no longer exists) with the new `docs/test-plans/` index, and link the task DAG schema walk-through.
- `CONTRIBUTING.md` — tell contributors to update the registry's `status:` / `pr:#N` tags when a CAP-\* / M-\* task lands.

## Validation

```
$ python3 - <<'PY'
import json, yaml, jsonschema
schema = json.load(open('manifests/task-dag.schema.json'))
plan   = yaml.safe_load(open('docs/test-plans/m0-m1-plan.yaml'))
jsonschema.validate(plan, schema)
print('OK, tasks:', len(plan['tasks']))
PY
OK, tasks: 36
```

No code change; no `build/scripts/test.sh` target is modified. Docs-only.

## Acceptance bullets

- [x] `docs/test-plans/task-schema.md` exists and points at `manifests/task-dag.schema.json` with an example walk-through (≤1 page).
- [x] `docs/test-plans/m0-m1-plan.yaml` exists, validates against the schema, and enumerates M0 / M1 (CAP-001..CAP-020, all done w/ closing PRs) / M2 in-flight tasks.
- [x] `docs/test-plans/README.md` links the schema doc + registry and documents update cadence.
- [x] `README.md` and `CONTRIBUTING.md` link the new index.
- [ ] *(Out of scope per the issue)* CI validator step asserting the registry parses against the schema — happy to file a follow-up if wanted.

## Follow-ups

- Optional CI: a tiny job that runs the validation snippet above on every PR touching `docs/test-plans/` or `manifests/task-dag.schema.json`.
- Future: drive `build/scripts/validate_bundle.sh`'s `TEST_TARGETS` from the registry instead of the hardcoded array (mentioned in #109's notes).