### PR TITLE
docs(abi): add docs/abi/ ABI reference (closes #93)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,20 @@ After successful builds, key outputs include:
 - `artifacts/user/**/*.bin`
 - `artifacts/lib/*.lib`
 
+## ABI Surface Discipline
+
+When a PR touches any of the following, the matching doc under `docs/abi/`
+must be updated in the same commit and its `Last verified against commit:`
+line bumped:
+
+- `user/include/secureos_api.h` (any `os_*` syscall) → `docs/abi/syscalls.md`
+- `kernel/cap/capability.h` capability ID enum or audit struct → `docs/abi/capabilities.md`
+- `kernel/format/sof.h` container layout, manifest fields, or signing policy → `docs/abi/manifest.md`
+- `OS_ABI_VERSION` policy or freeze plan → `docs/abi/versioning.md`
+
+This is enforced by review, not (yet) by CI. See `docs/abi/README.md` for the
+rationale.
+
 ## Coding and Planning Expectations
 
 Before opening a PR, review:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - Roadmap: `BUILD_ROADMAP.md`
 - M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
+- ABI reference (syscalls / capabilities / manifest / versioning): `docs/abi/`
 - ADRs: `docs/adr/`
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -1,0 +1,60 @@
+# SecureOS ABI Reference
+
+This directory is the canonical, append-only reference for the externally-visible
+SecureOS interfaces. It exists to make ABI drift auditable while we are still at
+`OS_ABI_VERSION=0` (rapid iteration), so that the freeze to `1` at SDK beta
+(see `BUILD_ROADMAP.md` §7) can be performed against a known, written contract
+rather than against whatever the source tree happened to look like at freeze
+time.
+
+## Scope
+
+These documents describe the surface that user-space code (apps, libraries,
+external SDK consumers) is allowed to depend on:
+
+| Doc                                | Surface                                                      |
+| ---------------------------------- | ------------------------------------------------------------ |
+| [`syscalls.md`](./syscalls.md)     | The `os_*` user-facing API and required capability per call. |
+| [`capabilities.md`](./capabilities.md) | Capability ID list, handle representation, grant/revoke/audit semantics. |
+| [`manifest.md`](./manifest.md)     | The launcher / app manifest schema and signing requirements. |
+| [`versioning.md`](./versioning.md) | `OS_ABI_VERSION` policy, freeze plan, compatibility shim window. |
+
+Anything not described here is **not** part of the ABI and may change without
+notice (kernel internals, `_for_tests` symbols, validator script names,
+artifact layouts inside `artifacts/`, etc.).
+
+## "Last verified against commit" discipline
+
+Each ABI doc carries a `Last verified against commit:` line at the bottom.
+When you change one of the underlying surfaces (add a syscall, add a capability
+ID, change manifest fields, etc.) you **must** update the corresponding doc
+*and* bump its `Last verified` line in the same commit. The "M-end checklist"
+in `BUILD_ROADMAP.md` should re-verify each doc at the close of every
+milestone (M2, M3, M4, …) and refresh the line even when nothing changed.
+
+This is the cheapest possible drift detector: if a reviewer sees a syscall or
+capability ID added without a docs touch, the PR is incomplete.
+
+## Stability rules at a glance
+
+- Capability numeric IDs are **append-only** and never renumbered (see
+  `docs/architecture/CAPABILITIES.md` CAP-001 contract).
+- Syscall names and signatures in `user/include/secureos_api.h` are part of
+  the ABI surface; renaming or changing argument order is a breaking change
+  and requires `OS_ABI_VERSION` bump + compat shim per `versioning.md`.
+- Manifest field names are part of the ABI; field additions are
+  backward-compatible if defaulted, removals or renames are breaking.
+- Result codes (`os_status_t`, `cap_result_t`, `sof_result_t`) are
+  append-only; existing numeric values never change.
+
+## Cross-references
+
+- `docs/architecture/CAPABILITIES.md` — narrative of the capability core
+  (CAP-001 .. CAP-019), kept as the engineering history. `capabilities.md`
+  here is the API-reference distillation for SDK consumers.
+- `BUILD_ROADMAP.md` §7 — overarching ABI freeze policy.
+- `kernel/format/sof.h` — the SOF (Signed Object Format) container that
+  signed bundles, libraries, and OS commands are wrapped in. The on-wire
+  bytes of SOF are an ABI concern; see `manifest.md`.
+
+Last verified against commit: `9f4f7cc` (2026-05-15).

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -1,0 +1,118 @@
+# SecureOS Capability ABI
+
+This is the SDK-facing reference for capability identifiers, the handle
+representation, and the grant / revoke / audit semantics. The narrative
+history (CAP-001 .. CAP-019) lives in
+[`docs/architecture/CAPABILITIES.md`](../architecture/CAPABILITIES.md); the
+file you are reading is the abridged contract that external code may rely on.
+
+## Capability IDs
+
+Defined in `kernel/cap/capability.h::capability_id_t`. **Append-only.** Numeric
+values are stable across all `OS_ABI_VERSION` bumps.
+
+| ID | Name                    | Guards                                    |
+| -- | ----------------------- | ----------------------------------------- |
+| 1  | `CAP_CONSOLE_WRITE`     | `os_console_write` and the console service. |
+| 2  | `CAP_SERIAL_WRITE`      | Direct serial port writes.                |
+| 3  | `CAP_DEBUG_EXIT`        | QEMU debug-exit signaling.                |
+| 4  | `CAP_CAPABILITY_ADMIN`  | Mutating the cap table (`cap_grant_as` / `cap_revoke_as`). Non-delegable; bootstrap subject `0` only. |
+| 5  | `CAP_DISK_IO_REQUEST`   | Raw disk I/O requests.                    |
+| 6  | `CAP_FS_READ`           | All `os_fs_*` read paths.                 |
+| 7  | `CAP_FS_WRITE`          | `os_fs_write_file`, `os_fs_mkdir`.        |
+| 8  | `CAP_EVENT_SUBSCRIBE`   | Event bus subscriptions.                  |
+| 9  | `CAP_EVENT_PUBLISH`     | Event bus publication.                    |
+| 10 | `CAP_APP_EXEC`          | Loading / running additional apps and libraries. |
+| 11 | `CAP_CODESIGN_BYPASS`   | Loading an unsigned bundle. **Strongly restricted; bootstrap-only.** |
+| 12 | `CAP_NETWORK`           | All `os_net_*` calls (HTTP and HTTPS).    |
+
+Result codes (`cap_result_t`, append-only):
+
+| Name                       | Value | Meaning                                       |
+| -------------------------- | ----- | --------------------------------------------- |
+| `CAP_OK`                   | 0     | Subject has explicit grant.                    |
+| `CAP_ERR_MISSING`          | 1     | Subject is valid; capability is not granted.   |
+| `CAP_ERR_SUBJECT_INVALID`  | 2     | Subject identifier is out of bounds / unknown. |
+| `CAP_ERR_CAP_INVALID`      | 3     | Capability identifier is out of bounds / unknown. |
+
+## Handle representation
+
+A capability "handle" in current SecureOS is **a per-subject grant entry in
+the kernel capability table**, *not* a userspace-passable opaque token. There
+are no `cap_handle_t` values to round-trip across the syscall boundary.
+
+- The cap table is fixed-capacity: `CAP_TABLE_MAX_SUBJECTS = 8` per-subject
+  slots, each storing a packed bitset of granted capability IDs (CAP-002 /
+  CAP-006).
+- A "subject" is identified by `cap_subject_id_t` (`uint32_t`). Subject `0`
+  is the bootstrap root and is the only subject permitted to hold
+  `CAP_CAPABILITY_ADMIN` (CAP-014).
+- All capability checks happen kernel-side via `cap_check(subject, cap_id)`;
+  user space never sees the bitset.
+
+A future SDK iteration may introduce explicit handle objects (e.g. a
+delegable read-only file handle) per `BUILD_ROADMAP.md` §6.1. Until that
+lands, the only way for an app to "have" a capability is for it to be granted
+to its subject id at launch time via the manifest (see `manifest.md`).
+
+## Grant / revoke semantics
+
+- **Default state is deny.** No subject holds any capability after
+  `cap_table_init` until an explicit grant.
+- **Mutation requires `CAP_CAPABILITY_ADMIN`.** `cap_grant_as` /
+  `cap_revoke_as` reject the call (`CAP_ERR_MISSING` audited against the
+  actor) when the actor lacks `CAP_CAPABILITY_ADMIN` (CAP-013).
+- **Non-delegable admin.** `CAP_CAPABILITY_ADMIN` itself can only be granted
+  to subject `0`; any attempt to grant it to another subject fails (CAP-014).
+- **Revoke is immediate.** A `cap_check` returns `CAP_ERR_MISSING` on the very
+  next call after a successful revoke; there is no caching layer or grace
+  period (CAP-003).
+- **Invalid inputs never silently succeed.** Unknown subject or capability
+  IDs return the matching `CAP_ERR_*_INVALID` and are recorded in the audit
+  ring with that error code.
+
+## Audit and observability
+
+Every `cap_check` / `cap_grant` / `cap_revoke` produces exactly one
+`cap_audit_event_t`:
+
+```c
+typedef struct {
+  uint64_t            sequence_id;       /* monotonic; preserved across overflow */
+  cap_audit_op_t      operation;         /* CHECK | GRANT | REVOKE */
+  cap_subject_id_t    actor_subject_id;  /* who attempted the mutation */
+  cap_subject_id_t    subject_id;        /* who the result applies to */
+  capability_id_t     capability_id;
+  cap_result_t        result;
+} cap_audit_event_t;
+```
+
+Guarantees (CAP-009 .. CAP-019):
+
+- The audit ring has bounded depth (`CAP_AUDIT_EVENT_MAX = 32`) with explicit
+  FIFO retention; a monotonic dropped-events counter is exposed via
+  `cap_audit_dropped_for_tests()`.
+- `sequence_id` is monotonically increasing across the lifetime of the
+  process and survives ring wrap.
+- Tamper-evident checkpoints (`cap_audit_checkpoint_t`, every
+  `CAP_AUDIT_CHECKPOINT_INTERVAL = 8` events) seal a window of sequence ids
+  and are exposed via `cap_audit_checkpoint_get_for_tests()`.
+- Logging never alters allow / deny semantics. The act of writing an audit
+  event must not change the result returned to the caller (CAP-009 +
+  test-suite invariant).
+
+The validator JSON summary (see `BUILD_ROADMAP.md` §4.3 / issue #110)
+surfaces the same sequence-id and checkpoint metadata so that CI can assert
+on capability-policy continuity without parsing free-text logs.
+
+## Adding a capability ID
+
+1. Append the new identifier to `capability_id_t` in
+   `kernel/cap/capability.h`. **Do not** renumber existing entries.
+2. Append a row to the table above with the guarded surface.
+3. Update `docs/architecture/CAPABILITIES.md` with a CAP-NNN narrative entry.
+4. Add at least one allow-path and one deny-path test exercising the new
+   capability (see `tests/` and the relevant validator script).
+5. Bump `Last verified against commit` below.
+
+Last verified against commit: `9f4f7cc` (2026-05-15).

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -1,0 +1,157 @@
+# SecureOS Manifest ABI
+
+This document describes the launcher / app manifest surface that the SDK
+consumes when packaging a signed app or library bundle. It is a **forward
+contract**: parts of the schema below are still being implemented across
+M2 (#82, console/launcher/HelloApp) and M3 (#83, filesystem service), and
+field-by-field stability is called out explicitly.
+
+The on-disk container for any signed artifact (OS command, user library, app
+bundle) is the SOF (Signed Object Format) wrapper defined in
+`kernel/format/sof.h`. The manifest sits **inside** that wrapper as a typed
+metadata blob.
+
+## SOF container — stable today
+
+Defined in `kernel/format/sof.h`. The `sof_header_t`, the metadata TLV
+entries (`sof_meta_entry_t`, max `SOF_META_MAX_ENTRIES = 12`), and the
+following result codes are part of the ABI:
+
+| Code                          | Value | Meaning                                  |
+| ----------------------------- | ----- | ---------------------------------------- |
+| `SOF_OK`                      | 0     | Parse / validation succeeded.             |
+| `SOF_ERR_INVALID_MAGIC`       | 1     | Wrong magic; not a SOF artifact.          |
+| `SOF_ERR_INVALID_VERSION`     | 2     | Container version unsupported.            |
+| `SOF_ERR_INVALID_TYPE`        | 3     | `file_type` not recognized.               |
+| `SOF_ERR_INVALID_SIZE`        | 4     | Size fields inconsistent with the buffer. |
+| `SOF_ERR_INVALID_META`        | 5     | Metadata TLV malformed.                   |
+| `SOF_ERR_BUFFER_TOO_SMALL`    | 6     | Output buffer too small.                  |
+| `SOF_ERR_NO_PAYLOAD`          | 7     | Payload absent.                           |
+| `SOF_ERR_SIGNATURE_REQUIRED`  | 8     | Unsigned bundle rejected (no `CAP_CODESIGN_BYPASS`). |
+| `SOF_ERR_SIGNATURE_INVALID`   | 9     | Signature present but verification failed. |
+
+Numeric values are append-only.
+
+## Build-time metadata fields (`sof_build_params_t`)
+
+These are the metadata fields that `tools/sof_wrap` writes into the SOF
+container at build time:
+
+| Field         | Required | Purpose                                                 |
+| ------------- | -------- | ------------------------------------------------------- |
+| `file_type`   | yes      | One of the `sof_file_type_t` enumerants (OS command, user library, app bundle). |
+| `name`        | yes      | Short identifier; printable ASCII, no `/`.              |
+| `description` | yes      | Human-readable summary.                                 |
+| `author`      | yes      | Author / publisher attribution.                         |
+| `version`     | yes      | SemVer-shaped version string.                           |
+| `date`        | yes      | ISO-8601 build date.                                    |
+| `icon`        | no       | Optional UI hint; may be NULL.                          |
+| `syscall_id`  | no       | OS-command dispatch routing key for `file_type = OS_COMMAND`. |
+| `elf_payload` / `elf_payload_size` | yes | The actual code/data. |
+
+These fields are intentionally simple — they are TLV entries in the
+SOF metadata block and are read on the kernel side by `sof_parse`.
+
+## App / launcher manifest — provisional schema
+
+The **app bundle** layer wraps zero or more SOF artifacts together with a
+launcher manifest. `sof_app_bundle_header_t` reserves the on-wire shape:
+
+```c
+typedef struct {
+  uint32_t entry_count;
+  uint32_t manifest_offset;
+  uint32_t manifest_size;
+  uint32_t compression_algo;  /* 0 = NONE; 1/2 reserved for LZ4 / ZSTD */
+  uint32_t reserved[4];
+} sof_app_bundle_header_t;
+```
+
+The on-disk encoding of the bundle header is **stable**. The contents of the
+manifest body it points to are still being defined under M2 (#82). The
+proposed minimal schema, which the SDK should target, is JSON with the
+following shape:
+
+```json
+{
+  "schema_version": 0,
+  "name": "HelloApp",
+  "version": "0.1.0",
+  "entry": "hello.sof",
+  "capabilities": {
+    "required": ["CAP_CONSOLE_WRITE"],
+    "optional": []
+  },
+  "signing": {
+    "publisher": "secureos.dev",
+    "key_id": "ed25519:bootstrap-root",
+    "policy": "must-verify"
+  }
+}
+```
+
+Field rules (provisional but stable from M2 onwards unless otherwise noted):
+
+- `schema_version` — append-only integer; bumped only on a breaking change.
+  At ABI version 0 the launcher accepts `schema_version = 0`.
+- `name` / `version` — must match the corresponding SOF metadata of the
+  entry binary; mismatch is a manifest-validation failure.
+- `entry` — relative path inside the bundle to the SOF artifact the
+  launcher should load.
+- `capabilities.required` — list of capability **names** (matching the
+  table in [`capabilities.md`](./capabilities.md)). Names are used here,
+  not numeric IDs, so manifests stay stable across capability ID
+  renumbering attempts (which are forbidden anyway, but the redundancy is
+  cheap).
+- `capabilities.optional` — capabilities the app prefers but can run
+  without; the launcher **may** grant a subset.
+- `signing.policy` — one of:
+  - `"must-verify"` — default; loader rejects on missing or invalid signature
+    (returns `SOF_ERR_SIGNATURE_REQUIRED` / `SOF_ERR_SIGNATURE_INVALID`).
+  - `"bypass"` — only honored if the loading subject holds
+    `CAP_CODESIGN_BYPASS`; bootstrap-only.
+
+### Worked example (HelloApp deny-path, M2)
+
+For the `helloapp_denied_console_write` test (issue #92), the launcher
+manifest deliberately omits `CAP_CONSOLE_WRITE`:
+
+```json
+{
+  "schema_version": 0,
+  "name": "HelloApp",
+  "version": "0.1.0",
+  "entry": "hello.sof",
+  "capabilities": { "required": [], "optional": ["CAP_CONSOLE_WRITE"] },
+  "signing": { "publisher": "secureos.dev", "key_id": "ed25519:bootstrap-root", "policy": "must-verify" }
+}
+```
+
+Expected behavior:
+
+1. Launcher loads `hello.sof`, verifies signature.
+2. Launcher allocates a subject id, grants no capabilities (the
+   `required` list is empty; `optional` does not auto-grant).
+3. App calls `os_console_write(...)` → `OS_STATUS_DENIED`.
+4. Audit ring contains a `CAP_AUDIT_OP_CHECK` event with
+   `capability_id = CAP_CONSOLE_WRITE`, `result = CAP_ERR_MISSING`.
+
+## Compatibility policy
+
+- Adding a manifest field is backward-compatible iff the field has a
+  documented default and the loader treats absence as that default.
+- Removing or renaming a field is breaking and requires bumping
+  `schema_version` and providing a one-major-version compat shim per
+  [`versioning.md`](./versioning.md).
+- The SOF binary layout (`sof_header_t`, TLV grammar,
+  `sof_app_bundle_header_t`) does not move within `OS_ABI_VERSION` 0; any
+  change there is automatically a major bump.
+
+## Outstanding items
+
+- Final wire format for `manifest_body` (JSON vs. binary TLV) is being
+  decided in M2 (#82). This document will be refreshed once a PR lands.
+- `signing.key_id` semantics depend on the corrected ed25519 stack landing
+  (#133 / PR #134) and the re-sign discipline tracked in #138.
+
+Last verified against commit: `9f4f7cc` (2026-05-15).

--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -1,0 +1,86 @@
+# SecureOS Syscall ABI (`os_*`)
+
+User-visible API surface declared in `user/include/secureos_api.h`. All entry
+points return an `os_status_t` value. The kernel-side implementation lives in
+the user-app native bridge (`kernel/user/process.c::app_native_*`) and behind
+the FS / network / console services.
+
+## Result codes
+
+`os_status_t` (append-only):
+
+| Name                | Value | Meaning                                                       |
+| ------------------- | ----- | ------------------------------------------------------------- |
+| `OS_STATUS_OK`      | 0     | Operation completed successfully.                              |
+| `OS_STATUS_DENIED`  | 1     | Caller lacks the required capability or service-level grant.   |
+| `OS_STATUS_NOT_FOUND` | 2   | Target resource (path, handle, env key, etc.) does not exist.  |
+| `OS_STATUS_ERROR`   | 3     | Generic error (malformed args, I/O failure, internal error).   |
+
+Numeric values are part of the ABI and must not change. New codes are appended
+with strictly larger numeric values.
+
+## Syscall surface
+
+Each row lists the user-visible signature, the capability the call requires
+(returned as `OS_STATUS_DENIED` if missing), and a one-line semantics summary.
+
+| Syscall | Required capability | Notes |
+| --- | --- | --- |
+| `os_status_t os_console_write(const char *message)` | `CAP_CONSOLE_WRITE` | Write a NUL-terminated string to the console service. Deny-by-default; granted via launcher manifest. |
+| `os_status_t os_fs_list_root(char *out, unsigned int out_size)` | `CAP_FS_READ` | Enumerate root entries; `out` is filled with newline-separated names. `OS_STATUS_ERROR` if `out_size` is too small. |
+| `os_status_t os_fs_list_dir(const char *path, char *out, unsigned int out_size)` | `CAP_FS_READ` | Enumerate entries in `path`. |
+| `os_status_t os_fs_read_file(const char *path, char *out, unsigned int out_size)` | `CAP_FS_READ` | Read entire file into `out`. |
+| `os_status_t os_fs_write_file(const char *path, const char *content, int append)` | `CAP_FS_WRITE` | Write or append `content` to `path`. |
+| `os_status_t os_fs_mkdir(const char *path)` | `CAP_FS_WRITE` | Create directory; idempotent on existing dir is implementation-defined (currently `OS_STATUS_ERROR`). |
+| `os_status_t os_process_chdir(const char *path)` | none (process-local) | Change current working directory of the calling app. |
+| `os_status_t os_process_getcwd(char *out, unsigned int out_size)` | none | Read current working directory. |
+| `os_status_t os_env_get(const char *key, char *out, unsigned int out_size)` | none (process-local env) | Read process env var. |
+| `os_status_t os_env_set(const char *key, const char *value)` | none | Set process env var. |
+| `os_status_t os_env_list(char *out, unsigned int out_size)` | none | Newline-separated `KEY=VALUE` dump. |
+| `os_status_t os_lib_list(char *out, unsigned int out_size)` | `CAP_FS_READ` (to enumerate library paths) | Enumerate currently-loaded libraries. |
+| `os_status_t os_lib_load(const char *path, char *out, unsigned int out_size)` | `CAP_APP_EXEC` | Load a SOF-wrapped library; signature must verify (see `manifest.md`). Returns handle id in `out`. |
+| `os_status_t os_lib_unload(unsigned int handle)` | `CAP_APP_EXEC` | Release a library previously loaded by `os_lib_load`. |
+| `os_status_t os_net_device_ready(void)` | `CAP_NETWORK` | Returns `OS_STATUS_OK` once the NIC backend is live. |
+| `os_status_t os_net_device_backend(char *out, unsigned int out_size)` | `CAP_NETWORK` | Backend descriptor string (e.g. `virtio-net-pci`). |
+| `os_status_t os_net_device_get_mac(unsigned char *out, unsigned int out_size)` | `CAP_NETWORK` | 6-byte MAC into `out`; `out_size` must be ≥ 6. |
+| `os_status_t os_net_frame_send(const unsigned char *frame, unsigned int len)` | `CAP_NETWORK` | Send a single L2 Ethernet frame. |
+| `os_status_t os_net_frame_recv(unsigned char *out, unsigned int out_size, unsigned int *out_len)` | `CAP_NETWORK` | Non-blocking receive; `*out_len = 0` if no frame is queued. |
+| `os_status_t os_net_ifconfig(char *out, unsigned int out_size)` | `CAP_NETWORK` | Human-readable interface summary. |
+| `os_status_t os_net_http_get(const char *url, char *out, unsigned int out_size)` | `CAP_NETWORK` | HTTP/1.1 GET; v1 stack only. |
+| `os_status_t os_net_https_get(const char *url, char *out, unsigned int out_size)` | `CAP_NETWORK` | HTTPS (TLS 1.2 via BearSSL) — `CAP_NETWORK` is sufficient, no separate TLS capability. |
+| `os_status_t os_net_ping(const char *host, char *out, unsigned int out_size)` | `CAP_NETWORK` | ICMP echo. |
+| `os_status_t os_apps_list(char *out, unsigned int out_size)` | `CAP_FS_READ` | Enumerate installed apps. |
+| `os_status_t os_storage_info(char *out, unsigned int out_size)` | `CAP_FS_READ` | Storage backend summary. |
+| `os_status_t os_get_args(char *out, unsigned int out_size)` | none (process-local) | Read the launcher-supplied argument string. |
+
+## Calling convention
+
+User apps are loaded by `kernel/user/process.c` and reach the kernel via the
+`app_native_bridge_t` function-pointer table at the well-known address
+`APP_NATIVE_BRIDGE_ADDR`. The bridge layout is currently considered an
+**internal** detail of the static-link app model and is *not* yet a stable
+ABI; SDK consumers must depend on the `os_*` symbols from
+`user/include/secureos_api.h` and the matching `user/lib/` runtime, not on
+the bridge offsets directly.
+
+When the syscall surface migrates to a true syscall instruction (planned for
+M6 SDK work, see `BUILD_ROADMAP.md` §5.6 + issue #136), the `os_*` signatures
+remain stable; only the lowering changes.
+
+## Capability check semantics
+
+Every `OS_STATUS_DENIED` return corresponds to exactly one `cap_check()` call
+and produces exactly one `CAP_AUDIT_OP_CHECK` audit event with
+`result = CAP_ERR_MISSING` (see `capabilities.md`). There is no silent denial
+path — if a syscall returns `OS_STATUS_DENIED`, the audit ring will contain a
+matching event.
+
+## Adding a new syscall
+
+1. Append the prototype to `user/include/secureos_api.h` (do not reorder).
+2. Append a row to the table above and state the required capability.
+3. If a new capability is needed, follow the procedure in `capabilities.md`
+   ("Adding a capability ID") *first*.
+4. Update `Last verified against commit` below.
+
+Last verified against commit: `9f4f7cc` (2026-05-15).

--- a/docs/abi/versioning.md
+++ b/docs/abi/versioning.md
@@ -1,0 +1,78 @@
+# SecureOS ABI Versioning Policy
+
+This restates and operationalizes the policy in `BUILD_ROADMAP.md` §7
+("ABI and Interface Freeze Plan"). It is the contract that
+`OS_ABI_VERSION`-aware code (loader, manifest parser, future SDK build tools)
+must follow.
+
+## Current state
+
+```
+OS_ABI_VERSION = 0
+```
+
+All surfaces described in this directory (`syscalls.md`, `capabilities.md`,
+`manifest.md`) are at version `0` — *rapid iteration*. Breaking changes are
+permitted within this version but must:
+
+- update the relevant doc in the same PR,
+- bump that doc's `Last verified against commit` line, and
+- carry a CHANGELOG-style entry in the PR body.
+
+## Freeze plan
+
+| Phase                              | `OS_ABI_VERSION` | Rules |
+| ---------------------------------- | ---------------- | ----- |
+| Pre-SDK (current; through M5)      | `0`              | Breaking changes allowed; surfaces stay documented. |
+| SDK beta announced (M6 / #136)     | `1`              | Frozen. No breaking changes without bumping major. |
+| Post-1.x maintenance               | `≥ 1`            | One major version of compatibility shims kept in tree. |
+
+When the freeze to `1` happens (planned alongside M6 SDK work, #136), this
+file's "Current state" block bumps to `1` and the docs in this directory
+become contractual.
+
+## Compatibility shim window
+
+After a freeze:
+
+- For one major version after a breaking change, the prior surface must
+  remain callable via a shim. Concretely: if v2 removes
+  `os_legacy_thing(...)`, the v2 build still ships an
+  `os_legacy_thing(...)` symbol that delegates to or rejects with a
+  documented `OS_STATUS_*` value.
+- The compat shim is removed in v3 (one major after deprecation).
+- Capability IDs are *never* removed; deprecated capabilities are documented
+  as no-ops and still reserve their numeric ID.
+
+## What is and is not part of the ABI
+
+In-scope (versioned, audit-tracked here):
+
+- The `os_*` syscall surface (`syscalls.md`).
+- Capability IDs, result codes, and grant/revoke/audit semantics
+  (`capabilities.md`).
+- SOF container layout, manifest field names, and signing policy
+  (`manifest.md`).
+- `OS_STATUS_*`, `CAP_*` (result and operation enums), `SOF_*` enums —
+  values are append-only.
+
+Out of scope (may change at any time, not part of `OS_ABI_VERSION`):
+
+- The `app_native_bridge_t` function-pointer table layout
+  (an internal lowering detail; will be replaced by a real syscall
+  instruction during M6 SDK work).
+- `_for_tests` symbols in any kernel module.
+- Kernel-internal data structures (cap table layout, audit ring storage,
+  scheduler state).
+- Validator script names and locations under `build/scripts/`.
+- Layout of `artifacts/` and toolchain container internals.
+
+## Changing this policy
+
+Changes to the freeze plan or shim window must be reviewed against
+`BUILD_ROADMAP.md` §7 and recorded as an ADR under `docs/adr/` (see
+`docs/adr/0001-capability-core-boundary.md` for the pattern). This file is
+the operational restatement; the roadmap is the source of truth for the
+policy itself.
+
+Last verified against commit: `9f4f7cc` (2026-05-15).


### PR DESCRIPTION
Closes #93.

## What

Adds `docs/abi/` — the SDK-facing reference for SecureOS's externally-visible
surfaces, while we are still at `OS_ABI_VERSION=0` and the contract is cheap
to write down.

Files:

- `docs/abi/README.md` — index + the *Last verified against commit* drift-detector convention
- `docs/abi/syscalls.md` — every `os_*` entry point in `user/include/secureos_api.h` with its required capability and `os_status_t` semantics
- `docs/abi/capabilities.md` — SDK-facing distillation of CAP-001..019: ID list, handle representation (cap table, no userspace tokens yet), grant/revoke rules, non-delegable admin, audit event struct with `sequence_id` + checkpoint guarantees
- `docs/abi/manifest.md` — SOF container ABI (stable today: `sof_header_t`, `sof_*_t` enums, `sof_app_bundle_header_t`) + provisional launcher manifest JSON schema with a worked HelloApp deny-path example tied to #92
- `docs/abi/versioning.md` — restated `BUILD_ROADMAP.md` §7 freeze plan + one-major-version compat shim window + explicit in-scope vs out-of-scope list

## Cross-links

- `README.md` *Repo Pointers* gains an `docs/abi/` entry.
- `CONTRIBUTING.md` gains an *ABI Surface Discipline* section: PRs touching `secureos_api.h` / `capability.h` / `sof.h` / `OS_ABI_VERSION` must update the matching doc and bump its `Last verified against commit:` line in the same commit.

## Why now

BUILD_ROADMAP.md §7 explicitly calls for early ABI definition to prevent churn. M2 (#82, console+launcher+HelloApp), M3 (#83, fs service), M4 (#85, broker), and M5 (#118) are all about to converge on the manifest + capability surface. Drift after that is much more expensive to undo. #93 documented this gap.

## Validation

Docs-only change; no code, no build script, no CI surface touched. `BUILD_ROADMAP.md` and existing `docs/architecture/CAPABILITIES.md` are referenced as sources of truth, not duplicated. The new files explicitly defer to the existing engineering history doc.

## Follow-ups

- After #134 (ed25519 fix) and #138 (re-sign discipline) land, refresh `manifest.md` *Outstanding items* and bump its `Last verified` line.
- Once M2 (#82) settles the manifest body wire format (JSON vs binary TLV), promote the *provisional* schema in `manifest.md` to stable.
- Per the doc convention, every milestone close should re-bump the `Last verified against commit:` lines.