### PR TITLE
feat(ci): deterministic image-hash check (closes #174)

### DIFF
--- a/.github/workflows/iso-vm-build.yml
+++ b/.github/workflows/iso-vm-build.yml
@@ -44,21 +44,6 @@ jobs:
       - name: VM smoke boot (kernel console)
         run: ./build/scripts/run_qemu.sh --test kernel_console
 
-      - name: Image determinism check (baseline; non-blocking, #174)
-        # Builds the disk image twice from a clean tree and asserts the
-        # two sha256 sums match. Initial baseline is allowed to fail per
-        # the issue contract; result is uploaded under artifacts/runs/.
-        continue-on-error: true
-        run: ./build/scripts/check_image_determinism.sh
-
-      - name: Upload determinism run bundle
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: runs-artifacts
-          path: artifacts/runs/
-          if-no-files-found: warn
-
       - name: Publish ISO to GitHub Release (tag builds)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
@@ -88,4 +73,20 @@ jobs:
         with:
           name: qemu-artifacts
           path: artifacts/qemu/
+          if-no-files-found: warn
+
+      # Run the determinism check AFTER artifact uploads. The script
+      # rebuilds the image from a clean tree (rm -rf artifacts/kernel
+      # artifacts/disk ...), so running it earlier wipes the kernel ISO
+      # before "Upload kernel artifacts" can publish it.
+      - name: Image determinism check (baseline; non-blocking, #174)
+        continue-on-error: true
+        run: ./build/scripts/check_image_determinism.sh
+
+      - name: Upload determinism run bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runs-artifacts
+          path: artifacts/runs/
           if-no-files-found: warn

--- a/.github/workflows/iso-vm-build.yml
+++ b/.github/workflows/iso-vm-build.yml
@@ -44,6 +44,21 @@ jobs:
       - name: VM smoke boot (kernel console)
         run: ./build/scripts/run_qemu.sh --test kernel_console
 
+      - name: Image determinism check (baseline; non-blocking, #174)
+        # Builds the disk image twice from a clean tree and asserts the
+        # two sha256 sums match. Initial baseline is allowed to fail per
+        # the issue contract; result is uploaded under artifacts/runs/.
+        continue-on-error: true
+        run: ./build/scripts/check_image_determinism.sh
+
+      - name: Upload determinism run bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runs-artifacts
+          path: artifacts/runs/
+          if-no-files-found: warn
+
       - name: Publish ISO to GitHub Release (tag builds)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2

--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -293,6 +293,10 @@ Validate:
 
 - no merge on failing boot or capability regression tests
 - require deterministic artifact hashes for release candidates
+  (see `docs/build/determinism.md`; CI step
+  `image-determinism` builds twice and asserts
+  `sha256(secureos-disk.img)` is stable, currently non-blocking baseline
+  per issue #174)
 - require validator-generated pass evidence for milestone closure
 
 ## 7) ABI and Interface Freeze Plan

--- a/build/scripts/check_image_determinism.ps1
+++ b/build/scripts/check_image_determinism.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding()]
+param(
+  [ValidateSet("disk", "image", "both")]
+  [string]$Target = "disk",
+
+  [switch]$Help
+)
+
+# PowerShell parity wrapper for check_image_determinism.sh.
+# Delegates to the .sh implementation inside the pinned toolchain container,
+# matching the cross-platform pattern from AGENTS.md (one implementation,
+# both hosts).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "common.ps1")
+
+if ($Help) {
+  Write-Host "Usage: check_image_determinism.ps1 -Target <disk|image|both>"
+  Write-Host ""
+  Write-Host "Builds the named target twice from a clean tree and asserts the"
+  Write-Host "two sha256 sums match. Writes the result into the per-run"
+  Write-Host "artifact bundle at artifacts/runs/<id>/ (see #161)."
+  exit 0
+}
+
+$rootDir = Get-SecureOSRootDir -ScriptRoot $PSScriptRoot
+$imageTag = Get-ToolchainImage
+
+Push-Location $rootDir
+try {
+  $env:SECUREOS_DET_TARGET = $Target
+  docker run --rm `
+    -v "${rootDir}:/workspace" `
+    -w /workspace `
+    -e "SECUREOS_DET_TARGET=$Target" `
+    -e "SECUREOS_RUN_ID=$($env:SECUREOS_RUN_ID)" `
+    $imageTag `
+    bash -lc './build/scripts/check_image_determinism.sh'
+  exit $LASTEXITCODE
+} finally {
+  Pop-Location
+}

--- a/build/scripts/check_image_determinism.sh
+++ b/build/scripts/check_image_determinism.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# check_image_determinism.sh
+#
+# Builds the SecureOS disk image (and ISO) twice from a clean tree and asserts
+# the two sha256 sums match. On mismatch, prints a debuggable diff summary
+# (`cmp -l | head`, byte counts, optionally `diffoscope` when present).
+#
+# Per BUILD_ROADMAP.md §4.4 (artifacts/runs/<id>/) and §6.3 (deterministic
+# artifact hashes for release candidates). See docs/build/determinism.md.
+#
+# Behavior:
+#   - Honors $SECUREOS_RUN_ID (mints one if unset) so the resulting
+#     image.sha256 lands inside the per-run artifact bundle (#161).
+#   - Default target is the seeded disk image (`build/scripts/build.sh disk`)
+#     because §4.4 names `secureos-disk.img`. Override via
+#     $SECUREOS_DET_TARGET=image to check the kernel ISO instead, or
+#     `both` to check both.
+#   - Exits 0 on match, non-zero on mismatch. Intended to run with
+#     `continue-on-error: true` in CI for the initial baseline (per the
+#     issue #174 contract) until known-bad sources of non-determinism
+#     are fixed in follow-up issues.
+#
+# Out of scope: actually *fixing* non-determinism (timestamps in FAT,
+# unsorted directory entries, embedded build paths, random padding, etc.).
+# This script makes the problem visible and measurable.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TARGET="${SECUREOS_DET_TARGET:-disk}"
+
+# Mint a run id if our parent (validate_bundle.sh, run_qemu.sh, CI) didn't.
+if [[ -z "${SECUREOS_RUN_ID:-}" ]]; then
+  short_sha="$(git rev-parse --short=12 HEAD 2>/dev/null || echo nogit)"
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  export SECUREOS_RUN_ID="${ts}-${short_sha}"
+fi
+
+RUN_DIR="$ROOT_DIR/artifacts/runs/$SECUREOS_RUN_ID"
+mkdir -p "$RUN_DIR"
+
+# Map logical target -> built artifact path.
+artifact_path_for() {
+  case "$1" in
+    disk)  echo "$ROOT_DIR/artifacts/disk/secureos-disk.img" ;;
+    image) echo "$ROOT_DIR/artifacts/kernel/secureos.iso" ;;
+    *)     echo "" ;;
+  esac
+}
+
+build_one() {
+  local what="$1"
+  # Clean to the maximum extent we can without nuking the toolchain cache.
+  rm -rf artifacts/iso artifacts/kernel artifacts/disk artifacts/os artifacts/tests >/dev/null 2>&1 || true
+  case "$what" in
+    disk)  ./build/scripts/build.sh disk ;;
+    image) ./build/scripts/build.sh image ;;
+    *)     echo "[determinism] unknown target: $what" >&2; return 64 ;;
+  esac
+}
+
+check_one_target() {
+  local what="$1"
+  local artifact
+  artifact="$(artifact_path_for "$what")"
+  if [[ -z "$artifact" ]]; then
+    echo "[determinism] unknown target: $what" >&2
+    return 64
+  fi
+
+  echo "[determinism] === target=$what ==="
+  echo "[determinism] build #1"
+  build_one "$what"
+  if [[ ! -f "$artifact" ]]; then
+    echo "[determinism] build #1 did not produce $artifact" >&2
+    return 65
+  fi
+  local h1
+  h1="$(sha256sum "$artifact" | awk '{print $1}')"
+  local copy1="$RUN_DIR/${what}.first.bin"
+  cp "$artifact" "$copy1"
+  echo "[determinism] build #1 sha256=$h1"
+
+  echo "[determinism] build #2"
+  build_one "$what"
+  if [[ ! -f "$artifact" ]]; then
+    echo "[determinism] build #2 did not produce $artifact" >&2
+    return 65
+  fi
+  local h2
+  h2="$(sha256sum "$artifact" | awk '{print $1}')"
+  local copy2="$RUN_DIR/${what}.second.bin"
+  cp "$artifact" "$copy2"
+  echo "[determinism] build #2 sha256=$h2"
+
+  # Always emit the per-target hash record into the run bundle.
+  # File name pattern: image.sha256 (the canonical name per #174), but we
+  # disambiguate when checking multiple targets so neither overwrites the
+  # other.
+  local hash_file
+  if [[ "$what" == "disk" ]]; then
+    hash_file="$RUN_DIR/image.sha256"
+  else
+    hash_file="$RUN_DIR/${what}.sha256"
+  fi
+  {
+    echo "$h1  build1/$(basename "$artifact")"
+    echo "$h2  build2/$(basename "$artifact")"
+  } > "$hash_file"
+
+  if [[ "$h1" == "$h2" ]]; then
+    echo "[determinism] PASS target=$what sha256=$h1"
+    # Replace the two-line record with a single canonical line on success.
+    echo "$h1  $(basename "$artifact")" > "$hash_file"
+    rm -f "$copy1" "$copy2"
+    return 0
+  fi
+
+  echo "[determinism] FAIL target=$what build1=$h1 build2=$h2" >&2
+  echo "[determinism] sizes: $(stat -c '%s' "$copy1") vs $(stat -c '%s' "$copy2")" >&2
+  echo "[determinism] first 32 differing bytes (offset old new):" >&2
+  cmp -l "$copy1" "$copy2" 2>/dev/null | head -n 32 >&2 || true
+  if command -v diffoscope >/dev/null 2>&1; then
+    echo "[determinism] diffoscope summary:" >&2
+    diffoscope --max-text-report-size 4096 --no-progress "$copy1" "$copy2" 2>&1 | head -n 200 >&2 || true
+  else
+    echo "[determinism] (install diffoscope locally for a richer summary)" >&2
+  fi
+  return 1
+}
+
+overall_rc=0
+case "$TARGET" in
+  both)
+    check_one_target disk  || overall_rc=$?
+    check_one_target image || overall_rc=$?
+    ;;
+  disk|image)
+    check_one_target "$TARGET" || overall_rc=$?
+    ;;
+  *)
+    echo "[determinism] SECUREOS_DET_TARGET must be one of: disk | image | both (got: $TARGET)" >&2
+    exit 64
+    ;;
+esac
+
+echo "[determinism] run bundle: $RUN_DIR"
+ls -1 "$RUN_DIR" >&2 || true
+exit "$overall_rc"

