### PR TITLE
feat(abi): OS_ABI_VERSION=0 anchor + drift-guard test (closes #150)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -310,6 +310,10 @@ Suggested policy:
 - freeze to `1` once SDK beta is announced,
 - maintain compatibility shims for at least one major version.
 
+Code-side source of truth: [`user/include/secureos_abi.h`](user/include/secureos_abi.h).
+Versioning reference and bump rules: [`docs/abi/versioning.md`](docs/abi/versioning.md).
+Drift guard: [`tests/abi_version_test.c`](tests/abi_version_test.c) (registered as `abi_version` in `build/scripts/test.sh` and `build/scripts/validate_bundle.sh`).
+
 ## 8) Immediate Next 14 Tasks (actionable backlog)
 
 1. Add pinned toolchain Dockerfile and lock file.

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|fs_service|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|abi_version|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|fs_service|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -33,6 +33,7 @@ Stop-SecureOSActiveInstances -RootDir $rootDir -ImageTag $imageTag
 $testScript = switch ($TestName) {
   "hello_boot" { "./build/scripts/test_boot_sector.sh; ./build/scripts/run_qemu.sh --test hello_boot" }
   "hello_boot_negative" { "./build/scripts/test_boot_sector_fail.sh; ./build/scripts/run_qemu.sh --test hello_boot_fail" }
+  "abi_version" { "./build/scripts/test_abi_version.sh" }
   "cap_api_contract" { "./build/scripts/test_cap_api_contract.sh" }
   "capability_table" { "./build/scripts/test_capability_table.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|abi_version|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -42,6 +42,9 @@ case "$TEST_NAME" in
   hello_boot_negative)
     "$ROOT_DIR/build/scripts/test_boot_sector_fail.sh"
     "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail
+    ;;
+  abi_version)
+    "$ROOT_DIR/build/scripts/test_abi_version.sh"
     ;;
   cap_api_contract)
     "$ROOT_DIR/build/scripts/test_cap_api_contract.sh"

