### PR TITLE
fix #140: add native_net_service.c to test_app_runtime.sh compile list

### DIFF
--- a/build/scripts/test_app_runtime.sh
+++ b/build/scripts/test_app_runtime.sh
@@ -13,9 +13,11 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/format/sof.c" \
   "$ROOT_DIR/kernel/hal/storage_hal.c" \
+  "$ROOT_DIR/kernel/hal/network_hal.c" \
   "$ROOT_DIR/kernel/drivers/disk/ramdisk.c" \
   "$ROOT_DIR/kernel/fs/fs_service.c" \
   "$ROOT_DIR/kernel/user/process.c" \
+  "$ROOT_DIR/kernel/user/native_net_service.c" \
   "$ROOT_DIR/tests/app_runtime_test.c" \
   -o "$OUT_DIR/app_runtime_test"
 


### PR DESCRIPTION
Closes #140.

## Problem
`build/scripts/test_app_runtime.sh` compiles `kernel/user/process.c` (which references the native_net_* helpers added in 2ffa788) without `kernel/user/native_net_service.c`, so every PR's Full validation bundle fails at link with undefined references to `native_net_device_ready/backend/get_mac` and `native_net_frame_send/recv`.

## Fix
Add `kernel/user/native_net_service.c` to the compile list. That surfaces a transitive link miss on `network_hal_*`, so also add `kernel/hal/network_hal.c` (the existing HAL impl those symbols come from).

## Validation
- Before: link fails with the 5 undefined references quoted in #140.
- After: `bash build/scripts/test_app_runtime.sh` links cleanly and runs the test binary.

The remaining `app_list_missing_expected_entries` runtime assertion is the separate pre-existing fs_service stale-assertion issue tracked in #124, not a link/build regression — out of scope here.

## Follow-ups
- #124 still needs the list_os/list_lib assertion update for the runtime test to go fully green.