### PR TITLE
docs: ADR-0001 boot protocol (Multiboot v1 + 64-bit long mode) (#116)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,7 @@ After successful builds, key outputs include:
 Before opening a PR, review:
 - `AGENTS.md`
 - `docs/CODING_CONVENTIONS.md`
+- `docs/architecture/decisions/` — Architecture Decision Records (start with the [ADR index](docs/architecture/decisions/README.md))
 
 Project-specific expectations include:
 - Keep PowerShell and shell build scripts in sync

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - Roadmap: `BUILD_ROADMAP.md`
 - M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
-- ADRs: `docs/adr/`
+- ADRs: `docs/architecture/decisions/` (see [README](docs/architecture/decisions/README.md))
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`
 - QEMU args: `build/qemu/`

--- a/docs/architecture/decisions/0001-boot-protocol-multiboot-long-mode.md
+++ b/docs/architecture/decisions/0001-boot-protocol-multiboot-long-mode.md
@@ -1,0 +1,140 @@
+# 0001. Boot protocol: Multiboot v1 + 64-bit long mode
+
+- Status: Accepted
+- Date: 2026-05-13
+
+## Context
+
+`BUILD_ROADMAP.md` §3.2 ("Bootloader strategy options") laid out two
+paths for the earliest boot stage:
+
+- **Option A (fastest path)**: a Multiboot2/Limine-compliant boot
+  protocol, leaning on an existing loader (GRUB / Limine) for the
+  real-mode → protected-mode transition and ELF loading.
+- **Option B (educational/full control)**: a custom stage-1/stage-2
+  bootloader with hand-rolled real-mode → protected-mode → long-mode
+  transitions.
+
+The roadmap recommended **Option A first**, with an optional later
+custom-loader milestone if educational value warranted it.
+
+In practice, the kernel has converged on a concrete realization of
+Option A:
+
+- The kernel image embeds a **Multiboot v1** header in the first 8 KiB
+  of the image (`kernel/arch/x86/boot/entry.asm`, `MULTIBOOT_MAGIC =
+  0x1BADB002`, with `ALIGN | MEMINFO` flags).
+- It is loaded by **GRUB** at the canonical 1 MiB physical base
+  (`kernel/arch/x86/boot/linker.ld`, `. = 1M;`,
+  `OUTPUT_FORMAT(elf64-x86-64)`).
+- `_start` runs in 32-bit protected mode (per Multiboot contract),
+  installs a minimal 64-bit GDT, builds identity-map page tables for the
+  first 4 MiB using two 2 MiB huge pages, enables PAE, sets EFER.LME,
+  enables paging, and far-jumps into a 64-bit code segment to reach
+  `_start64`, which sets up the 64-bit stack and calls `kmain`.
+- This is documented as current state in `docs/BOOT_ENTRY_X86.md`.
+
+This convergence has happened over several commits without an ADR
+recording the decision:
+
+- `86c3768` — `feat(boot): transition kernel to 64-bit long mode via
+  Multiboot entry`
+- `0f419e3` — `fix for networking and filedemo, migrate to 64 bit`
+- `13a817a` — `network and boot fixes`
+
+Before this ADR, future agents touching boot, paging, early console, or
+the QEMU harness had no single source explaining *why* the kernel
+assumes Multiboot v1 + 64-bit long mode at entry, or what would change
+under a different protocol.
+
+## Decision
+
+SecureOS commits to **Option A**, concretely realized as:
+
+1. **Boot protocol: Multiboot v1** (`0x1BADB002`) with the
+   `ALIGN | MEMINFO` flag set. The Multiboot header lives in the
+   `.multiboot` section, placed within the first 8 KiB of the kernel
+   image.
+2. **Reference loader: GRUB** (Multiboot v1 compliant). Any
+   Multiboot v1 compliant loader is acceptable; GRUB is the one wired
+   into the build/QEMU harness today.
+3. **Kernel entry contract**: GRUB hands control to `_start` in
+   **32-bit protected mode**, with `EAX = 0x2BADB002` and `EBX`
+   pointing at the Multiboot info structure, interrupts disabled,
+   paging disabled, GRUB-supplied flat 32-bit segments active.
+4. **Target CPU mode: 64-bit long mode.** The kernel transitions to
+   long mode in its own boot stub (PAE + identity-mapped first 4 MiB
+   via two 2 MiB huge pages + EFER.LME + CR0.PG + far-jump into 64-bit
+   CS) before calling `kmain`. `kmain` and all higher-level kernel code
+   runs in 64-bit mode at an identity-mapped virtual == physical
+   address starting at 1 MiB.
+5. **Image layout: ELF64**, loaded at physical/virtual 1 MiB. All
+   sections must fit within the first 4 MiB so the bootstrap
+   identity-map page tables fully cover the kernel.
+
+Multiboot2 and Limine remain compatible with Option A in spirit, but
+are explicitly **not adopted** at this time to avoid churn against the
+working Multiboot v1 path.
+
+A later ADR may revisit this decision (e.g. to add a Multiboot2 header
+for richer memory maps, or to introduce a custom stage-1/stage-2 loader
+for educational value as called out in roadmap §3.2 Option B). Any such
+change must supersede this ADR rather than silently diverge.
+
+## Consequences
+
+What now depends on this decision:
+
+- **Paging setup** (`kernel/arch/x86/boot/entry.asm`): bootstrap
+  identity-map page tables are sized for the first 4 MiB only; growing
+  beyond that requires either expanding the bootstrap page tables or
+  switching to a higher-half mapping ADR.
+- **Linker layout** (`kernel/arch/x86/boot/linker.ld`):
+  `OUTPUT_FORMAT(elf64-x86-64)`, `ENTRY(_start)`, and `. = 1M;` are all
+  Multiboot/long-mode assumptions; changing the protocol changes this
+  file.
+- **Early serial / VGA console** (`kernel/arch/x86/serial.c`,
+  `kernel/arch/x86/vga.c`): assume long-mode addressing and that GRUB
+  has already left the platform in a state where `0xB8000` and COM1
+  ports are usable.
+- **QEMU harness and debug-exit**: the headless harness boots the ELF
+  via a Multiboot-compatible flow and reads serial markers; the
+  contract above is what the harness expects.
+- **Build pipeline** (`build/scripts/build_kernel_entry.sh` and
+  friends): produces the ELF64 kernel image at 1 MiB; deterministic
+  build invariants assume this layout.
+
+What **Option B** would have changed instead:
+
+- We would own real-mode entry, A20, the protected-mode GDT setup,
+  ELF/raw image loading, and the long-mode transition end-to-end.
+- The build pipeline would produce stage-1/stage-2 binaries plus the
+  kernel image, and the QEMU harness would boot the loader rather than
+  the ELF directly.
+- Early debugging surface would be larger (more handwritten asm before
+  any serial output is reliable).
+
+Because Option A was chosen, we accept slightly less ownership of the
+very earliest stage in exchange for a much smaller boot-stub surface
+area and a working long-mode `kmain` today.
+
+## References
+
+- `BUILD_ROADMAP.md` §3.2 (Bootloader strategy options) and §3.3
+  (Concrete implementation backlog).
+- `BUILD_ROADMAP.md` §8 ("Immediate Next 14 Tasks") item 14 — the
+  task that motivated this ADR.
+- `docs/BOOT_ENTRY_X86.md` — current-state description of the boot
+  entry, build artifacts, and the `kmain` handoff.
+- Code paths:
+  - `kernel/arch/x86/boot/entry.asm` — Multiboot header, 32-bit
+    `_start`, long-mode transition, `_start64`.
+  - `kernel/arch/x86/boot/linker.ld` — ELF64 layout, 1 MiB load base.
+  - `kernel/core/kmain.c` — 64-bit `kmain` entrypoint.
+  - `kernel/arch/x86/serial.c`, `kernel/arch/x86/vga.c` — early
+    console drivers that assume the post-handoff environment defined
+    above.
+- Commits: `86c3768`, `0f419e3`, `13a817a`.
+- Related issues: #93 (ABI reference), #109 (test-plans registry) —
+  ADR index, ABI reference, and milestone registry together form the
+  "ground truth" surface future agents read first.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,62 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds Architecture Decision Records for SecureOS.
+
+## Purpose
+
+ADRs are the durable record of *why* SecureOS looks the way it does. They
+complement, but do not replace:
+
+- `BUILD_ROADMAP.md` — forward-looking plan and milestones.
+- `docs/BOOT_ENTRY_X86.md`, `docs/CODING_CONVENTIONS.md`, etc. — current
+  state and conventions.
+- `docs/architecture/CAPABILITIES.md` — narrative architecture docs.
+
+Where roadmap and architecture docs describe *what is* and *what's next*,
+ADRs describe *what was decided, when, and why*, so future agents can
+understand the constraints behind current code without rediscovering them.
+
+## Cadence
+
+- One MADR-style file per accepted decision.
+- Filenames use a 4-digit ordinal and a kebab-case slug:
+  `NNNN-short-title.md` (e.g. `0001-boot-protocol-multiboot-long-mode.md`).
+- Numbers are assigned at merge time, in order, and never reused.
+- Each ADR is short — ideally ≤ 1 page. The point is a stable record,
+  not a redesign.
+
+## Template
+
+Each ADR should contain at least the following sections:
+
+```
+# NNNN. <Title>
+
+- Status: Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+- Date: YYYY-MM-DD
+
+## Context
+What problem are we solving? What constraints exist
+(roadmap section, prior commits, dependent subsystems)?
+
+## Decision
+The choice we made, stated clearly and unambiguously.
+
+## Consequences
+What this implies for code, tests, and future work.
+What alternatives were rejected and why.
+
+## References
+Links to roadmap sections, related ADRs, code paths, and commits.
+```
+
+## Lifecycle
+
+- New ADRs land as `Status: Proposed` in a PR for discussion.
+- On merge, status is flipped to `Accepted` with the merge date.
+- A later ADR may `Supersede` an earlier one; the older file stays in
+  place and gets `Status: Superseded by ADR-NNNN`.
+
+## Index
+
+- [0001 — Boot protocol: Multiboot v1 + 64-bit long mode](./0001-boot-protocol-multiboot-long-mode.md)


### PR DESCRIPTION
Closes #116.

## Summary

Backfills `BUILD_ROADMAP.md` §8 ("Immediate Next 14 Tasks") item 14 by
recording the boot-protocol decision that the kernel has already
converged on in commits `86c3768`, `0f419e3`, and `13a817a`.

- New `docs/architecture/decisions/` directory with a `README.md`
  describing ADR cadence and a MADR-style template.
- `0001-boot-protocol-multiboot-long-mode.md` capturing:
  - **Status**: Accepted, dated 2026-05-13.
  - **Context**: roadmap §3.2 Option A vs B; the Multiboot v1 +
    long-mode reality in `kernel/arch/x86/boot/entry.asm` and
    `linker.ld`.
  - **Decision**: Multiboot v1 (`0x1BADB002`) + GRUB + ELF64 at 1 MiB +
    in-kernel long-mode transition + 64-bit `kmain`.
  - **Consequences**: what depends on the choice (paging setup, linker
    layout, early serial/VGA, QEMU harness, build pipeline) and what
    Option B would have changed.
  - **References**: roadmap sections, `docs/BOOT_ENTRY_X86.md`, code
    paths, and the relevant commits.
- Links the ADR index from `README.md` (Repo Pointers) and
  `CONTRIBUTING.md` (Coding and Planning Expectations).

Cross-links #93 (ABI reference) and #109 (test-plans registry) per the
issue notes.

## Validation

Documentation-only change; no code or build paths touched.

- `git diff --stat` limited to `README.md`, `CONTRIBUTING.md`, and the
  two new files under `docs/architecture/decisions/`.
- Internal links resolve relative to the new ADR directory.

## Follow-ups

- Future ADRs (capability handle representation, IPC wire format,
  manifest schema) can use the same template once #93 lands.
- If/when a Multiboot2 header or custom stage-1/stage-2 loader (roadmap
  §3.2 Option B) is adopted, a follow-up ADR should supersede 0001
  rather than silently diverge.