### PR TITLE
feat(artifacts): per-run bundle layout + run_qemu.sh run.json (#161)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -194,6 +194,10 @@ Store per-run outputs under `artifacts/runs/<timestamp-or-id>/`:
 
 This enables replay, diffing, and agent postmortems.
 
+See [`docs/test-plans/artifact-bundle.md`](docs/test-plans/artifact-bundle.md) for the
+on-disk layout, `<id>` derivation rule, and the `SECUREOS_RUN_ID` env-var
+contract that keeps all artifacts from one run co-located.
+
 ## 5) Milestones After Boot Slice
 
 ## 5.1 M1: Minimal kernel isolation + IPC skeleton

--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -59,6 +59,65 @@ mkdir -p "$ART_DIR"
 LOG_FILE="$ART_DIR/${TEST_NAME}.log"
 META_FILE="$ART_DIR/${TEST_NAME}.meta.json"
 
+# Per-run bundle layout (BUILD_ROADMAP §4.4, issue #161).
+# Honor SECUREOS_RUN_ID when set by a top-level driver (e.g. validate_bundle.sh)
+# so all artifacts from one run co-locate under artifacts/runs/<id>/.
+if [[ -z "${SECUREOS_RUN_ID:-}" ]]; then
+  SECUREOS_RUN_ID="$(date -u +"%Y%m%dT%H%M%SZ")-$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo nogit)"
+fi
+RUN_DIR="$ROOT_DIR/artifacts/runs/$SECUREOS_RUN_ID"
+RUN_QEMU_DIR="$RUN_DIR/qemu"
+mkdir -p "$RUN_QEMU_DIR"
+RUN_JSON="$RUN_QEMU_DIR/run.json"
+
+finalize_run_bundle() {
+  local rc="$?"
+  # Best-effort: never fail the parent script on bookkeeping issues.
+  set +e
+  if [[ -f "$LOG_FILE" ]]; then cp -f "$LOG_FILE" "$RUN_QEMU_DIR/" 2>/dev/null; fi
+  if [[ -f "$META_FILE" ]]; then cp -f "$META_FILE" "$RUN_QEMU_DIR/" 2>/dev/null; fi
+  TEST_NAME="$TEST_NAME" LOG_FILE="$LOG_FILE" META_FILE="$META_FILE" \
+    RUN_ID="$SECUREOS_RUN_ID" RUN_JSON="$RUN_JSON" RC="$rc" \
+    python3 - <<'PY' 2>/dev/null || true
+import json, os, pathlib
+run_json = pathlib.Path(os.environ["RUN_JSON"])
+test = os.environ["TEST_NAME"]
+meta_path = pathlib.Path(os.environ["META_FILE"])
+meta = {}
+if meta_path.exists():
+    try:
+        meta = json.loads(meta_path.read_text())
+    except Exception:
+        meta = {}
+entry = {
+    "test": test,
+    "logFile": f"qemu/{test}.log",
+    "metaFile": f"qemu/{test}.meta.json" if meta_path.exists() else None,
+    "command": meta.get("command", []),
+    "qemuExitCode": meta.get("qemuExitCode"),
+    "timedOut": meta.get("timedOut"),
+    "markers": meta.get("markers"),
+    "status": meta.get("status", "unknown"),
+    "wrapperExitCode": int(os.environ["RC"]),
+}
+doc = {"schemaVersion": 1, "runId": os.environ["RUN_ID"], "invocations": []}
+if run_json.exists():
+    try:
+        loaded = json.loads(run_json.read_text())
+        if isinstance(loaded, dict) and isinstance(loaded.get("invocations"), list):
+            doc = loaded
+            doc.setdefault("schemaVersion", 1)
+            doc["runId"] = os.environ["RUN_ID"]
+    except Exception:
+        pass
+doc["invocations"].append(entry)
+run_json.parent.mkdir(parents=True, exist_ok=True)
+run_json.write_text(json.dumps(doc, indent=2) + "\n")
+PY
+  exit "$rc"
+}
+trap finalize_run_bundle EXIT
+
 case "$TEST_NAME" in
   hello_boot|hello_boot_fail)
     if [[ "$TEST_NAME" == "hello_boot" ]]; then

