### PR TITLE
fix #140: add native_net_service.c to test_app_runtime.sh compile list

### DIFF
--- a/build/scripts/test_app_runtime.sh
+++ b/build/scripts/test_app_runtime.sh
@@ -13,9 +13,11 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/format/sof.c" \
   "$ROOT_DIR/kernel/hal/storage_hal.c" \
+  "$ROOT_DIR/kernel/hal/network_hal.c" \
   "$ROOT_DIR/kernel/drivers/disk/ramdisk.c" \
   "$ROOT_DIR/kernel/fs/fs_service.c" \
   "$ROOT_DIR/kernel/user/process.c" \
+  "$ROOT_DIR/kernel/user/native_net_service.c" \
   "$ROOT_DIR/tests/app_runtime_test.c" \
   -o "$OUT_DIR/app_runtime_test"
 


### PR DESCRIPTION
Closes #140.

## Problem
`build/scripts/test_app_runtime.sh` compiles `kernel/user/process.c` (which calls the `native_net_*` shims added in 2ffa788) but does not include `kernel/user/native_net_service.c`. Every PR's full validation bundle therefore fails at link with:

```
undefined reference to 'native_net_device_ready'
undefined reference to 'native_net_device_backend'
undefined reference to 'native_net_device_get_mac'
undefined reference to 'native_net_frame_send'
undefined reference to 'native_net_frame_recv'
```

## Fix
Add `kernel/user/native_net_service.c` and its `kernel/hal/network_hal.c` dependency to the compile list.

## Validation
- Before: link fails with the exact errors above.
- After: `bash build/scripts/test_app_runtime.sh` links cleanly and reaches runtime.
- A remaining `app_list_missing_expected_entries` assertion failure is unrelated to this link regression (matches the symptom tracked in #124 — fs_service test list_os/list_lib stale assertions after binaries moved to disk-image step).

## Follow-ups
- #124 still needs the runtime assertion fix to get a fully green app_runtime test.
