### PR TITLE
feat(wrappers): deterministic os-* agent tool wrappers (closes #162)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -182,6 +182,11 @@ Each wrapper must:
 - include artifact paths,
 - include stable pass/fail fields.
 
+Wrapper contract and JSON envelope: see
+[`docs/test-plans/wrappers.md`](docs/test-plans/wrappers.md). Implementation
+lives under `build/scripts/os-*` (sh + ps1 peers); each wrapper mirrors its
+envelope into `artifacts/runs/<run_id>/<tool>.json` per §4.4.
+
 ## 4.4 Artifact policy
 
 Store per-run outputs under `artifacts/runs/<timestamp-or-id>/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,25 @@ macOS/Linux:
 ./build/scripts/build.sh build-all
 ```
 
+### Agent tool wrappers (`os-*`)
+
+Automated agents (and CI scripts) should prefer the deterministic
+`build/scripts/os-*` wrappers over invoking raw `*.sh` directly. Each
+wrapper emits a stable JSON envelope on stdout and mirrors it into the
+per-run bundle at `artifacts/runs/<run_id>/<tool>.json`:
+
+```bash
+export SECUREOS_RUN_ID="cron-$(date -u +%Y%m%dT%H%M%SZ)"
+./build/scripts/os-build image
+./build/scripts/os-package
+./build/scripts/os-run-qemu --test kernel_console
+./build/scripts/os-validate
+./build/scripts/os-snapshot
+```
+
+Full contract: [`docs/test-plans/wrappers.md`](docs/test-plans/wrappers.md).
+Raw scripts remain supported for humans and ad-hoc invocation.
+
 ### Common build targets
 
 Windows PowerShell:

--- a/build/scripts/_os_wrapper_common.sh
+++ b/build/scripts/_os_wrapper_common.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# _os_wrapper_common.sh — shared helpers for the os-* deterministic agent
+# tool wrappers (BUILD_ROADMAP §4.3 / issue #162).
+#
+# Sourced by os-build, os-package, os-run-qemu, os-validate, os-snapshot.
+#
+# Contract (per wrapper, on stdout AND mirrored into the per-run bundle):
+#   {
+#     "tool":        "os-build" | "os-package" | "os-run-qemu" | "os-validate" | "os-snapshot",
+#     "version":     "1",
+#     "ok":          true | false,
+#     "exit_code":   <int>,
+#     "artifacts":   [ "<path>", ... ],
+#     "started_at":  "YYYY-MM-DDTHH:MM:SSZ",
+#     "finished_at": "YYYY-MM-DDTHH:MM:SSZ",
+#     "reason":      "<short failure description, only when ok=false>"
+#   }
+#
+# Behavior notes:
+#   - Wrappers are intentionally thin: they do not re-implement the underlying
+#     build/test logic, only stabilize the agent-facing surface (#162 scope).
+#   - JSON is always emitted on stdout, regardless of --json (the flag exists
+#     for forward-compat with future human-readable modes).
+#   - The mirrored file lives at
+#         artifacts/runs/<SECUREOS_RUN_ID>/<tool>.json
+#     coordinating with the per-run bundle layout from #161 / validate_bundle.sh.
+
+# Resolve repo root (one level up from build/scripts/).
+OS_WRAPPER_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+OS_WRAPPER_API_VERSION="1"
+
+os_wrapper_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+# Stable run id: prefer caller-provided SECUREOS_RUN_ID, else derive
+# timestamp-shortsha (matches validate_bundle.sh / run_qemu.sh #161 contract).
+os_wrapper_run_id() {
+  if [[ -n "${SECUREOS_RUN_ID:-}" ]]; then
+    printf '%s' "$SECUREOS_RUN_ID"
+    return 0
+  fi
+  local ts sha
+  ts="$(date -u +"%Y%m%dT%H%M%SZ")"
+  if sha="$(git -C "$OS_WRAPPER_ROOT_DIR" rev-parse --short HEAD 2>/dev/null)"; then
+    printf '%s-%s' "$ts" "$sha"
+  else
+    printf '%s' "$ts"
+  fi
+}
+
+# Minimal JSON string escaper: backslash, double-quote, and control chars.
+os_wrapper_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# os_wrapper_emit <tool> <ok 0|1> <exit_code> <started_at> <finished_at> <reason> <artifact...>
+# Prints the JSON to stdout AND writes it into the run bundle.
+os_wrapper_emit() {
+  local tool="$1"; shift
+  local ok_bool="$1"; shift     # "true" / "false"
+  local exit_code="$1"; shift
+  local started_at="$1"; shift
+  local finished_at="$1"; shift
+  local reason="$1"; shift
+  local artifacts=("$@")
+
+  local run_id run_dir out_file
+  run_id="$(os_wrapper_run_id)"
+  run_dir="$OS_WRAPPER_ROOT_DIR/artifacts/runs/$run_id"
+  mkdir -p "$run_dir" 2>/dev/null || true
+  out_file="$run_dir/$tool.json"
+
+  local arts_json="" first=1 a esc
+  for a in "${artifacts[@]}"; do
+    esc="$(os_wrapper_json_escape "$a")"
+    if [[ $first -eq 1 ]]; then
+      arts_json="\"$esc\""
+      first=0
+    else
+      arts_json+=",\"$esc\""
+    fi
+  done
+
+  local reason_field=""
+  if [[ "$ok_bool" == "false" && -n "$reason" ]]; then
+    reason_field=",\"reason\":\"$(os_wrapper_json_escape "$reason")\""
+  fi
+
+  local json
+  json="{\"tool\":\"$tool\",\"version\":\"$OS_WRAPPER_API_VERSION\",\"ok\":$ok_bool,\"exit_code\":$exit_code,\"artifacts\":[${arts_json}],\"started_at\":\"$started_at\",\"finished_at\":\"$finished_at\",\"run_id\":\"$(os_wrapper_json_escape "$run_id")\"$reason_field}"
+
+  printf '%s\n' "$json"
+  printf '%s\n' "$json" > "$out_file" 2>/dev/null || true
+}
+
+# Helper: run a child script, tee its output, then emit JSON.
+# Usage: os_wrapper_run_and_emit <tool> <reason-on-fail> <artifact...> -- <cmd> [args...]
+os_wrapper_run_and_emit() {
+  local tool="$1"; shift
+  local fail_reason="$1"; shift
+  local artifacts=()
+  while [[ $# -gt 0 && "$1" != "--" ]]; do
+    artifacts+=("$1"); shift
+  done
+  [[ "${1:-}" == "--" ]] && shift
+
+  local started finished rc=0
+  started="$(os_wrapper_now)"
+  set +e
+  "$@"
+  rc=$?
+  set -e
+  finished="$(os_wrapper_now)"
+
+  local ok="true" reason=""
+  if [[ $rc -ne 0 ]]; then
+    ok="false"
+    reason="$fail_reason (exit $rc)"
+  fi
+  os_wrapper_emit "$tool" "$ok" "$rc" "$started" "$finished" "$reason" "${artifacts[@]}"
+  return $rc
+}

--- a/build/scripts/os-build
+++ b/build/scripts/os-build
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# os-build — deterministic agent wrapper around build/scripts/build.sh.
+#
+# Issue #162 / BUILD_ROADMAP §4.3. Thin façade: delegates to build.sh,
+# emits a stable JSON summary on stdout, and mirrors it into the per-run
+# artifact bundle at artifacts/runs/<id>/os-build.json (#161).
+#
+# Usage:
+#   os-build [--json] [target]
+# Default target: "image" (matches build.sh default).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_os_wrapper_common.sh
+source "$SCRIPT_DIR/_os_wrapper_common.sh"
+
+WANT_JSON=1  # JSON always emitted; flag kept for forward-compat.
+TARGET="image"
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) WANT_JSON=1; shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: os-build [--json] [target]
+
+Deterministic agent wrapper around build/scripts/build.sh. Always emits a
+JSON summary on stdout (see docs/test-plans/wrappers.md).
+
+Targets are forwarded as-is to build.sh (default: image).
+EOF
+      exit 0
+      ;;
+    *) EXTRA_ARGS+=("$1"); shift ;;
+  esac
+done
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+  TARGET="${EXTRA_ARGS[0]}"
+fi
+
+ART_DIR="$OS_WRAPPER_ROOT_DIR/artifacts"
+# Artifact paths reported are best-effort: build.sh writes here, but exact
+# files depend on the target. We list directory roots the agent can scan.
+ARTIFACTS=("artifacts/iso" "artifacts/kernel" "artifacts/disk")
+
+os_wrapper_run_and_emit "os-build" \
+  "build.sh target=$TARGET failed" \
+  "${ARTIFACTS[@]}" -- \
+  bash "$SCRIPT_DIR/build.sh" "$TARGET"

--- a/build/scripts/os-build.ps1
+++ b/build/scripts/os-build.ps1
@@ -1,0 +1,32 @@
+[CmdletBinding()]
+param(
+  [Parameter(Position=0)]
+  [string]$Target = "image",
+  [switch]$Json,
+  [switch]$Help
+)
+
+# os-build.ps1 — Windows peer of build/scripts/os-build.
+# Issue #162 (BUILD_ROADMAP §4.3). Thin shim that runs the .sh peer inside
+# the pinned toolchain container so the JSON envelope is produced by a
+# single implementation (preserves .sh ↔ .ps1 parity rule #156).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: os-build.ps1 [-Json] [-Target <name>]"
+  Write-Host "Deterministic agent wrapper around build.sh; emits JSON envelope."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+$dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+Assert-DockerAvailable
+Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile
+
+Invoke-ToolchainScript -RootDir $rootDir -ImageTag $imageTag -ScriptText "./build/scripts/os-build $Target"

--- a/build/scripts/os-package
+++ b/build/scripts/os-package
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# os-package — deterministic agent wrapper around build_disk_image.sh.
+#
+# Issue #162 / BUILD_ROADMAP §4.3. Produces the seeded disk image and
+# emits a stable JSON summary. The disk image is the primary "package"
+# artifact today (signed/sealed bundles will be a separate follow-up).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_os_wrapper_common.sh
+source "$SCRIPT_DIR/_os_wrapper_common.sh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: os-package [--json]
+
+Deterministic agent wrapper around build/scripts/build_disk_image.sh.
+Emits JSON {tool:"os-package", ok, artifacts:["artifacts/disk/secureos-disk.img"], ...}
+on stdout and mirrors it into the per-run bundle.
+EOF
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+ARTIFACTS=("artifacts/disk/secureos-disk.img")
+
+os_wrapper_run_and_emit "os-package" \
+  "build_disk_image.sh failed" \
+  "${ARTIFACTS[@]}" -- \
+  bash "$SCRIPT_DIR/build_disk_image.sh"

--- a/build/scripts/os-package.ps1
+++ b/build/scripts/os-package.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+  [switch]$Json,
+  [switch]$Help
+)
+
+# os-package.ps1 — Windows peer of build/scripts/os-package. See #162.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: os-package.ps1 [-Json]"
+  Write-Host "Deterministic agent wrapper around build_disk_image.sh; emits JSON envelope."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+$dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+Assert-DockerAvailable
+Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile
+
+Invoke-ToolchainScript -RootDir $rootDir -ImageTag $imageTag -ScriptText "./build/scripts/os-package"