--- a/build/scripts/test_abi_version.sh
+++ b/build/scripts/test_abi_version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$ROOT_DIR/user/include" \
+  "$ROOT_DIR/user/runtime/secureos_api_stubs.c" \
+  "$ROOT_DIR/tests/abi_version_test.c" \
+  -o "$OUT_DIR/abi_version_test"
+
+"$OUT_DIR/abi_version_test"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -13,6 +13,7 @@ mkdir -p "$RUN_QEMU_DIR" "$RUN_TESTS_DIR"
 TEST_TARGETS=(
   hello_boot
   hello_boot_negative
+  abi_version
   cap_api_contract
   capability_table
   capability_gate

--- a/docs/abi/versioning.md
+++ b/docs/abi/versioning.md
@@ -1,0 +1,83 @@
+# SecureOS ABI Versioning
+
+> Source of truth for the `OS_ABI_VERSION` constant lives in
+> [`user/include/secureos_abi.h`](../../user/include/secureos_abi.h).
+> Any change to that header must be reflected here and exercised by
+> [`tests/abi_version_test.c`](../../tests/abi_version_test.c).
+
+This document is the initial stub created for issue #150 to anchor the
+ABI version constant prescribed by [BUILD_ROADMAP.md §7](../../BUILD_ROADMAP.md#7-abi-and-interface-freeze-plan).
+A fuller reference (manifest schema, capability handle layout, full
+syscall surface) is tracked by issue #93 and may supersede or extend
+this file.
+
+## Constants
+
+`OS_ABI_VERSION` is a packed unsigned 32-bit value:
+
+| Bits   | Field | Current value |
+| ------ | ----- | ------------- |
+| 16..31 | major | `0`           |
+| 0..15  | minor | `0`           |
+
+```c
+#define OS_ABI_VERSION_MAJOR 0u
+#define OS_ABI_VERSION_MINOR 0u
+#define OS_ABI_VERSION (((unsigned int)OS_ABI_VERSION_MAJOR << 16) | \
+                        ((unsigned int)OS_ABI_VERSION_MINOR & 0xFFFFu))
+```
+
+## Accessor
+
+```c
+unsigned int os_get_abi_version(void);
+```
+
+- Information-only. No capability required.
+- Returns the packed `OS_ABI_VERSION` that the runtime stubs (or, in a
+  future build, the kernel syscall surface) were built against.
+- Callers should treat a mismatch versus their compile-time
+  `OS_ABI_VERSION` as a build-environment error: the runtime stubs are
+  out of sync with the headers used to compile the app.
+
+## Policy (per BUILD_ROADMAP §7)
+
+- Start at `OS_ABI_VERSION_MAJOR = 0` during rapid iteration.
+- Freeze to `1` when the public SDK beta is announced
+  (see issue #136, "Plan: M6 public SDK").
+- Maintain compatibility shims for **at least one** previous major
+  version after a bump.
+
+### Bumping rules (pre-SDK-beta, major = 0)
+
+- Additive, backward-compatible changes (new syscall stub, new field at
+  end of a struct): bump **minor** in `secureos_abi.h`.
+- Breaking changes are allowed without a major bump while
+  `OS_ABI_VERSION_MAJOR == 0`, but each one MUST update this document
+  and the test in `tests/abi_version_test.c`.
+
+### Bumping rules (post-SDK-beta, major ≥ 1)
+
+- Additive: bump minor.
+- Breaking: bump major, ship shims for previous major, document the
+  removed/changed surface in a dedicated migration note under
+  `docs/abi/`.
+
+## Test coverage
+
+- `tests/abi_version_test.c` (registered as `abi_version` in
+  `build/scripts/test.sh` and `build/scripts/validate_bundle.sh`)
+  asserts:
+  1. The packed `OS_ABI_VERSION` decomposes back into the major/minor
+     constants (bit-layout sanity).
+  2. `OS_ABI_VERSION_MAJOR == 0` (pinned until SDK beta).
+  3. `os_get_abi_version()` returns the same value the header defines
+     (stale-stub guard).
+
+## Related
+
+- BUILD_ROADMAP.md §7 — policy source
+- Issue #150 — this anchor
+- Issue #93 — full ABI reference (manifest schema, capability handles,
+  syscall surface)
+- Issue #136 — M6 public SDK plan (consumer of this version)

--- a/tests/abi_version_test.c
+++ b/tests/abi_version_test.c
@@ -1,0 +1,66 @@
+/**
+ * @file abi_version_test.c
+ * @brief Asserts OS_ABI_VERSION header constant matches runtime stub.
+ *
+ * Purpose:
+ *   Implements the "stale stub" guard required by issue #150 and
+ *   BUILD_ROADMAP.md §7. If a future change bumps OS_ABI_VERSION in
+ *   secureos_abi.h without updating the runtime accessor (or vice
+ *   versa), this test fails the build before that drift reaches users.
+ *
+ * Interactions:
+ *   - user/include/secureos_abi.h: source of OS_ABI_VERSION constants.
+ *   - user/include/secureos_api.h: declares os_get_abi_version().
+ *   - user/runtime/secureos_api_stubs.c: provides the runtime stub.
+ *
+ * Launched by:
+ *   build/scripts/test_abi_version.sh, invoked via
+ *   build/scripts/test.sh abi_version and registered in
+ *   build/scripts/validate_bundle.sh TEST_TARGETS.
+ */
+
+#include "secureos_abi.h"
+#include "secureos_api.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int failures = 0;
+
+#define EXPECT_EQ_U(actual, expected, label)                                 \
+  do {                                                                       \
+    unsigned int _a = (unsigned int)(actual);                                \
+    unsigned int _e = (unsigned int)(expected);                              \
+    if (_a != _e) {                                                          \
+      fprintf(stderr,                                                        \
+              "FAIL: %s: expected 0x%08x, got 0x%08x\n",                     \
+              (label), _e, _a);                                              \
+      failures++;                                                            \
+    }                                                                        \
+  } while (0)
+
+int main(void) {
+  /* Layout sanity: major must occupy bits 16..31, minor bits 0..15. */
+  EXPECT_EQ_U(OS_ABI_VERSION_MAJOR_OF(OS_ABI_VERSION),
+              OS_ABI_VERSION_MAJOR,
+              "major-of(packed) == OS_ABI_VERSION_MAJOR");
+  EXPECT_EQ_U(OS_ABI_VERSION_MINOR_OF(OS_ABI_VERSION),
+              OS_ABI_VERSION_MINOR,
+              "minor-of(packed) == OS_ABI_VERSION_MINOR");
+
+  /* Roadmap §7: must remain 0 until SDK beta. */
+  EXPECT_EQ_U(OS_ABI_VERSION_MAJOR, 0u,
+              "OS_ABI_VERSION_MAJOR pinned to 0 pre-SDK-beta");
+
+  /* Stale-stub guard: header constant must match runtime accessor. */
+  EXPECT_EQ_U(os_get_abi_version(), OS_ABI_VERSION,
+              "os_get_abi_version() == OS_ABI_VERSION");
+
+  if (failures != 0) {
+    fprintf(stderr, "abi_version_test: %d failure(s)\n", failures);
+    return EXIT_FAILURE;
+  }
+  printf("abi_version_test: ok (OS_ABI_VERSION=0x%08x)\n",
+         (unsigned int)OS_ABI_VERSION);
+  return EXIT_SUCCESS;
+}

--- a/user/include/secureos_abi.h
+++ b/user/include/secureos_abi.h
@@ -1,0 +1,53 @@
+/**
+ * @file secureos_abi.h
+ * @brief SecureOS ABI version constant — single source of truth.
+ *
+ * Purpose:
+ *   Defines the OS_ABI_VERSION constant family as prescribed by
+ *   BUILD_ROADMAP.md §7 ("ABI and Interface Freeze Plan").
+ *
+ *   During the rapid-iteration phase (pre-SDK-beta) OS_ABI_VERSION_MAJOR
+ *   remains 0. It will be frozen to 1 when the public SDK beta is
+ *   announced (see plan: docs/abi/versioning.md and issue #136).
+ *
+ * Interactions:
+ *   - secureos_api.h re-exports the version accessor
+ *     os_get_abi_version() so user apps can query the runtime ABI
+ *     without taking any capability (information-only).
+ *   - user/runtime/secureos_api_stubs.c provides the stub
+ *     implementation that returns OS_ABI_VERSION.
+ *   - tests/abi_version_test.c asserts that the compile-time constant
+ *     matches the runtime accessor — catches stale stubs or header drift.
+ *
+ * Wire layout (u32, packed):
+ *     bits 16..31  major  (currently 0)
+ *     bits  0..15  minor  (currently 0)
+ *
+ * Compatibility policy (per BUILD_ROADMAP §7):
+ *   - Same major: backward-compatible additions only.
+ *   - Major bump: breaking change; one previous major must keep
+ *     compatibility shims for at least one release cycle.
+ */
+
+#ifndef SECUREOS_ABI_H
+#define SECUREOS_ABI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OS_ABI_VERSION_MAJOR 0u
+#define OS_ABI_VERSION_MINOR 0u
+
+#define OS_ABI_VERSION                                                   \
+  (((unsigned int)OS_ABI_VERSION_MAJOR << 16) |                          \
+   ((unsigned int)OS_ABI_VERSION_MINOR & 0xFFFFu))
+
+#define OS_ABI_VERSION_MAJOR_OF(v) (((unsigned int)(v) >> 16) & 0xFFFFu)
+#define OS_ABI_VERSION_MINOR_OF(v) ((unsigned int)(v) & 0xFFFFu)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_ABI_H */

--- a/user/include/secureos_api.h
+++ b/user/include/secureos_api.h
@@ -1,6 +1,8 @@
 #ifndef SECUREOS_API_H
 #define SECUREOS_API_H
 
+#include "secureos_abi.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,6 +46,14 @@ os_status_t os_net_ping(const char *host, char *out_buffer, unsigned int out_buf
 os_status_t os_apps_list(char *out_buffer, unsigned int out_buffer_size);
 os_status_t os_storage_info(char *out_buffer, unsigned int out_buffer_size);
 os_status_t os_get_args(char *out_buffer, unsigned int out_buffer_size);
+
+/*
+ * ABI version query — information-only, requires no capability.
+ * Returns the packed OS_ABI_VERSION (see secureos_abi.h) the runtime
+ * was built against. A mismatch with the caller's compile-time
+ * OS_ABI_VERSION indicates the runtime stubs are stale.
+ */
+unsigned int os_get_abi_version(void);
 
 #ifdef __cplusplus
 }

--- a/user/runtime/secureos_api_stubs.c
+++ b/user/runtime/secureos_api_stubs.c
@@ -318,5 +318,16 @@ os_status_t os_get_args(char *out_buffer, unsigned int out_buffer_size) {
   if (out_buffer != 0 && out_buffer_size > 0u) {
     out_buffer[0] = '\0';
   }
+
   return OS_STATUS_OK;
+}
+
+unsigned int os_get_abi_version(void) {
+  /*
+   * Information-only accessor (no capability required).
+   * Returns the compile-time OS_ABI_VERSION the runtime was built
+   * against; a test asserts this matches the caller's view to catch
+   * stale stubs (see tests/abi_version_test.c).
+   */
+  return OS_ABI_VERSION;
 }


### PR DESCRIPTION
Closes #150.

## What
Establishes `OS_ABI_VERSION` as prescribed by BUILD_ROADMAP.md §7 — a single header source of truth plus a runtime accessor and a drift-guard test, so the upcoming M6 SDK (#136) and ABI reference docs (#93) have a stable code-side anchor to point at.

## Changes
- **`user/include/secureos_abi.h`** — new. Defines `OS_ABI_VERSION_MAJOR=0`, `OS_ABI_VERSION_MINOR=0`, packed `OS_ABI_VERSION` (`(major<<16)|minor`), plus `OS_ABI_VERSION_MAJOR_OF`/`MINOR_OF` decomposers.
- **`user/include/secureos_api.h`** — includes the new header and declares `unsigned int os_get_abi_version(void)` (information-only, no capability).
- **`user/runtime/secureos_api_stubs.c`** — implements `os_get_abi_version()` returning `OS_ABI_VERSION`.
- **`tests/abi_version_test.c`** — new. Asserts bit-layout sanity, `MAJOR==0` pin, and runtime-accessor ↔ header-constant match (catches stale stubs).
- **`build/scripts/test_abi_version.sh`** — new test runner.
- **`build/scripts/test.sh`**, **`build/scripts/test.ps1`**, **`build/scripts/validate_bundle.sh`** — register `abi_version` target. \.sh/\.ps1 parity preserved (also relevant to #156).
- **`docs/abi/versioning.md`** — new stub: layout, accessor contract, bump rules, test-coverage note. Designed to be superseded/extended by #93.
- **`BUILD_ROADMAP.md §7`** — cross-references header, doc, and test.

## Validation
```
$ ./build/scripts/test_abi_version.sh
abi_version_test: ok (OS_ABI_VERSION=0x00000000)

$ ./build/scripts/test_cap_api_contract.sh
TEST:PASS:cap_api_contract_id_stability
TEST:PASS:cap_api_contract_default_deny
TEST:PASS:cap_api_contract_allow
TEST:PASS:cap_api_contract_admin_gated_mutation
TEST:PASS:cap_api_contract_invalid_inputs
```
(cap_api_contract run as a smoke check that touching the stubs/api headers did not break existing consumers.)

## Out of scope (per issue)
- Bumping to `OS_ABI_VERSION=1` — only at SDK beta.
- Manifest schema version field — covered by #93.
- Kernel-side syscall wiring for `os_get_abi_version` — stub returns the constant for now; when the syscall surface lands, the test will still pass (stubs path) and a follow-up can route through the kernel.

## Follow-ups
- #93 can replace/extend `docs/abi/versioning.md` with the full reference.
- #136 (M6 SDK) can now depend on `OS_ABI_VERSION` directly.
- #156 (\.sh/\.ps1 parity): this PR keeps parity for the new target.