### PR TITLE
fix #124: fs_service test no longer asserts disk-image-staged content

### DIFF
--- a/tests/fs_service_test.c
+++ b/tests/fs_service_test.c
@@ -82,26 +82,32 @@ int main(void) {
   }
   printf("TEST:PASS:fs_service_list_root\n");
 
+  /*
+   * Note: fs_service_init() seeds only the directory skeleton (os/,
+   * apps/, lib/) plus /readme.txt and /apps/filedemo.bin. The
+   * /os/<cmd>.bin user commands and /lib/<lib>.lib shared libraries
+   * are staged into the disk image by tools/populate_disk_image.py
+   * and are therefore validated by the QEMU-level kernel_* suites
+   * that mount the real disk image, not by this host-side ramdisk
+   * unit test. See issue #124 for the regression history.
+   */
   if (fs_list_dir("/os", output, sizeof(output), &output_len) != FS_OK) {
     fail("list_os_failed");
-  }
-  if (!string_contains(output, "help.bin\n") || !string_contains(output, "env.bin\n") ||
-      !string_contains(output, "libs.bin\n") || !string_contains(output, "loadlib.bin\n") ||
-      !string_contains(output, "unload.bin\n")) {
-    fail("list_os_missing_help");
   }
   printf("TEST:PASS:fs_service_list_os\n");
 
   if (fs_list_dir("/lib", output, sizeof(output), &output_len) != FS_OK) {
     fail("list_lib_failed");
   }
-  if (!string_contains(output, "envlib.lib\n")) {
-    fail("list_lib_missing_envlib");
-  }
-  if (!string_contains(output, "fslib.lib\n")) {
-    fail("list_lib_missing_fslib");
-  }
   printf("TEST:PASS:fs_service_list_lib\n");
+
+  if (fs_list_dir("/apps", output, sizeof(output), &output_len) != FS_OK) {
+    fail("list_apps_failed");
+  }
+  if (!string_contains(output, "filedemo.bin\n")) {
+    fail("list_apps_missing_filedemo");
+  }
+  printf("TEST:PASS:fs_service_list_apps\n");
 
   if (fs_read_file("readme.txt", output, sizeof(output), &output_len) != FS_OK) {
     fail("read_seed_file_failed");


### PR DESCRIPTION
Closes #124.

## Problem

`build/scripts/test.sh fs_service` has been failing on every PR with:

```
TEST:START:fs_service
TEST:PASS:fs_service_fat32_boot_signature
TEST:PASS:fs_service_list_root
TEST:FAIL:fs_service:list_os_missing_help
```

## Root cause

Commit `2ffa788` ("refactored binaries in standalone elf", 2026-03-17) moved the `/os/*.bin` user commands and `/lib/*.lib` shared libraries out of `fs_service_init()` and into `tools/populate_disk_image.py` (where they get baked into `secureos-disk.img`). The host-side ramdisk unit test in `tests/fs_service_test.c` still asserted the old, in-init layout (`help.bin`, `env.bin`, `libs.bin`, `loadlib.bin`, `unload.bin`, `envlib.lib`, `fslib.lib`) and started failing because nothing on the unit-test path produces those files.

## Fix

Replace the stale presence assertions with the weaker invariants the unit-test path can actually guarantee:

- `/os` and `/lib` list cleanly (`FS_OK`) — the directory skeleton is still seeded by `fs_service_init()`.
- `/apps` lists cleanly and contains `filedemo.bin` (still seeded by `fs_service_init()` via `fs_build_sof_binary` / `fs_write_file_bytes`).

The disk-image-supplied content is already covered end-to-end by the QEMU-level `kernel_console` / `kernel_filedemo` / `kernel_persistence` suites that mount the real `secureos-disk.img`, which is where those files actually exist at runtime.

## Validation

Local `bash build/scripts/test.sh fs_service`:

```
TEST:START:fs_service
TEST:PASS:fs_service_fat32_boot_signature
TEST:PASS:fs_service_list_root
TEST:PASS:fs_service_list_os
TEST:PASS:fs_service_list_lib
TEST:PASS:fs_service_list_apps
TEST:PASS:fs_service_read_seed
TEST:PASS:fs_service_write_create
TEST:PASS:fs_service_append
TEST:PASS:fs_service_nested_paths
```

No source under `kernel/` or `tools/` is touched; this is a test-only fix.

## Relationship to the open CI fix stack

This is one of three independent reasons the validator bundle is currently red on `main`:

- **`fs_service:list_os_missing_help`** — fixed here.
- **`tests/sof_format_test.c` `-Werror=unused-function`** — addressed by PR #105.
- **`secureos-disk.img` permission denied for host qemu** — addressed by PR #107.

All three need to land for `VALIDATION_FAIL:` to clear, but each is independent and small. None depend on the in-flight broker / launcher slices.

## Follow-ups

None required. Could add a forward-looking comment in `fs_service_init()` pointing at `tools/populate_disk_image.py` so the next refactor doesn't silently desync the test again — happy to do that as a separate doc-only PR if useful.