--- a/build/scripts/os-run-qemu
+++ b/build/scripts/os-run-qemu
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# os-run-qemu — deterministic agent wrapper around build/scripts/run_qemu.sh.
+#
+# Issue #162 / BUILD_ROADMAP §4.3. Forwards arguments to run_qemu.sh,
+# captures the per-test log + meta.json paths into a stable JSON summary,
+# and mirrors that summary into the per-run bundle (#161).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_os_wrapper_common.sh
+source "$SCRIPT_DIR/_os_wrapper_common.sh"
+
+TEST_NAME=""
+FORWARD=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) shift ;;
+    --test)
+      TEST_NAME="${2:-}"
+      FORWARD+=("$1" "${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      cat <<EOF
+Usage: os-run-qemu [--json] --test <name> [run_qemu.sh args...]
+
+Deterministic agent wrapper around build/scripts/run_qemu.sh. Emits JSON
+{tool:"os-run-qemu", ok, exit_code, artifacts:[<log>, <meta.json>], ...}
+on stdout and mirrors it into the per-run bundle.
+EOF
+      exit 0
+      ;;
+    *) FORWARD+=("$1"); shift ;;
+  esac
+done
+
+if [[ -z "$TEST_NAME" ]]; then
+  echo "os-run-qemu: --test <name> is required" >&2
+  os_wrapper_emit "os-run-qemu" "false" 2 \
+    "$(os_wrapper_now)" "$(os_wrapper_now)" "missing --test argument"
+  exit 2
+fi
+
+ARTIFACTS=(
+  "artifacts/qemu/${TEST_NAME}.log"
+  "artifacts/qemu/${TEST_NAME}.meta.json"
+)
+
+os_wrapper_run_and_emit "os-run-qemu" \
+  "run_qemu.sh --test $TEST_NAME failed" \
+  "${ARTIFACTS[@]}" -- \
+  bash "$SCRIPT_DIR/run_qemu.sh" "${FORWARD[@]}"

