### PR TITLE
fix #90: defensively chmod +x build scripts in PR validation workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,6 +14,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Ensure build scripts are executable
+        # Defensive: mirrors the same step in iso-vm-build.yml.
+        # Several validator scripts have repeatedly landed on `main`
+        # without the `+x` bit (see #90 / #91 / #101), which makes
+        # `build/scripts/test.sh` print a wall of `Permission denied`
+        # before the harness can emit a parseable `TEST:FAIL:` marker.
+        # Restoring the bit here unblocks every PR even if a future
+        # commit drops it again, and complements the dispatch-time
+        # `bash <path>` fallback tracked under #91.
+        run: |
+          find build/scripts -type f -name "*.sh" -exec chmod +x {} +
+          find tools -type f \( -name "*.sh" -o -name "sof_wrap" \) -exec chmod +x {} + 2>/dev/null || true
+
       - name: Build pinned toolchain image
         run: |
           docker build \


### PR DESCRIPTION
Refs #90 / #91 / #101.

## Why

`.github/workflows/pr-build.yml` does **not** have the `Ensure build scripts are executable` step that the ISO/VM smoke workflow already has. Every time a commit lands on `main` that drops the executable bit on a validator script (the exact failure mode tracked in #90, and repeatedly re-introduced — see #95's own PR run still printing `Permission denied` for `test_event_bus.sh`, `test_sof_format.sh`, `test_fs_service.sh`, `test_app_runtime.sh`, `build_kernel_image.sh`, `test_kernel_persistence.sh` on 2026-05-12), every PR fails the `Full validation bundle` step before the harness can emit a parseable `TEST:FAIL:` marker.

This is what's currently keeping #95 / #96 / #102–#107 / #112 red, despite #95 restoring the bit on `main`: each PR branch checks out its *own* tree, which may still carry rw- only modes on validator scripts, and the toolchain-container path doesn't re-apply `+x` defensively the way `iso-vm-build.yml` does.

## What landed

`pr-build.yml` gets a new step **before** the toolchain build:

```yaml
- name: Ensure build scripts are executable
  run: |
    find build/scripts -type f -name "*.sh" -exec chmod +x {} +
    find tools -type f \( -name "*.sh" -o -name "sof_wrap" \) -exec chmod +x {} + 2>/dev/null || true
```

That is:

- Mirrors the same step from `iso-vm-build.yml` so the two workflows have symmetric pre-flight handling.
- Also flips `+x` on `tools/sof_wrap` and any `tools/*.sh` to cover the #101 class of regression (the prebuilt `sof_wrap` binary landing without `+x`).
- Tolerates missing `tools/` entries with `|| true` so a fresh `tools/` layout doesn't break CI.

No source files are modified, no test names change, and the workflow still calls `./build/scripts/validate_bundle.sh` as before. This is purely a CI pre-flight hardening.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-build.yml'))"` → `OK`.
- This PR's own `build-and-validate` job is the most direct end-to-end test: if it goes green where #95's same-tree job does not, the defense works. (If it doesn't, that surfaces a separate harness regression and gives #91's runtime fallback a real failure mode to convert into a parseable marker.)

## Relationship to the in-flight CI fix stack

This is intentionally additive and complementary:

- **#95** (restore committed `+x` on validator scripts) — fixes the *state* of `main`.
- **#96** (#91 — `run_validator` + `bash <path>` fallback + `TEST:FAIL:harness_missing_script`) — fixes the *runtime* surface so a future `+x` regression becomes parseable instead of `Permission denied`.
- **This PR** — fixes the *CI workflow* so PR runs are tolerant of either of the above being momentarily out of sync.

Together the three changes mean any one of them landing alone unblocks the wall, and all three landing makes the wall structurally unable to recur.

## Follow-ups

- None required. Optional: collapse the duplicated `Ensure build scripts are executable` step in both workflows into a composite action under `.github/actions/`. Not done here to keep the change to a single-file workflow edit.