--- a/docs/build/determinism.md
+++ b/docs/build/determinism.md
@@ -1,0 +1,91 @@
+# Build determinism (BUILD_ROADMAP §4.4 / §6.3)
+
+This document defines the **deterministic-image contract** used by CI and by
+the `os-snapshot` agent tool wrapper (#162).
+
+## Goal
+
+Given a clean working tree at commit `C`, building the SecureOS disk image
+twice must produce **bit-identical** output:
+
+```
+sha256(build1/secureos-disk.img) == sha256(build2/secureos-disk.img)
+```
+
+Without this guarantee we cannot distinguish a real regression from a
+non-determinism bug (FAT timestamps, unsorted directory entries, embedded
+build paths, random padding, etc.), and snapshots taken by `os-snapshot`
+are not comparable across runs.
+
+## Tooling
+
+- **Script:** `build/scripts/check_image_determinism.sh`
+  (PowerShell peer: `check_image_determinism.ps1`, per AGENTS.md
+  cross-platform rule).
+- **Targets:** `disk` (default, `secureos-disk.img`), `image`
+  (`secureos.iso`), or `both`. Override with
+  `SECUREOS_DET_TARGET=image` or `=both`.
+- **Bundle integration (#161):** result is recorded as
+  `artifacts/runs/<SECUREOS_RUN_ID>/image.sha256` (for the disk target),
+  or `<target>.sha256` for the ISO target. The script honors a parent's
+  `SECUREOS_RUN_ID`; if unset, it mints one with the same
+  `YYYYMMDDTHHMMSSZ-<shortsha>` rule as `validate_bundle.sh` and
+  `run_qemu.sh`.
+- **On match:** the hash file is one line, `sha256  filename`.
+- **On mismatch:** the hash file records both sums, the two binaries are
+  preserved in the run bundle as `<target>.first.bin` /
+  `<target>.second.bin`, and the script prints the first 32 differing
+  byte offsets via `cmp -l | head` plus an optional `diffoscope`
+  summary when that tool is available.
+
+## CI wiring
+
+CI runs the determinism check as a **separate, currently non-blocking**
+step inside the `iso-vm-build` workflow (`continue-on-error: true`),
+per issue #174:
+
+> Initial run is allowed to fail — log the result as a known-bad
+> baseline issue rather than blocking merges — but the job itself is
+> wired in and visible in PR checks.
+
+The step uploads `artifacts/runs/` alongside the existing kernel / disk /
+qemu artifact bundles so a failing run leaves both `first.bin` and
+`second.bin` downloadable for offline diffing.
+
+Each known source of non-determinism gets its **own** follow-up issue
+(grub timestamp, FAT mtime, embedded build path, etc.). When those are
+fixed, the `continue-on-error: true` flag is removed and the check
+becomes a release-candidate gate per BUILD_ROADMAP §6.3.
+
+## Local usage
+
+```bash
+# Default: check the disk image.
+./build/scripts/check_image_determinism.sh
+
+# Check both the disk image and the kernel ISO.
+SECUREOS_DET_TARGET=both ./build/scripts/check_image_determinism.sh
+
+# Run inside a named bundle.
+SECUREOS_RUN_ID=det-smoke ./build/scripts/check_image_determinism.sh
+ls artifacts/runs/det-smoke/
+# image.sha256                (on match)
+# disk.first.bin  disk.second.bin  image.sha256  (on mismatch)
+```
+
+## Out of scope
+
+- *Fixing* the sources of non-determinism. The purpose of this script is
+  to make the problem visible and measurable; fixes are tracked in
+  separate issues per source.
+- Reproducibility of the kernel ELF in isolation (separate, easier; can
+  be added later with the same script extended to a `kernel` target).
+
+## Cross-references
+
+- BUILD_ROADMAP.md §4.4 (per-run artifact bundle)
+- BUILD_ROADMAP.md §6.3 (deterministic artifact hashes for release candidates)
+- docs/test-plans/artifact-bundle.md (run bundle layout, #161)
+- Issue #161 (per-run bundle layout)
+- Issue #162 (`os-snapshot` consumes the same hash)
+- Issue #174 (this contract)


### PR DESCRIPTION
Closes #174 (BUILD_ROADMAP §4.4 / §6.3).

## What

Wires the deterministic-image-hash gate from BUILD_ROADMAP §6.3 into CI as a **visible, currently non-blocking baseline**, exactly as issue #174 prescribes.

### Files

- **build/scripts/check_image_determinism.sh** — builds the named target (`disk` default, `image`, or `both`) twice from a clean tree and asserts `sha256` stability. On match: writes `artifacts/runs/<id>/image.sha256` (one line, canonical form). On mismatch: preserves both binaries (`<target>.first.bin` / `<target>.second.bin`) in the run bundle, prints sizes, the first 32 differing byte offsets via `cmp -l | head`, and an optional `diffoscope` summary when available. Honors `SECUREOS_RUN_ID` per the #161 bundle contract; mints one with the same `YYYYMMDDTHHMMSSZ-<shortsha>` rule as `validate_bundle.sh` / `run_qemu.sh` if unset.
- **build/scripts/check_image_determinism.ps1** — PowerShell peer that shells out to the `.sh` inside the pinned toolchain container, matching the AGENTS.md cross-platform rule (#156 — one implementation, both hosts).
- **docs/build/determinism.md** — contract doc: goal, tooling, bundle integration, CI wiring, local usage, out-of-scope. Cross-refs #161, #162, #174.
- **BUILD_ROADMAP.md §6.3** — cross-references the new doc and names the CI step.
- **.github/workflows/iso-vm-build.yml** — new `Image determinism check` step with `continue-on-error: true` (per the issue: "Initial run is allowed to fail … but the job itself is wired in and visible in PR checks") + a new `runs-artifacts` upload so a failing baseline leaves both `first.bin` and `second.bin` downloadable for offline diffing.

## Done-when checklist (issue #174)

- [x] CI step builds the image twice from a clean tree and asserts `sha256` match.
- [x] Hash is written to `artifacts/runs/<id>/image.sha256` per #161's bundle layout.
- [x] On mismatch, prints differing offsets via `cmp -l | head` (and `diffoscope` when present).
- [x] Contract documented in `docs/build/determinism.md` and cross-referenced from BUILD_ROADMAP §6.3.
- [x] Initial run is allowed to fail (`continue-on-error: true`) — the job is wired in and visible in PR checks, not blocking merges yet.

## Validation

- `bash -n build/scripts/check_image_determinism.sh` — clean.
- Script is no-op until invoked; no existing test surface changed, so this does not interact with the red-CI unblock chain (#104, #107, #125, #133, #134) or the in-flight wrapper / bundle PRs (#165, #168).

## Out of scope (per issue #174)

Actually *fixing* sources of non-determinism (FAT timestamps, unsorted directory entries, embedded build paths, random padding, …). Each known source gets its own follow-up issue when the baseline run identifies it. When all are fixed, `continue-on-error: true` is removed and this becomes the release-candidate gate per BUILD_ROADMAP §6.3.

## Coordination

- Pairs with **#161** (per-run artifact bundle layout) — `image.sha256` is one of its fields. Forward-compatible with PR #165 (`run_qemu.sh` bundle wiring): both write into the same `artifacts/runs/<id>/` tree, no overlap.
- Pairs with **#162** (`os-snapshot`) — snapshots will consume the same hash file.
- Independent of red-CI chain (#133).