--- a/build/scripts/os-run-qemu.ps1
+++ b/build/scripts/os-run-qemu.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)]
+  [string]$Test,
+  [switch]$Json,
+  [switch]$Help
+)
+
+# os-run-qemu.ps1 — Windows peer of build/scripts/os-run-qemu. See #162.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: os-run-qemu.ps1 [-Json] -Test <name>"
+  Write-Host "Deterministic agent wrapper around run_qemu.sh; emits JSON envelope."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+$dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+Assert-DockerAvailable
+Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile
+
+Invoke-ToolchainScript -RootDir $rootDir -ImageTag $imageTag -ScriptText "./build/scripts/os-run-qemu --test $Test"

--- a/build/scripts/os-snapshot
+++ b/build/scripts/os-snapshot
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# os-snapshot — deterministic agent wrapper that snapshots the current
+# per-run artifact bundle into a tarball for upload / archival.
+#
+# Issue #162 / BUILD_ROADMAP §4.3. There is no existing snapshot.sh today,
+# so this wrapper provides the minimal stable behavior the contract
+# requires: pack artifacts/runs/<id>/ into artifacts/snapshots/<id>.tar.gz
+# and emit the standard JSON envelope. Future work can extend this to
+# include kernel/disk artifacts and signing (M6 / #136 territory).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_os_wrapper_common.sh
+source "$SCRIPT_DIR/_os_wrapper_common.sh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: os-snapshot [--json]
+
+Packs artifacts/runs/<SECUREOS_RUN_ID>/ into
+artifacts/snapshots/<run_id>.tar.gz and emits the standard JSON envelope.
+If the run bundle does not exist, the snapshot is reported as ok=false
+with reason="run bundle missing".
+EOF
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+RUN_ID="$(os_wrapper_run_id)"
+export SECUREOS_RUN_ID="$RUN_ID"
+RUN_DIR="$OS_WRAPPER_ROOT_DIR/artifacts/runs/$RUN_ID"
+SNAP_DIR="$OS_WRAPPER_ROOT_DIR/artifacts/snapshots"
+SNAP_FILE="$SNAP_DIR/${RUN_ID}.tar.gz"
+
+started="$(os_wrapper_now)"
+
+if [[ ! -d "$RUN_DIR" ]]; then
+  finished="$(os_wrapper_now)"
+  os_wrapper_emit "os-snapshot" "false" 1 "$started" "$finished" \
+    "run bundle missing: $RUN_DIR" \
+    "artifacts/snapshots/${RUN_ID}.tar.gz"
+  exit 1
+fi
+
+mkdir -p "$SNAP_DIR"
+rc=0
+if ! tar -czf "$SNAP_FILE" -C "$OS_WRAPPER_ROOT_DIR/artifacts/runs" "$RUN_ID"; then
+  rc=$?
+fi
+finished="$(os_wrapper_now)"
+
+if [[ $rc -eq 0 ]]; then
+  os_wrapper_emit "os-snapshot" "true" 0 "$started" "$finished" "" \
+    "artifacts/snapshots/${RUN_ID}.tar.gz"
+else
+  os_wrapper_emit "os-snapshot" "false" "$rc" "$started" "$finished" \
+    "tar failed (exit $rc)" \
+    "artifacts/snapshots/${RUN_ID}.tar.gz"
+fi
+exit $rc

