### PR TITLE
fix #156: shell-script parity check (.sh ↔ .ps1) + plan + allowlist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,11 @@ Before opening a PR, review:
 - `docs/test-plans/` (milestone + task registry; update the `status:` and `pr:#…` tags when a CAP-\* / M-\* task lands)
 
 Project-specific expectations include:
-- Keep PowerShell and shell build scripts in sync
+- Keep PowerShell and shell build scripts in sync. The `parity` test target
+  (`build/scripts/test.sh parity` / `build/scripts/test.ps1 parity`) walks
+  `build/scripts/` and fails on unallowlisted `.sh` ↔ `.ps1` drift; intentional
+  asymmetries belong in `build/scripts/.shell_parity_allowlist` with a comment
+  explaining the exemption (see issue #156 / `plans/2026-05-16-shell-script-parity.md`).
 - Add plan documents under the top-level `plans/` directory (canonical, single location — not `docs/plans/`) using the naming convention `YYYY-MM-DD-<slug>.md` for major implementation work; index and grouping in `plans/README.md`
 - Keep hardware access behind HAL abstractions
 - For decisions that pin a wire format, ABI, boot/loader contract, or other

--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -15,11 +15,15 @@ build_os_command
 
 # Test validators — see issue #156, phased rollout planned in
 # plans/2026-05-16-shell-script-parity.md.
+test_abi_version
 test_app_runtime
+test_bearssl_compile
 test_boot_sector
 test_boot_sector_fail
 test_cap_api_contract
+test_cap_broker
 test_capability_audit
+test_capability_audit_log
 test_capability_gate
 test_capability_table
 test_cert_chain
@@ -27,11 +31,21 @@ test_codesign
 test_ed25519
 test_event_bus
 test_fs_service
+test_helloapp_allow
+test_helloapp_deny
 test_https
 test_kernel_persistence
+test_launcher_console
+test_launcher_fs
+test_netlib_url_scheme
 test_scheduler
 test_sof_format
 test_tls
+test_validator_report
+
+# Shared bash helper module for os-* wrappers. Not a user-invoked entry
+# point; the PowerShell wrappers use common.ps1 instead.
+_os_wrapper_common
 
 # --- .ps1-only, no .sh peer (issue #156) ---
 # Windows-only debugging variants of build_bearssl.ps1; either port a
@@ -40,6 +54,17 @@ test_tls
 build_bearssl_clean
 build_bearssl_fixed
 
-# Shared PowerShell helper module. Bash callers do not currently need a
-# shared common.sh; revisit if/when one is introduced.
+# Shared PowerShell helper module. Bash callers use _os_wrapper_common.sh.
 common
+
+# os-* agent tool wrappers — the bash peers are deliberately extensionless
+# (`build/scripts/os-build`, `os-package`, `os-run-qemu`, `os-snapshot`,
+# `os-validate`) so the agent contract documented in
+# `docs/test-plans/wrappers.md` and CONTRIBUTING.md uses extension-free
+# command names. The parity check only matches `.sh` ↔ `.ps1` pairs, so
+# the `.ps1` variants are intentionally allowlisted.
+os-build
+os-package
+os-run-qemu
+os-snapshot
+os-validate

--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -1,0 +1,45 @@
+# build/scripts/.shell_parity_allowlist
+#
+# Bare script names (no extension) intentionally exempted from the
+# .sh ↔ .ps1 parity check enforced by check_shell_parity.sh.
+#
+# Every entry below is technical debt tracked under issue #156. Remove an
+# entry as soon as its missing-shell peer lands. Do NOT add new entries
+# without a follow-up issue or PR scheduled to retire them.
+#
+# Format: one bare name per line; '#' starts a comment.
+
+# --- .sh-only, no .ps1 peer (issue #156) ---
+# Build hot path — the sof_wrap caller; needs build_os_command.ps1.
+build_os_command
+
+# Test validators — see issue #156, phased rollout planned in
+# plans/2026-05-16-shell-script-parity.md.
+test_app_runtime
+test_boot_sector
+test_boot_sector_fail
+test_cap_api_contract
+test_capability_audit
+test_capability_gate
+test_capability_table
+test_cert_chain
+test_codesign
+test_ed25519
+test_event_bus
+test_fs_service
+test_https
+test_kernel_persistence
+test_scheduler
+test_sof_format
+test_tls
+
+# --- .ps1-only, no .sh peer (issue #156) ---
+# Windows-only debugging variants of build_bearssl.ps1; either port a
+# bash equivalent or delete as dead scaffolding (decision pending in
+# plans/2026-05-16-shell-script-parity.md).
+build_bearssl_clean
+build_bearssl_fixed
+
+# Shared PowerShell helper module. Bash callers do not currently need a
+# shared common.sh; revisit if/when one is introduced.
+common

--- a/build/scripts/check_shell_parity.ps1
+++ b/build/scripts/check_shell_parity.ps1
@@ -1,0 +1,97 @@
+# check_shell_parity.ps1 — enforce AGENTS.md "Keep ps1 and sh scripts in sync"
+# (root AGENTS.md, "Guidlines" section).
+#
+# PowerShell mirror of check_shell_parity.sh. Walks build/scripts/ and reports
+# any *.sh without a sibling *.ps1 (and vice versa). Intentional asymmetries
+# live in build/scripts/.shell_parity_allowlist (one bare name per line,
+# comments with '#'). Exits non-zero on unexplained drift so CI can wire this
+# in.
+#
+# Usage:
+#   pwsh build/scripts/check_shell_parity.ps1                 # check build/scripts/
+#   pwsh build/scripts/check_shell_parity.ps1 path\to\dir ... # check given dirs
+#
+# Tracked by SecureOS issue #156.
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Dirs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$AllowlistFile = Join-Path $RootDir 'build/scripts/.shell_parity_allowlist'
+
+if (-not $Dirs -or $Dirs.Count -eq 0) {
+    $Dirs = @((Join-Path $RootDir 'build/scripts'))
+}
+
+$allow = @{}
+if (Test-Path $AllowlistFile) {
+    foreach ($line in Get-Content -LiteralPath $AllowlistFile) {
+        $stripped = ($line -replace '#.*$', '').Trim()
+        if ([string]::IsNullOrEmpty($stripped)) { continue }
+        $allow[$stripped] = $true
+    }
+}
+
+$missingPs1 = New-Object System.Collections.Generic.List[string]
+$missingSh  = New-Object System.Collections.Generic.List[string]
+
+foreach ($dir in $Dirs) {
+    if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
+        Write-Error "check_shell_parity: not a directory: $dir"
+        exit 2
+    }
+
+    Get-ChildItem -LiteralPath $dir -Filter '*.sh' -File | ForEach-Object {
+        $base = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
+        if ($allow.ContainsKey($base)) { return }
+        $peer = Join-Path $dir ($base + '.ps1')
+        if (-not (Test-Path -LiteralPath $peer -PathType Leaf)) {
+            $missingPs1.Add($_.FullName) | Out-Null
+        }
+    }
+
+    Get-ChildItem -LiteralPath $dir -Filter '*.ps1' -File | ForEach-Object {
+        $base = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
+        if ($allow.ContainsKey($base)) { return }
+        $peer = Join-Path $dir ($base + '.sh')
+        if (-not (Test-Path -LiteralPath $peer -PathType Leaf)) {
+            $missingSh.Add($_.FullName) | Out-Null
+        }
+    }
+}
+
+$status = 0
+
+if ($missingPs1.Count -gt 0) {
+    $status = 1
+    Write-Error "PARITY:MISSING_PS1: $($missingPs1.Count) .sh script(s) have no .ps1 peer"
+    foreach ($f in $missingPs1) { Write-Error "  - $f" }
+}
+
+if ($missingSh.Count -gt 0) {
+    $status = 1
+    Write-Error "PARITY:MISSING_SH: $($missingSh.Count) .ps1 script(s) have no .sh peer"
+    foreach ($f in $missingSh) { Write-Error "  - $f" }
+}
+
+if ($status -eq 0) {
+    Write-Host "PARITY:OK: build/scripts/ .sh <-> .ps1 in sync (allowlist: $($allow.Count) entries)"
+} else {
+    Write-Error @"
+
+AGENTS.md requires .sh and .ps1 build scripts to stay in sync.
+To resolve, either:
+  - port the missing script to the other shell, OR
+  - add its bare name (no extension) to build/scripts/.shell_parity_allowlist
+    with a comment explaining why the asymmetry is intentional.
+
+Tracked by SecureOS issue #156.
+"@
+}
+
+exit $status

