### PR TITLE
tests #138: SOF verify-at-rest (stacked on #134)

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|sof_verify_at_rest]
 
 Runs SecureOS test targets.
 EOF
@@ -72,6 +72,9 @@ case "$TEST_NAME" in
     ;;
   codesign)
     "$ROOT_DIR/build/scripts/test_codesign.sh"
+    ;;
+  sof_verify_at_rest)
+    "$ROOT_DIR/build/scripts/test_sof_verify_at_rest.sh"
     ;;
   tls)
     "$ROOT_DIR/build/scripts/test_tls.sh"

--- a/build/scripts/test_sof_verify_at_rest.sh
+++ b/build/scripts/test_sof_verify_at_rest.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# test_sof_verify_at_rest.sh — Compile and run the SOF verify-at-rest tests (#138).
+#
+# Builds tests/sof_verify_at_rest_test.c against the same crypto + SOF
+# sources that codesign_test.sh links, then runs the binary. The test
+# writes a signed SOF blob to a temp file, re-reads it, and asserts that
+# sof_verify_signature accepts the unmodified persisted bytes and rejects
+# single-byte mutations in both the signature region and the payload
+# region — the at-rest counterpart of the in-memory roundtrip exercised
+# by tests/codesign_test.c.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+SRC_TEST="$ROOT_DIR/tests/sof_verify_at_rest_test.c"
+SRC_SOF="$ROOT_DIR/kernel/format/sof.c"
+SRC_SHA512="$ROOT_DIR/kernel/crypto/sha512.c"
+SRC_ED25519="$ROOT_DIR/kernel/crypto/ed25519.c"
+SRC_CERT="$ROOT_DIR/kernel/crypto/cert.c"
+
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+OUT="$OUT_DIR/sof_verify_at_rest_test"
+TMP_SOF="$OUT_DIR/sof_verify_at_rest.sof"
+
+mkdir -p "$OUT_DIR"
+
+echo "[test_sof_verify_at_rest] compiling..."
+cc -std=c11 -Wall -Wextra -Werror -O2 \
+    -o "$OUT" \
+    "$SRC_TEST" "$SRC_SOF" "$SRC_SHA512" "$SRC_ED25519" "$SRC_CERT"
+
+echo "[test_sof_verify_at_rest] running..."
+"$OUT" "$TMP_SOF"
+EXIT_CODE=$?
+
+rm -f "$TMP_SOF"
+
+exit $EXIT_CODE

--- a/kernel/crypto/ed25519.c
+++ b/kernel/crypto/ed25519.c
@@ -246,9 +246,22 @@ static int unpackneg(ge_p3 r, const uint8_t p[32]) {
   return 0;
 }
 