--- a/build/scripts/os-snapshot.ps1
+++ b/build/scripts/os-snapshot.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+  [switch]$Json,
+  [switch]$Help
+)
+
+# os-snapshot.ps1 — Windows peer of build/scripts/os-snapshot. See #162.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: os-snapshot.ps1 [-Json]"
+  Write-Host "Tars artifacts/runs/<run_id>/ into artifacts/snapshots/; emits JSON envelope."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+$dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+Assert-DockerAvailable
+Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile
+
+Invoke-ToolchainScript -RootDir $rootDir -ImageTag $imageTag -ScriptText "./build/scripts/os-snapshot"

--- a/build/scripts/os-validate
+++ b/build/scripts/os-validate
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# os-validate — deterministic agent wrapper around build/scripts/validate_bundle.sh.
+#
+# Issue #162 / BUILD_ROADMAP §4.3. validate_bundle.sh already writes its
+# own per-run validator_report.json (#110/#161); this wrapper additionally
+# emits the standard {tool, ok, exit_code, artifacts, ...} envelope on
+# stdout for agents that drive multiple wrappers uniformly.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_os_wrapper_common.sh
+source "$SCRIPT_DIR/_os_wrapper_common.sh"
+
+FORWARD=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: os-validate [--json] [validate_bundle.sh args...]
+
+Deterministic agent wrapper around build/scripts/validate_bundle.sh.
+Emits JSON {tool:"os-validate", ok, exit_code, artifacts, run_id, ...}
+on stdout. The underlying validator continues to write its own structured
+report into artifacts/runs/<run_id>/validator_report.json (#110).
+EOF
+      exit 0
+      ;;
+    *) FORWARD+=("$1"); shift ;;
+  esac
+done
+
+# Ensure parent and child resolve to the same per-run bundle.
+export SECUREOS_RUN_ID="$(os_wrapper_run_id)"
+
+ARTIFACTS=(
+  "artifacts/runs/${SECUREOS_RUN_ID}/validator_report.json"
+  "artifacts/runs/${SECUREOS_RUN_ID}/build_metadata.json"
+)
+
+os_wrapper_run_and_emit "os-validate" \
+  "validate_bundle.sh failed" \
+  "${ARTIFACTS[@]}" -- \
+  bash "$SCRIPT_DIR/validate_bundle.sh" "${FORWARD[@]}"