--- a/docs/test-plans/artifact-bundle.md
+++ b/docs/test-plans/artifact-bundle.md
@@ -1,0 +1,129 @@
+# Per-run artifact bundle layout (`artifacts/runs/<id>/`)
+
+Status: draft (issue #161, BUILD_ROADMAP §4.4)
+
+This document defines the on-disk layout used for **per-run** build / test /
+QEMU artifacts. The goal is to capture everything needed to replay or
+postmortem a single run into one self-contained directory, so:
+
+- agents can diff two runs by `diff -ru artifacts/runs/A artifacts/runs/B`,
+- the validator JSON (#110) has a canonical home next to the logs/image it
+  describes,
+- the CI matrix harness (#151) can attach one bundle per matrix cell.
+
+## Run id
+
+```
+<id> ::= <UTC-timestamp>-<short-sha>[ -<kind> ]
+<UTC-timestamp> ::= YYYYMMDDThhmmssZ        (date -u +%Y%m%dT%H%M%SZ)
+<short-sha>     ::= git rev-parse --short HEAD
+<kind>          ::= optional, lowercase, e.g. "matrix-cap-deny-net"
+```
+
+The id is chosen by the **top-level driver** (typically `validate_bundle.sh`)
+and propagated to child scripts via the `SECUREOS_RUN_ID` environment
+variable. Child scripts that observe `SECUREOS_RUN_ID` MUST reuse it and
+MUST NOT mint a new one — that is what keeps a single run's artifacts
+co-located.
+
+If `SECUREOS_RUN_ID` is unset, a script writing into the bundle is allowed
+to mint one (using the rule above) so it remains useful when invoked
+standalone.
+
+## Layout
+
+```
+artifacts/runs/<id>/
+├── build_metadata.json          # run id, timestamps, git sha/ref, paths
+├── validator_report.json        # validator summary (schemaVersion=1, #110)
+├── secureos.iso                 # snapshot of the kernel ISO (optional)
+├── qemu/
+│   ├── <test>.log               # raw serial / stdout+stderr capture
+│   ├── <test>.meta.json         # per-invocation metadata (see below)
+│   └── run.json                 # aggregate manifest of qemu invocations in this run
+└── tests/
+    └── <test>_*.json            # per-test summary artifacts (e.g. capability_audit_summary.json)
+```
+
+Notes:
+- All paths inside `validator_report.json` are **relative to the bundle
+  root** (`artifacts/runs/<id>/`) so a bundle can be moved or uploaded
+  whole without rewriting paths.
+- `qemu/<test>.log` is the same content currently written to
+  `artifacts/qemu/<test>.log` (the flat path is preserved for backward
+  compatibility; the run-scoped copy is the canonical replay surface).
+
+### `qemu/run.json`
+
+A small manifest describing every QEMU invocation that belongs to this
+run (today: one entry per call to `run_qemu.sh --test <name>`).
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260517T141800Z-abc1234",
+  "invocations": [
+    {
+      "test": "hello_boot",
+      "logFile": "qemu/hello_boot.log",
+      "metaFile": "qemu/hello_boot.meta.json",
+      "imageSha256": "…",
+      "command": ["qemu-system-x86_64", "…"],
+      "exitCode": 33,
+      "wallClockSeconds": 4,
+      "markers": { "start": true, "pass": true, "fail": false },
+      "status": "pass"
+    }
+  ]
+}
+```
+
+`run.json` is **append-only within a run**: each `run_qemu.sh` invocation
+adds one element to `invocations`. Concurrent invocations within one run
+id are out of scope for the initial implementation (BUILD_ROADMAP §6.1
+matrix harness will revisit if needed).
+
+### `build_metadata.json`
+
+Written by `validate_bundle.sh`. Minimum fields:
+
+```json
+{
+  "runId": "…",
+  "startedAt": "2026-05-17T14:18:00Z",
+  "finishedAt": "2026-05-17T14:21:33Z",
+  "git": { "sha": "…", "ref": "main" },
+  "artifactsRoot": "/abs/path/to/artifacts/runs/<id>"
+}
+```
+
+### `validator_report.json`
+
+Owned by `validate_bundle.sh` (#110). This document does not re-spec the
+report — it only fixes its **location** as `artifacts/runs/<id>/validator_report.json`
+so #110 and #161 agree.
+
+## Cross-platform parity
+
+`build/scripts/run_qemu.ps1` and `build/scripts/validate_bundle.ps1`
+shell out to their `.sh` peers inside the toolchain container, so the
+on-disk layout is produced by exactly one implementation and is
+identical across Linux and Windows hosts. This preserves the AGENTS.md
+sh ↔ ps1 parity rule (#156) without duplicating the layout logic.
+
+## Out of scope (follow-ups)
+
+- Bundle retention / pruning policy.
+- Uploading bundles as CI artifacts.
+- Concurrent multi-process writers to a single `qemu/run.json`.
+- A worked example bundle checked into the repo — once #110 + #161 are
+  both live, capture one canonical bundle under
+  `docs/test-plans/examples/run-sample/` as documentation.
+
+## Related
+
+- BUILD_ROADMAP.md §4.4 (artifact policy)
+- #110 (validator JSON report)
+- #151 (CI matrix harness)
+- #156 (sh ↔ ps1 parity)
+- #109 / PR #113 (test-plans registry — this file lives next to that)


### PR DESCRIPTION
Closes #161 (BUILD_ROADMAP §4.4).

## What

Defines the on-disk layout for `artifacts/runs/<id>/` and wires
`run_qemu.sh` to participate in it without changing its existing flat
`artifacts/qemu/<test>.{log,meta.json}` outputs (backward compatible).

### Files
- **docs/test-plans/artifact-bundle.md** — layout spec, `<id>` derivation
  rule, `SECUREOS_RUN_ID` env-var contract, `qemu/run.json` schema, and
  explicit coordination notes for #110 (validator JSON location) and
  #151 (matrix harness consumes one bundle per cell).
- **build/scripts/run_qemu.sh** — honor `SECUREOS_RUN_ID` (mint one if
  unset using `date -u +%Y%m%dT%H%M%SZ`-`short-sha`), mirror per-invocation
  `.log`/`.meta.json` into `qemu/`, append an entry to `qemu/run.json`
  (schemaVersion=1) on EXIT. Best-effort: never fails the parent script
  on bookkeeping issues; original exit code is preserved via trap.
- **BUILD_ROADMAP.md §4.4** — cross-references the layout doc.
- **.gitignore** — already ignores `artifacts/` (covers `artifacts/runs/`).

## Why this scope

`validate_bundle.sh` already mints `SECUREOS_RUN_ID` and writes
`artifacts/runs/<id>/validator_report.json` + `build_metadata.json`.
The missing piece was a) a documented contract and b) child scripts
(`run_qemu.sh`) honoring the same id so a single run's qemu artifacts
land in the same bundle. This PR is purely additive against that.

## Done-when checklist (issue #161)

- [x] `docs/test-plans/artifact-bundle.md` defines the layout, JSON
      manifest schema, and `<id>` derivation rule.
- [x] `run_qemu.sh` writes per-invocation outputs under
      `artifacts/runs/<id>/qemu/` and emits `run.json` with image hash
      (via meta), qemu commandline, exit code, marker counts.
- [~] `validate_bundle.sh` writes its summary JSON into the same
      `artifacts/runs/<id>/` — **already true today**; doc now pins
      that location as the contract.
- [x] PowerShell parity: `run_qemu.ps1` / `validate_bundle.ps1` shell
      out to their `.sh` peers inside the toolchain container, so the
      layout is produced by exactly one implementation and is identical
      cross-host (#156 rule preserved by construction).
- [x] `.gitignore` already ignores `artifacts/runs/`.
- [ ] Worked example bundle under `docs/test-plans/examples/` — deferred
      to a follow-up once #110 lands the structured report; the doc shows
      the expected `tree` shape in the meantime.

## Validation

```
SECUREOS_RUN_ID=smoke build/scripts/run_qemu.sh --test hello_boot
# -> rc=1 (no fixture in this workspace), run.json valid:
#    invocations[0].test=hello_boot, wrapperExitCode=1
SECUREOS_RUN_ID=smoke build/scripts/run_qemu.sh --test kernel_console
# -> rc=1, run.json now lists [hello_boot, kernel_console] in order
```

`bash -n build/scripts/run_qemu.sh` clean. No existing test surface
touched, so this should not interact with the red-CI unblock chain
(#104 → #107 → #125 → #134).

## Coordination

- **#110**: doc pins `validator_report.json` location only; schema stays
  fully owned by #110.
- **#151**: matrix harness can set `SECUREOS_RUN_ID=<run>-<cell>` per
  cell and get one bundle each, no further plumbing.
- **#156**: parity preserved (single implementation).

## Follow-ups

- Bundle retention / pruning policy.
- Uploading bundles as CI artifacts once layout is exercised by #110/#151.
- Worked example bundle under `docs/test-plans/examples/run-sample/`.