+/*
+ * Scalar multiplication by the standard base point.
+ *
+ * Implements the textbook double-and-add ladder, processing scalar bits
+ * from most significant to least significant.  Doubling reuses
+ * add_points() (which is the unified "add-2008-hwcd-3" formula for
+ * twisted Edwards a=-1; it is correct for the doubling case as well
+ * when both operands are the same point in projective coordinates).
+ *
+ * Verified against RFC 8032 §7.1 Test 1:
+ *   seed = 9d61b19deffd5a60ba844af492ec2cc4 4449c5697b32691970...
+ *   pub  = d75a980182b10ab7d54bfed3c964073a 0ee172f3daa62325af021a68f707511a
+ */
 static void scalarmult_base(ge_p3 p, const uint8_t *s) {
   ge_p3 bp;
-  int i;
+  int i, j;
 
   set25519(bp[0], X);
   set25519(bp[1], Y);
@@ -263,17 +276,17 @@ static void scalarmult_base(ge_p3 p, const uint8_t *s) {
   for (i = 255; i >= 0; --i) {
     uint8_t b = (s[i / 8] >> (i & 7)) & 1;
     ge_p3 tmp;
-    int j;
+
+    /* p = 2 * p (unified formula handles the doubling case) */
+    for (j = 0; j < 4; ++j) set25519(tmp[j], p[j]);
+    add_points(p, tmp);
+
+    /* tmp = p + bp */
     for (j = 0; j < 4; ++j) set25519(tmp[j], p[j]);
     add_points(tmp, bp);
-    /* constant-time select */
+
+    /* p = b ? tmp : p   (sel25519 swaps when b=1, leaves when b=0) */
     for (j = 0; j < 4; ++j) sel25519(p[j], tmp[j], b);
-    {
-      ge_p3 bp2;
-      for (j = 0; j < 4; ++j) set25519(bp2[j], bp[j]);
-      add_points(bp2, bp);
-      for (j = 0; j < 4; ++j) set25519(bp[j], bp2[j]);
-    }
   }
 }
 
@@ -288,29 +301,16 @@ static void scalarmult(ge_p3 p, const uint8_t *s, const ge_p3 q) {
   for (i = 255; i >= 0; --i) {
     uint8_t b = (s[i / 8] >> (i & 7)) & 1;
     ge_p3 tmp;
+
+    /* p = 2 * p */
+    for (j = 0; j < 4; ++j) set25519(tmp[j], p[j]);
+    add_points(p, tmp);
+
+    /* tmp = p + q */
     for (j = 0; j < 4; ++j) set25519(tmp[j], p[j]);
     add_points(tmp, q);
+
     for (j = 0; j < 4; ++j) sel25519(p[j], tmp[j], b);
-    /* double in place */
-    {
-      gf a2, b2, c2, e2, f2, g2, h2;
-      S(a2, p[0]);
-      S(b2, p[1]);
-      S(c2, p[2]);
-      A(c2, c2, c2);
-      A(h2, p[0], p[1]);
-      S(h2, h2);
-      Z(e2, h2, a2);
-      Z(e2, e2, b2);
-      Z(g2, b2, a2);
-      /* Note: for curve25519, a = -1, so this needs care */
-      /* Actually for Ed25519 doubling: */
-      /* A = X1^2, B = Y1^2, C = 2*Z1^2, H = (X1+Y1)^2 */
-      /* E = H-A-B, G = A+B (since a=-1, D_coeff = -A+B, but ref uses A+B differently) */
-      /* This simplified approach may not be exactly right for doubling. */
-      /* We rely on the repeated add_points(bp, bp) in scalarmult_base instead. */
-      (void)f2; (void)g2; (void)e2; (void)a2; (void)b2; (void)c2; (void)h2;
-    }
   }
 }
 

--- a/tests/sof_verify_at_rest_test.c
+++ b/tests/sof_verify_at_rest_test.c
@@ -1,0 +1,263 @@
+/**
+ * @file sof_verify_at_rest_test.c
+ * @brief Re-sign discipline + verify-at-rest tests (issue #138).
+ *
+ * Purpose:
+ *   Locks down the contract that a SOF binary signed by sof_build_signed,
+ *   persisted to disk, re-read into a separate buffer, and parsed again,
+ *   verifies successfully via sof_verify_signature against the chain
+ *   rooted at SECUREOS_ROOT_PUBLIC_KEY. Companion negative case asserts
+ *   that a single-byte mutation of the persisted signature bytes is
+ *   rejected by the verifier.
+ *
+ *   This is the at-rest counterpart to the in-memory roundtrip in
+ *   tests/codesign_test.c (#131/PR #132) and the RFC 8032 known-answer
+ *   coverage in tests/ed25519_kat_test.c (#137/PR #143). Together the
+ *   three lock down: math (KAT) -> in-memory roundtrip -> on-disk
+ *   roundtrip.
+ *
+ *   Specifically asserts the regression risk #138 calls out: that after
+ *   the #133 / PR #134 ed25519 fix lands, a signature produced by the
+ *   corrected signer and persisted to disk verifies cleanly when re-read,
+ *   so no committed artifact ends up trusted-by-broken-symmetry.
+ *
+ * Interactions:
+ *   - kernel/format/sof.c: sof_build_signed / sof_parse / sof_verify_signature
+ *   - kernel/crypto/{sha512,ed25519,cert}.c: crypto primitives
+ *   - kernel/crypto/root_key.h: trust anchor + intermediate seed
+ *
+ * Launched by:
+ *   build/scripts/test_sof_verify_at_rest.sh compiles and runs this test.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../kernel/crypto/sha512.h"
+#include "../kernel/crypto/ed25519.h"
+#include "../kernel/crypto/cert.h"
+#include "../kernel/crypto/root_key.h"
+#include "../kernel/format/sof.h"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+static void check(const char *label, int condition) {
+  if (condition) {
+    printf("  PASS: %s\n", label);
+    ++g_pass;
+  } else {
+    printf("  FAIL: %s\n", label);
+    ++g_fail;
+  }
+}
+
+/* Build a minimal valid ELF that carries `payload` as a single PT_LOAD. */
+static size_t build_test_elf(uint8_t *buf, size_t buf_size, const char *payload) {
+  const size_t ehdr = 52;
+  const size_t phdr = 32;
+  const size_t seg = ehdr + phdr;
+  size_t slen = strlen(payload);
+  size_t total = seg + slen;
+  size_t i;
+
+  if (total > buf_size) return 0;
+  memset(buf, 0, buf_size);
+
+  buf[0] = 0x7F; buf[1] = 'E'; buf[2] = 'L'; buf[3] = 'F';
+  buf[4] = 1; buf[5] = 1; buf[6] = 1;
+  buf[16] = 2; buf[18] = 3; buf[20] = 1;
+  buf[24] = 0x00; buf[25] = 0x10;
+  buf[28] = (uint8_t)ehdr;
+  buf[40] = (uint8_t)ehdr;
+  buf[42] = (uint8_t)phdr;
+  buf[44] = 1;
+
+  buf[ehdr] = 1;
+  buf[ehdr + 4] = (uint8_t)seg;
+  buf[ehdr + 8] = 0x00; buf[ehdr + 9] = 0x10;
+  buf[ehdr + 12] = 0x00; buf[ehdr + 13] = 0x10;
+  buf[ehdr + 16] = (uint8_t)(slen & 0xFF);
+  buf[ehdr + 17] = (uint8_t)((slen >> 8) & 0xFF);
+  buf[ehdr + 20] = (uint8_t)(slen & 0xFF);
+  buf[ehdr + 21] = (uint8_t)((slen >> 8) & 0xFF);
+
+  for (i = 0; i < slen; ++i) {
+    buf[seg + i] = (uint8_t)payload[i];
+  }
+  return total;
+}
+
+/* Write `len` bytes of `data` to `path`. Returns 1 on success, 0 on error. */
+static int write_all(const char *path, const uint8_t *data, size_t len) {
+  FILE *fp = fopen(path, "wb");
+  if (fp == NULL) return 0;
+  size_t n = fwrite(data, 1, len, fp);
+  fclose(fp);
+  return (n == len) ? 1 : 0;
+}
+
+/* Read up to `max` bytes from `path` into `out`. Returns bytes read, or 0 on error. */
+static size_t read_all(const char *path, uint8_t *out, size_t max) {
+  FILE *fp = fopen(path, "rb");
+  if (fp == NULL) return 0;
+  size_t n = fread(out, 1, max, fp);
+  fclose(fp);
+  return n;
+}
+
+/* Build a signed SOF blob for the test payload, sharing the cert + key
+ * derivation path used by kernel/fs/fs_service.c and tools/sof_wrap. */
+static int build_signed(uint8_t *sof_buf, size_t sof_buf_size, size_t *sof_len_out) {
+  uint8_t elf[512];
+  uint8_t root_pub[32], root_priv[64];
+  uint8_t inter_pub[32], inter_priv[64];
+  secureos_cert_t cert;
+  uint8_t cert_data[SECUREOS_CERT_TOTAL_SIZE];
+  sof_build_params_t params;
+  size_t elf_len;
+
+  ed25519_create_keypair(SECUREOS_ROOT_SEED, root_pub, root_priv);
+  ed25519_create_keypair(SECUREOS_INTERMEDIATE_SEED, inter_pub, inter_priv);
+
+  cert_build(root_pub, root_priv, inter_pub, &cert);
+  cert_serialize(&cert, cert_data);
+
+  elf_len = build_test_elf(elf, sizeof(elf), "print [at-rest] hello\n");
+  if (elf_len == 0) return 0;
+
+  memset(&params, 0, sizeof(params));
+  params.file_type = SOF_TYPE_BIN;
+  params.name = "atrest";
+  params.description = "verify-at-rest test payload";
+  params.author = "SecureOS";
+  params.version = "1.0";
+  params.date = "2026-05-16";
+  params.elf_payload = elf;
+  params.elf_payload_size = elf_len;
+
+  return (sof_build_signed(&params, inter_priv, inter_pub,
+                           cert_data, SECUREOS_CERT_TOTAL_SIZE,
+                           sof_buf, sof_buf_size, sof_len_out) == SOF_OK) ? 1 : 0;
+}
+
+static void test_signed_persists_and_verifies(const char *path) {
+  uint8_t sof_built[2048];
+  uint8_t sof_read[2048];
+  size_t sof_len = 0u;
+  size_t read_len = 0u;
+  sof_parsed_file_t parsed;
+
+  printf("[test_signed_persists_and_verifies]\n");
+
+  check("build_signed ok", build_signed(sof_built, sizeof(sof_built), &sof_len) == 1);
+  check("sof_len > 0", sof_len > 0);
+
+  /* Persist to disk, then re-read into a *separate* buffer so we exercise
+   * the full at-rest path (no in-memory shortcut). */
+  check("write_all ok", write_all(path, sof_built, sof_len) == 1);
+  read_len = read_all(path, sof_read, sizeof(sof_read));
+  check("read_all matches written length", read_len == sof_len);
+  check("read bytes match written bytes",
+        memcmp(sof_built, sof_read, sof_len) == 0);
+
+  check("sof_parse ok (re-read)", sof_parse(sof_read, read_len, &parsed) == SOF_OK);
+  check("has_signature (re-read)", parsed.has_signature == 1);
+  check("verify ok (re-read)",
+        sof_verify_signature(sof_read, read_len, &parsed) == SOF_OK);
+}
+
+static void test_at_rest_signature_flip_rejected(const char *path) {
+  uint8_t sof_built[2048];
+  uint8_t sof_read[2048];
+  size_t sof_len = 0u;
+  size_t read_len = 0u;
+  sof_parsed_file_t parsed;
+  sof_result_t verify_result;
+
+  printf("[test_at_rest_signature_flip_rejected]\n");
+
+  check("build_signed ok", build_signed(sof_built, sizeof(sof_built), &sof_len) == 1);
+  check("write_all ok", write_all(path, sof_built, sof_len) == 1);
+  read_len = read_all(path, sof_read, sizeof(sof_read));
+  check("read_all matches written length", read_len == sof_len);
+
+  /* Locate the signature in the on-disk image via sof_parse, then flip a
+   * single byte inside the signature region of the re-read buffer. */
+  check("sof_parse ok (pre-flip)", sof_parse(sof_read, read_len, &parsed) == SOF_OK);
+  check("has_signature (pre-flip)", parsed.has_signature == 1);
+
+  /* The signature section is [cert (132 bytes)][ed25519 sig (64 bytes)].
+   * Flip a byte inside the trailing Ed25519 signature region (last byte of
+   * the section) so cert parsing still succeeds and the verify failure is
+   * unambiguously the signature comparison, not cert parse. */
+  size_t sig_offset = parsed.header.sig_offset;
+  size_t sig_size = parsed.header.sig_size;
+  check("sig_offset in bounds", sig_offset > 0 && sig_offset + sig_size <= read_len);
+  check("sig_size = cert + ed25519",
+        sig_size == SECUREOS_CERT_TOTAL_SIZE + ED25519_SIGNATURE_SIZE);
+
+  size_t flip_at = sig_offset + sig_size - 1u;
+  sof_read[flip_at] ^= 0x01;
+
+  /* Re-parse to refresh the parsed view, then verify must fail. */
+  check("sof_parse ok (post-flip)", sof_parse(sof_read, read_len, &parsed) == SOF_OK);
+  verify_result = sof_verify_signature(sof_read, read_len, &parsed);
+  check("verify rejects bit-flipped on-disk signature",
+        verify_result != SOF_OK);
+}
+
+static void test_at_rest_payload_flip_rejected(const char *path) {
+  uint8_t sof_built[2048];
+  uint8_t sof_read[2048];
+  size_t sof_len = 0u;
+  size_t read_len = 0u;
+  sof_parsed_file_t parsed;
+
+  printf("[test_at_rest_payload_flip_rejected]\n");
+
+  check("build_signed ok", build_signed(sof_built, sizeof(sof_built), &sof_len) == 1);
+  check("write_all ok", write_all(path, sof_built, sof_len) == 1);
+  read_len = read_all(path, sof_read, sizeof(sof_read));
+  check("read_all matches written length", read_len == sof_len);
+
+  check("sof_parse ok (pre-flip)", sof_parse(sof_read, read_len, &parsed) == SOF_OK);
+  check("has_signature (pre-flip)", parsed.has_signature == 1);
+
+  /* Flip a payload byte (inside the ELF region) — verify must fail. */
+  size_t payload_offset = parsed.header.payload_offset;
+  size_t payload_size = parsed.header.payload_size;
+  check("payload_offset in bounds",
+        payload_offset > 0 && payload_offset + payload_size <= read_len);
+  check("payload non-empty", payload_size > 0);
+
+  sof_read[payload_offset] ^= 0x01;
+
+  check("sof_parse ok (post-flip)", sof_parse(sof_read, read_len, &parsed) == SOF_OK);
+  check("verify rejects bit-flipped on-disk payload",
+        sof_verify_signature(sof_read, read_len, &parsed) != SOF_OK);
+}
+
+int main(int argc, char **argv) {
+  const char *path = "/tmp/sof_verify_at_rest_test.sof";
+  if (argc > 1) path = argv[1];
+
+  printf("TEST:START:sof_verify_at_rest\n");
+
+  test_signed_persists_and_verifies(path);
+  test_at_rest_signature_flip_rejected(path);
+  test_at_rest_payload_flip_rejected(path);
+
+  (void)remove(path);
+
+  printf("Results: %d passed, %d failed\n", g_pass, g_fail);
+
+  if (g_fail == 0) {
+    printf("TEST:PASS:sof_verify_at_rest\n");
+    return 0;
+  }
+  printf("TEST:FAIL:sof_verify_at_rest\n");
+  return 1;
+}


### PR DESCRIPTION
Refs #138. Stacked on top of PR #134 (issue-133-ed25519-scalarmult-fix) — same staging pattern PR #143 used for #137's RFC 8032 KAT.

## What this PR adds

A new `tests/sof_verify_at_rest_test.c` + `build/scripts/test_sof_verify_at_rest.sh` that lock down the **at-rest** contract called out in #138: a SOF binary produced by `sof_build_signed`, persisted to disk, re-read into a *separate* buffer, and re-parsed, must verify successfully via `sof_verify_signature` against the chain rooted at `SECUREOS_ROOT_PUBLIC_KEY`.

This is intentionally the on-disk counterpart of:

- `tests/codesign_test.c` (in-memory roundtrip — #131 / PR #132)
- `tests/ed25519_kat_test.c` (RFC 8032 §7.1 known-answer math — #137 / PR #143)

Three test cases, 26 sub-checks:

- `test_signed_persists_and_verifies` — `sof_build_signed` → `fopen/fwrite` → `fopen/fread` into a *separate* buffer → `sof_parse` → `sof_verify_signature == SOF_OK`. Also asserts written bytes == re-read bytes so the test cannot pass on an in-memory shortcut.
- `test_at_rest_signature_flip_rejected` — flip the **last** byte of the signature section in the re-read buffer (so cert parse still succeeds and the failure unambiguously attributes to the Ed25519 signature compare): verify must return non-`SOF_OK`. Also asserts `sig_size == SECUREOS_CERT_TOTAL_SIZE + ED25519_SIGNATURE_SIZE`.
- `test_at_rest_payload_flip_rejected` — flip the first ELF payload byte in the re-read buffer: verify must return non-`SOF_OK`.

The shared `build_signed()` helper uses the same key derivation path the kernel uses on the real load path (`SECUREOS_ROOT_SEED` / `SECUREOS_INTERMEDIATE_SEED` from `kernel/crypto/root_key.h`, `cert_build` + `cert_serialize` matching `kernel/fs/fs_service.c:874` and `tools/sof_wrap/main.c:204`), so the test exercises the chain the kernel actually trusts.

## Why this matters (motivation from #138)

#133 documents that today's `kernel/crypto/ed25519.c` is broken on both sides (signer + verifier). The two wrong answers happen to agree, so nothing in CI catches it. Once #133 / PR #134 lands, that symmetry breaks: any pre-existing signed artifact in the tree (or staged into `secureos-disk.img`) signed by the *old* signer will be **rejected** by the *new* verifier — silently breaking boot for `kernel_console` / `kernel_filedemo` / `kernel_persistence` / `app_runtime`.

This test directly exercises that risk:

- **On `main` today** (without #134): the positive case `verify ok (re-read)` **fails** — exactly because the verifier can't accept its own signer's output. That's the regression #138 is calling out.
- **On top of PR #134**: 26/26 sub-checks PASS — the corrected signer's output round-trips cleanly through the corrected verifier when persisted.

## Audit list (#138 done-when item 1)

Per the issue's first done-when bullet, here is every place in the tree that calls `sof_build_signed` or otherwise embeds a signature into a tracked artifact:

| Call site | When it runs | What it produces | At-rest in repo? |
|---|---|---|---|
| `tools/sof_wrap/main.c:204` | host build time, invoked by `build/scripts/build_os_command.sh:43`, `build_user_app.sh:123`, `build_user_lib.sh:59` | per-binary signed SOF wrapping an ELF, with cert | **No** — `artifacts/` is gitignored; never committed |
| `kernel/fs/fs_service.c:874` | runtime inside `fs_service_init()` | seeded `/apps/filedemo.bin` etc. inside the in-memory ramdisk | **No** — generated each boot |
| `tests/codesign_test.c` (multiple) | host test time | in-memory test SOFs | **No** — never persisted |
| `tests/sof_verify_at_rest_test.c` (new in this PR) | host test time | temp file under `artifacts/tests/` | **No** — `rm -f` after run |
| `tools/populate_disk_image.py` | host build time, invoked by `build/scripts/build_disk_image.sh:67` | copies `artifacts/os/*.bin` + `artifacts/lib/*.lib` + `artifacts/user/*.bin` (all already-signed by `sof_wrap`) into `secureos-disk.img` | **No** — `secureos-disk.img` lives under `artifacts/disk/` (also gitignored) |

`git ls-files | grep -E '\.(sof|bin)$'` returns **zero** tracked binaries (verified in this PR). So there is no committed pre-signed artifact that can survive across the #133 fix — every signature in the build pipeline is recomputed on each build by `sof_wrap` from source, and the at-rest path under `secureos-disk.img` is regenerated by `build_disk_image.sh` on every CI run.

That means the at-rest regression risk in #138 reduces to: *"does a freshly-signed binary verify after it's been written to disk and re-read?"* — which is precisely what the new test asserts.

## Validation

On top of PR #134 (`origin/issue-133-ed25519-scalarmult-fix` @ e79bd33):

```
$ bash build/scripts/test.sh sof_verify_at_rest
[test_sof_verify_at_rest] compiling...
[test_sof_verify_at_rest] running...
TEST:START:sof_verify_at_rest
[test_signed_persists_and_verifies]
  PASS: build_signed ok
  PASS: sof_len > 0
  PASS: write_all ok
  PASS: read_all matches written length
  PASS: read bytes match written bytes
  PASS: sof_parse ok (re-read)
  PASS: has_signature (re-read)
  PASS: verify ok (re-read)
[test_at_rest_signature_flip_rejected]
  ... 9 PASS ...
[test_at_rest_payload_flip_rejected]
  ... 9 PASS ...
Results: 26 passed, 0 failed
TEST:PASS:sof_verify_at_rest
```

On `main` today (without #134), the positive case fails with `FAIL: verify ok (re-read)` — that failure mode is the regression #138 calls out, not a bug in this test.

## Acceptance mapping (#138)

- [x] Audit list of every `sof_build_signed` / signature-embedding call site (table above; no committed signed artifacts found).
- [x] New positive+negative test: `tests/sof_verify_at_rest_test.c` — `sof_build_signed` then `sof_verify_signature == SOF_OK` (positive), single-byte flip in signature region and payload region each reject (negative).
- [x] Uses the same key derivation path as the real signing path (`SECUREOS_ROOT_SEED` / `SECUREOS_INTERMEDIATE_SEED`), so once #137's KAT lands the math is RFC-validated end-to-end.
- [ ] **Deferred to follow-up:** demonstrating `kernel_filedemo` / `kernel_persistence` / `kernel_console` / `kernel_sessions` / `app_runtime` still pass on top of #134 — those require the QEMU + disk-image perms CI path (#106 / PR #107), which is still in the merge-queue unblock chain per #126 / #139. Best surfaced once that chain clears.
- [ ] **Out of scope here:** `tools/sof_wrap/sof_wrap` pre-built / `+x` discipline — already addressed by #101 / PR #104.

## Dependencies / sequencing

- **Stacked on PR #134** (`issue-133-ed25519-scalarmult-fix`). Will need to be re-targeted to `main` after #134 merges; happy to rebase or you can change the base branch via the GitHub UI.
- Per #126 / #139, the merge queue is jammed on `#104 → #107 → #125 → #134`. CI signal on this PR may be red until that chain clears (workflow scripts / disk-image perms), but the `test_sof_verify_at_rest.sh` invocation itself is independent of those blockers.
- Deliberately **NOT** added to `build/scripts/validate_bundle.sh` `TEST_TARGETS` in this PR — same discipline PR #143 used for `ed25519_kat`. The bundle add should be a small follow-up after #134 + this PR land, alongside the `codesign` / `ed25519` / `cert_chain` bundle expansion already tracked in #129.

— autonomous cron pass 2026-05-16T12:17Z (cron:secureos-hourly-issue-work)
