### PR TITLE
fix #129: add scheduler/tls/https to validator bundle TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -18,13 +18,22 @@ TEST_TARGETS=(
   capability_gate
   capability_audit
     event_bus
+    scheduler
     sof_format
+    tls
+    https
     fs_service
     app_runtime
     kernel_console
     kernel_filedemo
     kernel_persistence
 )
+# NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
+# NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /
+# test.ps1 but currently red (ed25519 sign/verify roundtrip, cert_chain root
+# validation, codesign -Werror=unused-variable on tests/codesign_test.c:307)
+# or blocked on the disk-image perms chain (#106 / PR #107 for kernel_sessions).
+# Add each here as the corresponding fix lands, so the bundle stays green.
 
 STATUS_LINES=()
 FAILED_TESTS=()


### PR DESCRIPTION
Closes #129.

`build/scripts/test.sh` and `build/scripts/test.ps1` both expose 19 dispatch arms, but `build/scripts/validate_bundle.sh` was only running 13 of them. This PR adds the three already-green orphans (`scheduler`, `tls`, `https`) to `TEST_TARGETS` and documents why the four remaining orphans (`ed25519`, `cert_chain`, `codesign`, `kernel_sessions`) are intentionally still excluded.

## What changed

- `build/scripts/validate_bundle.sh`: added `scheduler`, `tls`, `https` to `TEST_TARGETS`. Added an inline NOTE listing the four still-excluded targets and their respective red-state / upstream block, so future patches add each one as its fix lands instead of regressing the gap.

No other files touched. No schema change \u2014 each new target lands in `validator_report.json` `checks[]` automatically via the existing `STATUS_LINES` loop, so this is also additive on top of #110 / PR #112's machine-readable report.

## Validation

Per-target host runs (post-#90 `bash <script>` invocation pattern, since the +x bits on tracked scripts are still the issue tracked separately by #90 / #95 / #114):

```
$ bash build/scripts/test.sh scheduler
TEST:START:scheduler
TEST:PASS:scheduler_run_contract

$ bash build/scripts/test.sh tls
TEST:START:tls
TEST:PASS:tls_components

$ bash build/scripts/test.sh https
TEST:START:https
TEST:PASS:https_url_parsing
```

The four NOTE-listed exclusions were also confirmed red on host:

- `ed25519` \u2014 `FAIL: sign/verify roundtrip succeeds`
- `cert_chain` \u2014 `FAIL: cert chain validates to root`
- `codesign` \u2014 `-Werror=unused-variable` on `tests/codesign_test.c:307` (`cert_data`)
- `kernel_sessions` \u2014 same disk-image perms block as the other `kernel_*` arms, addressed by #106 / PR #107

These should each be tracked as separate red-test issues per the #129 done-when checklist; this PR deliberately does not touch them so the bundle stays green.

## Acceptance mapping (#129)

- [x] `scheduler`, `tls`, `https` added to `TEST_TARGETS`.
- [x] `ed25519`, `cert_chain`, `codesign`, `kernel_sessions` exclusions documented in source so they aren't lost.
- [x] No new files; no schema change; `validator_report.json` picks up the three new targets through the existing loop.

## Follow-ups

- File the three red-test issues for `ed25519`, `cert_chain`, `codesign` and add each to `TEST_TARGETS` as fixes land.
- Add `kernel_sessions` to `TEST_TARGETS` once #106 / PR #107 lands and the `kernel_*` arms are reliably green.
- Mirror the bundle expansion in any future Windows-side bundle once `validate_bundle.ps1` grows beyond delegating to the Linux script.