--- a/build/scripts/os-validate.ps1
+++ b/build/scripts/os-validate.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+  [switch]$Json,
+  [switch]$Help
+)
+
+# os-validate.ps1 — Windows peer of build/scripts/os-validate. See #162.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: os-validate.ps1 [-Json]"
+  Write-Host "Deterministic agent wrapper around validate_bundle.sh; emits JSON envelope."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+$dockerfile = Get-ToolchainDockerfile -RootDir $rootDir
+
+Assert-DockerAvailable
+Ensure-ToolchainImage -RootDir $rootDir -ImageTag $imageTag -Dockerfile $dockerfile
+
+Invoke-ToolchainScript -RootDir $rootDir -ImageTag $imageTag -ScriptText "./build/scripts/os-validate"

--- a/docs/test-plans/wrappers.md
+++ b/docs/test-plans/wrappers.md
@@ -1,0 +1,110 @@
+# Agent Tool Wrapper Contract (`os-*`)
+
+Issue: [#162](https://github.com/rwrife/SecureOS/issues/162) ·
+Roadmap: `BUILD_ROADMAP.md` §4.3 ("Deterministic tool API wrappers")
+
+## Why
+
+Agents (and the cron sessions that drive them) should not invoke raw
+`build/scripts/*.sh` directly. Each raw script has its own argv shape,
+exit-code semantics, and (mostly) no machine-readable output. The
+`os-*` wrappers stabilize that surface so an agent can drive any
+combination of build/test steps with one parsing rule and one place to
+discover artifact paths.
+
+## Wrapper set
+
+| Wrapper       | Wraps                              | Primary artifacts                                      |
+|---------------|------------------------------------|--------------------------------------------------------|
+| `os-build`    | `build.sh <target>`                | `artifacts/iso/`, `artifacts/kernel/`, `artifacts/disk/` |
+| `os-package`  | `build_disk_image.sh`              | `artifacts/disk/secureos-disk.img`                     |
+| `os-run-qemu` | `run_qemu.sh --test <name>`        | `artifacts/qemu/<name>.log`, `artifacts/qemu/<name>.meta.json` |
+| `os-validate` | `validate_bundle.sh`               | `artifacts/runs/<run_id>/validator_report.json`, `build_metadata.json` |
+| `os-snapshot` | tars `artifacts/runs/<run_id>/`    | `artifacts/snapshots/<run_id>.tar.gz`                  |
+
+PowerShell peers (`os-build.ps1`, etc.) live next to each wrapper and
+delegate to the `.sh` peer inside the pinned toolchain container, so
+the JSON envelope is produced by a single implementation across
+Linux / macOS / Windows. This preserves the `.sh ↔ .ps1` parity rule
+(see [#156](https://github.com/rwrife/SecureOS/issues/156)).
+
+## JSON envelope (v1)
+
+Every wrapper writes the same envelope to stdout AND mirrors it into
+the per-run bundle at `artifacts/runs/<run_id>/<tool>.json`:
+
+```json
+{
+  "tool":        "os-build",
+  "version":     "1",
+  "ok":          true,
+  "exit_code":   0,
+  "artifacts":   ["artifacts/iso", "artifacts/kernel", "artifacts/disk"],
+  "started_at":  "2026-05-17T17:30:00Z",
+  "finished_at": "2026-05-17T17:31:42Z",
+  "run_id":      "20260517T173000Z-abc1234"
+}
+```
+
+On failure the envelope also includes a `"reason"` string and `ok` is
+`false`. Exit codes from the underlying script are preserved.
+
+## `run_id` selection
+
+The wrappers reuse the `SECUREOS_RUN_ID` contract from the per-run
+bundle layout
+([#161](https://github.com/rwrife/SecureOS/issues/161) /
+`docs/test-plans/artifact-bundle.md` when present):
+
+1. If `SECUREOS_RUN_ID` is set in the environment, use it verbatim.
+2. Otherwise derive `<UTC timestamp>-<short git sha>`
+   (e.g. `20260517T173000Z-abc1234`).
+
+`os-validate` exports `SECUREOS_RUN_ID` before invoking
+`validate_bundle.sh` so that the wrapper envelope, the validator's
+own structured report (#110), and any sibling `os-run-qemu` calls all
+land in the same `artifacts/runs/<run_id>/` bundle. The matrix
+harness ([#151](https://github.com/rwrife/SecureOS/issues/151)) can
+set `SECUREOS_RUN_ID=<run>-<cell>` per cell and get exactly one
+bundle per matrix cell with no extra plumbing.
+
+## Usage pattern (for agents)
+
+```bash
+export SECUREOS_RUN_ID="cron-$(date -u +%Y%m%dT%H%M%SZ)"
+
+build/scripts/os-build image      | tee /tmp/os-build.json
+build/scripts/os-package          | tee /tmp/os-package.json
+build/scripts/os-run-qemu --test kernel_console | tee /tmp/os-run-qemu.json
+build/scripts/os-validate         | tee /tmp/os-validate.json
+build/scripts/os-snapshot         | tee /tmp/os-snapshot.json
+
+# All five JSON envelopes are also under:
+#   artifacts/runs/$SECUREOS_RUN_ID/{os-build,os-package,os-run-qemu,os-validate,os-snapshot}.json
+```
+
+Agents should parse `ok` first, then read `artifacts[]` and
+`run_id` to locate logs. Treat unknown fields as forward-compatible.
+
+## Coordination
+
+- **#110** `os-validate` does not respec the validator report schema;
+  the validator continues to own `validator_report.json`. The wrapper
+  envelope is additive metadata about *invocation success*, not the
+  validation result content.
+- **#151** Each matrix cell gets its own `SECUREOS_RUN_ID`, hence its
+  own bundle and its own set of envelopes.
+- **#161** Per-run bundle layout is the single home for both the
+  envelopes and the underlying tools' detailed outputs.
+- **#156** Parity is preserved by construction: the `.ps1` peers shell
+  into the container and run the `.sh` peer.
+- **#136 (M6 SDK)** The same wrapper set is the natural seed for the
+  public `os-cc` / `os-pack` / `os-run` family, so freezing this
+  contract now keeps the SDK surface stable.
+
+## Out of scope
+
+- Rewriting the underlying scripts (separate hardening passes per
+  #91 / #129 / #140).
+- Publishing wrappers as a `bin/` on `$PATH` for end users (M6 / #136).
+- Bundle signing or upload (M6 + ADR follow-up).


### PR DESCRIPTION
Closes #162 (BUILD_ROADMAP §4.3).

## What

Adds the five deterministic agent wrappers prescribed by §4.3 as thin
façades over the existing build/test scripts, plus PowerShell peers and
the wrapper contract doc.

| Wrapper | Wraps | Primary artifacts |
|---|---|---|
| `os-build` | `build.sh <target>` | `artifacts/iso/`, `artifacts/kernel/`, `artifacts/disk/` |
| `os-package` | `build_disk_image.sh` | `artifacts/disk/secureos-disk.img` |
| `os-run-qemu` | `run_qemu.sh --test <name>` | `artifacts/qemu/<name>.{log,meta.json}` |
| `os-validate` | `validate_bundle.sh` | `artifacts/runs/<run_id>/validator_report.json` |
| `os-snapshot` | tar `artifacts/runs/<run_id>/` | `artifacts/snapshots/<run_id>.tar.gz` |

## JSON envelope (v1)

Every wrapper writes the same envelope to stdout AND mirrors it to
`artifacts/runs/<run_id>/<tool>.json`:

```json
{
  "tool":        "os-build",
  "version":     "1",
  "ok":          true,
  "exit_code":   0,
  "artifacts":   ["artifacts/iso", "artifacts/kernel", "artifacts/disk"],
  "started_at":  "2026-05-17T17:30:00Z",
  "finished_at": "2026-05-17T17:31:42Z",
  "run_id":      "20260517T173000Z-abc1234"
}
```

On failure: `ok=false` plus a `reason` field; underlying exit code is preserved.

## Implementation notes

- Shared helpers live in `build/scripts/_os_wrapper_common.sh`
  (run-id derivation matches the #161 contract; minimal JSON escaper to
  avoid a `jq` dependency).
- `os-validate` exports `SECUREOS_RUN_ID` before invoking
  `validate_bundle.sh` so wrapper envelope, validator report (#110), and
  sibling `os-run-qemu` calls all land in the same bundle.
- PowerShell peers (`os-*.ps1`) shell into the pinned toolchain
  container and run the `.sh` peer — single implementation, parity
  preserved by construction (#156).
- No underlying scripts were modified; this is a pure additive surface.
  Hardening of the wrapped scripts continues in #91 / #129 / #140.

## Done-when (issue #162)

- [x] `os-build` / `os-package` / `os-run-qemu` / `os-validate` / `os-snapshot` exist as thin wrappers.
- [x] Each wrapper emits the v1 JSON envelope and mirrors it into the per-run bundle.
- [x] PowerShell peers added per AGENTS.md cross-platform rule (#156).
- [x] `docs/test-plans/wrappers.md` documents the contract; agents should prefer wrappers over raw scripts.
- [x] `CONTRIBUTING.md` Build section gets the wrapper usage example. (`README.md` left untouched in this PR — its build sections currently mirror CONTRIBUTING and the wrapper guidance is now a one-link hop away; happy to also update it if maintainers prefer.)

## Coordination

- **#110** Wrapper envelope is invocation metadata; validator continues to own `validator_report.json` schema.
- **#151** Matrix harness can set `SECUREOS_RUN_ID=<run>-<cell>` per cell and get one bundle per cell.
- **#161** Wrapper output location reuses the per-run bundle layout.
- **#156** `.sh ↔ .ps1` parity preserved (single implementation, ps1 shells into container).
- **#136** Same wrapper set seeds the public M6 SDK `os-cc` / `os-pack` / `os-run` family.

## Validation

```
$ bash -n build/scripts/_os_wrapper_common.sh build/scripts/os-*
$ SECUREOS_RUN_ID=wrapper-smoke build/scripts/os-snapshot
{"tool":"os-snapshot","version":"1","ok":false,"exit_code":1,...,"reason":"run bundle missing: ..."}
rc=1

$ mkdir -p artifacts/runs/wrapper-smoke && echo hi > artifacts/runs/wrapper-smoke/dummy.txt
$ SECUREOS_RUN_ID=wrapper-smoke build/scripts/os-snapshot
{"tool":"os-snapshot","version":"1","ok":true,"exit_code":0,"artifacts":["artifacts/snapshots/wrapper-smoke.tar.gz"],...,"run_id":"wrapper-smoke"}
rc=0
# -> tarball produced; envelope mirrored to artifacts/runs/wrapper-smoke/os-snapshot.json
```

No existing test surface touched, so this should not interact with the
red-CI unblock chain (#104 → #107 → #125 → #134).

## Follow-ups

- Wire wrappers into the CI workflow once the underlying unblock chain lands.
- Bundle retention / pruning policy (mentioned in #161 PR #165).
- Promote `build/scripts/os-*` onto `$PATH` for end users as part of M6 (#136).