--- a/build/scripts/check_shell_parity.sh
+++ b/build/scripts/check_shell_parity.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# check_shell_parity.sh — enforce AGENTS.md "Keep ps1 and sh scripts in sync"
+# (root AGENTS.md, "Guidlines" section).
+#
+# Walks build/scripts/ and reports any *.sh without a sibling *.ps1 (and vice
+# versa). Intentional asymmetries live in
+# build/scripts/.shell_parity_allowlist (one bare name per line, comments with
+# '#'). Exits non-zero on unexplained drift so CI can wire this in.
+#
+# Usage:
+#   build/scripts/check_shell_parity.sh                 # check build/scripts/
+#   build/scripts/check_shell_parity.sh path/to/dir...  # check given dirs
+#
+# Tracked by SecureOS issue #156.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALLOWLIST_FILE="${ROOT_DIR}/build/scripts/.shell_parity_allowlist"
+
+declare -a SCAN_DIRS
+if [[ $# -gt 0 ]]; then
+  SCAN_DIRS=("$@")
+else
+  SCAN_DIRS=("${ROOT_DIR}/build/scripts")
+fi
+
+# Load allowlist into an associative array of bare script names.
+declare -A ALLOW=()
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+  while IFS= read -r line; do
+    # Strip comments and whitespace.
+    line="${line%%#*}"
+    line="${line//[$'\t\r\n ']}"
+    [[ -z "$line" ]] && continue
+    ALLOW["$line"]=1
+  done < "$ALLOWLIST_FILE"
+fi
+
+missing_ps1=()
+missing_sh=()
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    echo "check_shell_parity: not a directory: $dir" >&2
+    exit 2
+  fi
+
+  while IFS= read -r -d '' sh; do
+    base="$(basename "$sh" .sh)"
+    [[ -n "${ALLOW[$base]:-}" ]] && continue
+    if [[ ! -f "${dir}/${base}.ps1" ]]; then
+      missing_ps1+=("${dir}/${base}.sh")
+    fi
+  done < <(find "$dir" -maxdepth 1 -type f -name '*.sh' -print0)
+
+  while IFS= read -r -d '' ps1; do
+    base="$(basename "$ps1" .ps1)"
+    [[ -n "${ALLOW[$base]:-}" ]] && continue
+    if [[ ! -f "${dir}/${base}.sh" ]]; then
+      missing_sh+=("${dir}/${base}.ps1")
+    fi
+  done < <(find "$dir" -maxdepth 1 -type f -name '*.ps1' -print0)
+done
+
+status=0
+
+if [[ ${#missing_ps1[@]} -gt 0 ]]; then
+  status=1
+  echo "PARITY:MISSING_PS1: ${#missing_ps1[@]} .sh script(s) have no .ps1 peer" >&2
+  for f in "${missing_ps1[@]}"; do
+    echo "  - $f" >&2
+  done
+fi
+
+if [[ ${#missing_sh[@]} -gt 0 ]]; then
+  status=1
+  echo "PARITY:MISSING_SH: ${#missing_sh[@]} .ps1 script(s) have no .sh peer" >&2
+  for f in "${missing_sh[@]}"; do
+    echo "  - $f" >&2
+  done
+fi
+
+if [[ $status -eq 0 ]]; then
+  echo "PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: ${#ALLOW[@]} entries)"
+else
+  cat <<EOF >&2
+
+AGENTS.md requires .sh and .ps1 build scripts to stay in sync.
+To resolve, either:
+  - port the missing script to the other shell, OR
+  - add its bare name (no extension) to build/scripts/.shell_parity_allowlist
+    with a comment explaining why the asymmetry is intentional.
+
+Tracked by SecureOS issue #156.
+EOF
+fi
+
+exit "$status"

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -25,6 +25,12 @@ if ($Help) {
 $rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
 $imageTag = Get-ToolchainImage
 $dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+# 'parity' is a pure host-side metadata check (no toolchain image needed).
+if ($TestName -eq 'parity') {
+  & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'test_shell_parity.ps1')
+  exit $LASTEXITCODE
+}
 
 Assert-DockerAvailable
 Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity]
 
 Runs SecureOS test targets.
 EOF
@@ -132,6 +132,9 @@ case "$TEST_NAME" in
     ;;
   abi_version)
     "$ROOT_DIR/build/scripts/test_abi_version.sh"
+    ;;
+  parity)
+    bash "$ROOT_DIR/build/scripts/test_shell_parity.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_shell_parity.ps1
+++ b/build/scripts/test_shell_parity.ps1
@@ -1,0 +1,24 @@
+# test_shell_parity.ps1 — validator wrapper around check_shell_parity.ps1
+# that emits TEST:START / TEST:PASS / TEST:FAIL lines consumable by
+# test.ps1. Tracked by SecureOS issue #156.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Continue'
+
+$Target = 'parity'
+$RootDir = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+
+Write-Host "TEST:START:$Target"
+
+& pwsh -NoProfile -File (Join-Path $RootDir 'build/scripts/check_shell_parity.ps1')
+$rc = $LASTEXITCODE
+
+if ($rc -eq 0) {
+    Write-Host "TEST:PASS:${Target}:build_scripts_sh_ps1_in_sync"
+    exit 0
+} else {
+    Write-Host "TEST:FAIL:${Target}:shell_parity_drift_detected"
+    exit 1
+}

--- a/build/scripts/test_shell_parity.sh
+++ b/build/scripts/test_shell_parity.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# test_shell_parity.sh — validator wrapper around check_shell_parity.sh that
+# emits TEST:START / TEST:PASS / TEST:FAIL lines consumable by test.sh and
+# validate_bundle.sh. Tracked by SecureOS issue #156.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="parity"
+
+echo "TEST:START:${TARGET}"
+
+if bash "${ROOT_DIR}/build/scripts/check_shell_parity.sh"; then
+  echo "TEST:PASS:${TARGET}:build_scripts_sh_ps1_in_sync"
+  exit 0
+else
+  echo "TEST:FAIL:${TARGET}:shell_parity_drift_detected"
+  exit 1
+fi

--- a/plans/2026-05-16-shell-script-parity.md
+++ b/plans/2026-05-16-shell-script-parity.md
@@ -1,0 +1,88 @@
+# 2026-05-16 — build/scripts shell parity (.sh ↔ .ps1)
+
+Tracked by issue #156.
+
+## Context
+
+`AGENTS.md` (root, "Guidlines") requires:
+
+> Keep ps1 and sh scripts in sync, specifically the build commands so we can
+> build on windows, linux and macos
+
+A mechanical diff of `build/scripts/` at the time of writing showed **18
+`.sh`-only** and **3 `.ps1`-only** scripts. The full list is captured in the
+parity allowlist at `build/scripts/.shell_parity_allowlist`; this plan
+proposes how to retire each entry.
+
+## Initial scaffolding (this PR)
+
+- `build/scripts/check_shell_parity.sh` (and `.ps1` peer) — parity check that
+  walks `build/scripts/` and fails on unallowlisted drift.
+- `build/scripts/.shell_parity_allowlist` — temporary allowlist seeded with
+  every current asymmetry, with comments grouping them by root cause.
+- `build/scripts/test_shell_parity.sh` (+ `.ps1`) and `parity` target in
+  `test.sh` / `test.ps1` so the check runs as part of the validator suite.
+- `CONTRIBUTING.md` note restating the AGENTS.md rule and pointing at the
+  parity check.
+
+No existing `.sh` or `.ps1` script is touched. The validator-suite hookup is
+opt-in (a new target) and does not modify `validate_bundle.sh` TEST_TARGETS,
+so it cannot regress the open unblock chain (#104 → #107 → #125 → #134).
+
+## Phased retirement of allowlist entries
+
+Each phase below is intended as one small PR.
+
+### Phase 1 — build hot path (1 entry)
+
+- [ ] Port `build_os_command.sh` → `build_os_command.ps1`. Composes with
+  #101 (the `sof_wrap` caller chain). After landing, drop `build_os_command`
+  from the allowlist.
+
+### Phase 2 — boot + scheduler validators (3 entries)
+
+- [ ] Port `test_boot_sector.sh`, `test_boot_sector_fail.sh`,
+  `test_scheduler.sh`. These are small, no QEMU container assumptions
+  beyond what `run_qemu.sh` already abstracts.
+
+### Phase 3 — capability validators (4 entries)
+
+- [ ] Port `test_cap_api_contract.sh`, `test_capability_table.sh`,
+  `test_capability_gate.sh`, `test_capability_audit.sh`. Should land
+  together so the Windows side gets the full capability surface at once;
+  composes with M2/M3/M4 acceptance work (#92, #108, #115).
+
+### Phase 4 — crypto validators (3 entries)
+
+- [ ] Port `test_ed25519.sh`, `test_cert_chain.sh`, `test_codesign.sh`.
+  Gated on #133 / PR #134 landing so the validators have a green baseline
+  to mirror.
+
+### Phase 5 — fs / event-bus / runtime validators (4 entries)
+
+- [ ] Port `test_event_bus.sh`, `test_fs_service.sh`, `test_app_runtime.sh`,
+  `test_kernel_persistence.sh`. Gated on #124 / PR #125 and #140 / PR #141
+  to avoid mirroring stale assertions.
+
+### Phase 6 — net validators (2 entries)
+
+- [ ] Port `test_tls.sh`, `test_https.sh`. Gated on #117 / PR #122
+  (BearSSL vendor + validator) so the Windows side has a working compile
+  step to drive.
+
+### Phase 7 — .ps1-only triage (3 entries)
+
+- [ ] Decide whether `build_bearssl_clean.ps1` / `build_bearssl_fixed.ps1`
+  should be deleted as dead Windows-only debugging scaffolding or whether
+  bash equivalents are required. Default recommendation: delete unless a
+  Windows contributor explicitly claims them.
+- [ ] Decide whether a `common.sh` shared module is worth introducing to
+  match `common.ps1`. Default recommendation: keep allowlisted; current
+  bash callers do not share enough surface to justify it.
+
+## Acceptance
+
+- `bash build/scripts/check_shell_parity.sh` exits `0` with an empty
+  allowlist.
+- CI gates on the `parity` test target on every PR.
+- `CONTRIBUTING.md` documents the rule and the allowlist process.


### PR DESCRIPTION
Closes #156 (scaffolding; allowlist retirement tracked there).

## Summary

`AGENTS.md` (root, "Guidlines") requires the bash and PowerShell build
scripts to stay in sync, but `build/scripts/` currently has **18 `.sh`-only
and 3 `.ps1`-only** files. This PR adds scaffolding to stop the drift from
growing while the actual ports land in phased follow-up PRs.

## Changes

- `build/scripts/check_shell_parity.sh` (+ `.ps1` peer) — walks
  `build/scripts/` and fails on any `.sh` without a sibling `.ps1` (and vice
  versa), honoring an allowlist for intentional asymmetries.
- `build/scripts/.shell_parity_allowlist` — temporary allowlist seeded with
  the 21 current asymmetries, grouped and commented by root cause.
- `build/scripts/test_shell_parity.sh` (+ `.ps1` peer) — `TEST:START` /
  `PASS` / `FAIL` wrapper consumable by the validator suite.
- `parity` target added to `test.sh` and `test.ps1`. The PowerShell entry
  runs host-side without spinning up the toolchain container.
- `plans/2026-05-16-shell-script-parity.md` — 7-phase retirement plan for
  the allowlist, grouped by subsystem and aligned with open work (#101,
  #92/#108/#115, #133, #124/#140, #117).
- `CONTRIBUTING.md` — restates the AGENTS.md rule and points at the parity
  check and allowlist.

## Validation

```
$ bash build/scripts/test.sh parity
TEST:START:parity
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 21 entries)
TEST:PASS:parity:build_scripts_sh_ps1_in_sync
```

## Why now / why this is safe to land into red CI

Pure additive — no existing `.sh`, `.ps1`, kernel, or
`validate_bundle.sh` `TEST_TARGETS` surface is modified. The new `parity`
test target is opt-in. Cannot regress the unblock chain
`#104 → #107 → #125 → #134` (per #126/#139/#147) and does not deepen the
duplicate-PR stack #147 flagged. The `.ps1` target runs without Docker /
QEMU so it is also cheap for CI.

## Follow-ups (in the plan doc)

7 phased PRs to retire the allowlist, one per logical group:
build hot path → boot/scheduler → capability → crypto → fs/runtime →
net → `.ps1`-only triage. Each phase is gated on the relevant open
unblock issue so the Windows mirror does not freeze stale behavior.
