### PR TITLE
fix #173: negative-path harness self-test (run_qemu.sh falsifier)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -31,6 +31,8 @@ test_codesign
 test_ed25519
 test_event_bus
 test_fs_service
+test_harness_defense
+test_harness_negative
 test_helloapp_allow
 test_helloapp_deny
 test_https

--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -128,6 +128,23 @@ case "$TEST_NAME" in
       EXPECTED_STATUS="fail"
     fi
 
+    # Harness self-test hook (issue #173): allow forcing the wrapper to *expect*
+    # a passing run for a fixture that intentionally fails. Used by the
+    # negative-path harness self-test to prove run_qemu.sh propagates non-zero
+    # exit codes and the TEST:FAIL marker rather than silently swallowing
+    # failures. Not for routine use.
+    if [[ -n "${SECUREOS_FORCE_EXPECTED_STATUS:-}" ]]; then
+      case "$SECUREOS_FORCE_EXPECTED_STATUS" in
+        pass|fail)
+          EXPECTED_STATUS="$SECUREOS_FORCE_EXPECTED_STATUS"
+          ;;
+        *)
+          echo "Invalid SECUREOS_FORCE_EXPECTED_STATUS: $SECUREOS_FORCE_EXPECTED_STATUS (expected pass|fail)"
+          exit 1
+          ;;
+      esac
+    fi
+
     if [[ ! -f "$BOOT_BIN" ]]; then
       echo "Missing boot binary: $BOOT_BIN"
       echo "Run build/scripts/test.sh $TEST_NAME first."

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -39,6 +39,7 @@ Stop-SecureOSActiveInstances -RootDir $rootDir -ImageTag $imageTag
 $testScript = switch ($TestName) {
   "hello_boot" { "./build/scripts/test_boot_sector.sh; ./build/scripts/run_qemu.sh --test hello_boot" }
   "hello_boot_negative" { "./build/scripts/test_boot_sector_fail.sh; ./build/scripts/run_qemu.sh --test hello_boot_fail" }
+  "harness_negative" { "./build/scripts/test_harness_negative.sh" }
   "cap_api_contract" { "./build/scripts/test_cap_api_contract.sh" }
   "capability_table" { "./build/scripts/test_capability_table.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -93,6 +93,9 @@ case "$TEST_NAME" in
   hello_boot_negative)
     run_script "$ROOT_DIR/build/scripts/test_boot_sector_fail.sh"
     run_script "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail
+    ;;
+  harness_negative)
+    "$ROOT_DIR/build/scripts/test_harness_negative.sh"
     ;;
   cap_api_contract)
     run_script "$ROOT_DIR/build/scripts/test_cap_api_contract.sh"

--- a/build/scripts/test_harness_negative.sh
+++ b/build/scripts/test_harness_negative.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test_harness_negative.sh
+#
+# Harness self-test (BUILD_ROADMAP §3.4 / §8 item 9, issue #173).
+#
+# What this proves
+# ----------------
+# The existing `hello_boot_negative` target verifies that a deliberately
+# failing boot fixture is *detected* by the harness (wrapper inverts the
+# exit code: fixture exits fail, harness reports pass). That alone is not
+# enough to falsify a silent-skip bug, because we never observe what the
+# harness does when it *should* surface a failure.
+#
+# This self-test runs the same `hello_boot_fail` fixture but forces the
+# wrapper to expect a *passing* run via SECUREOS_FORCE_EXPECTED_STATUS=pass.
+# The wrapper MUST then:
+#   1. exit non-zero, and
+#   2. write a log that contains the `TEST:FAIL:hello_boot_fail:` marker.
+#
+# If either check fails, the harness is silently swallowing failures and
+# every previous "green" run is unfalsifiable.
+#
+# Used by
+# -------
+#   build/scripts/test.sh harness_negative
+#   build/scripts/validate_bundle.sh   (TEST_TARGETS)
+#
+# Independent of the M2/M3/M4 red-CI chain (#101/#106/#133): only touches
+# the bootloader fixture + run_qemu.sh harness.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "TEST:START:harness_negative"
+
+# Build the intentionally failing boot sector fixture.
+"$ROOT_DIR/build/scripts/test_boot_sector_fail.sh" >/dev/null
+
+LOG_FILE="$ROOT_DIR/artifacts/qemu/hello_boot_fail.log"
+META_FILE="$ROOT_DIR/artifacts/qemu/hello_boot_fail.meta.json"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Run the wrapper with inverted expectations. We expect it to FAIL (non-zero).
+set +e
+SECUREOS_FORCE_EXPECTED_STATUS=pass \
+  "$ROOT_DIR/build/scripts/run_qemu.sh" --test hello_boot_fail >/dev/null 2>&1
+HARNESS_RC=$?
+set -e
+
+if [[ "$HARNESS_RC" -eq 0 ]]; then
+  echo "TEST:FAIL:harness_negative:wrapper-returned-zero-on-known-failing-fixture"
+  exit 1
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "TEST:FAIL:harness_negative:missing-log:$LOG_FILE"
+  exit 1
+fi
+
+if ! grep -q "TEST:FAIL:hello_boot_fail:" "$LOG_FILE"; then
+  echo "TEST:FAIL:harness_negative:missing-fail-marker-in-log"
+  exit 1
+fi
+
+# Meta JSON should also record the inverted-expectation failure so downstream
+# bundle inspection can see it.
+if [[ -f "$META_FILE" ]] && command -v python3 >/dev/null 2>&1; then
+  if ! python3 - "$META_FILE" <<'PY'
+import json, sys
+meta = json.loads(open(sys.argv[1]).read())
+ok = (
+    meta.get("expectedStatus") == "pass"
+    and meta.get("status") == "fail"
+    and meta.get("markers", {}).get("fail") is True
+)
+sys.exit(0 if ok else 1)
+PY
+  then
+    echo "TEST:FAIL:harness_negative:meta-json-did-not-record-inverted-failure"
+    exit 1
+  fi
+fi
+
+echo "TEST:PASS:harness_negative:wrapper_rc=${HARNESS_RC}"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -13,6 +13,7 @@ mkdir -p "$RUN_QEMU_DIR" "$RUN_TESTS_DIR"
 TEST_TARGETS=(
   hello_boot
   hello_boot_negative
+  harness_negative
   cap_api_contract
   capability_table
   capability_gate

--- a/docs/BOOTSTRAP_TESTING.md
+++ b/docs/BOOTSTRAP_TESTING.md
@@ -51,3 +51,36 @@ Even though the fixture exits with `EXIT_FAIL`, the harness reports success when
 ```text
 QEMU_PASS:hello_boot_fail
 ```
+
+### Harness self-test (negative-path falsifier)
+
+`hello_boot_negative` only proves the inverted-expectation path: a failing
+fixture marked "expected to fail" results in a green wrapper exit. It does
+**not** prove that the wrapper reports failures loudly when a fixture
+unexpectedly fails. Without that proof, a silent-skip bug in `run_qemu.sh`
+or `test.sh` could make every "green" CI run unfalsifiable
+(BUILD_ROADMAP §3.4 / §8 item 9, issue #173).
+
+Run:
+
+```bash
+./build/scripts/test.sh harness_negative
+```
+
+What it does:
+
+1. Builds the `boot_fail.bin` fixture (same fixture as
+   `hello_boot_negative`).
+2. Invokes `run_qemu.sh --test hello_boot_fail` with
+   `SECUREOS_FORCE_EXPECTED_STATUS=pass`, lying to the wrapper that the
+   fixture should pass.
+3. Asserts the wrapper exits **non-zero** and that
+   `artifacts/qemu/hello_boot_fail.log` contains
+   `TEST:FAIL:hello_boot_fail:`.
+4. Asserts the wrapper's `hello_boot_fail.meta.json` recorded
+   `expectedStatus: "pass"`, `status: "fail"`, and `markers.fail: true`.
+
+`SECUREOS_FORCE_EXPECTED_STATUS` is a harness-internal escape hatch
+introduced for this self-test only; it MUST NOT be set in routine CI runs.
+The target is wired into `validate_bundle.sh`'s `TEST_TARGETS` so it cannot
+be silently dropped (see #129).


### PR DESCRIPTION
Closes #173.

## Why

`hello_boot_negative` proves the inverted-expectation path (a fixture
marked *expected to fail* greens when it fails as expected). It does **not**
prove the wrapper reports failures loudly when a fixture *unexpectedly*
fails. Without that proof, a silent-skip regression in `run_qemu.sh` or
`test.sh` would make every CI green run unfalsifiable
(BUILD_ROADMAP §3.4 / §8 item 9, recent silent-skip context from #90 / #91 / #129).

## What

- **`build/scripts/run_qemu.sh`** — adds a `SECUREOS_FORCE_EXPECTED_STATUS`
  escape hatch (harness-internal). Lets the self-test invert the wrapper's
  expectation for the existing `hello_boot_fail` fixture without shipping a
  second always-passing fixture. Not for routine use.
- **`build/scripts/test_harness_negative.sh`** (new) — builds
  `boot_fail.bin`, invokes the wrapper with
  `SECUREOS_FORCE_EXPECTED_STATUS=pass`, then asserts:
  1. wrapper exits non-zero,
  2. log contains `TEST:FAIL:hello_boot_fail:`,
  3. meta JSON records `expectedStatus=pass`, `status=fail`,
     `markers.fail=true`.
  Any silent-skip regression in the wrapper makes this self-test scream.
- **`build/scripts/test.sh` + `test.ps1`** — adds `harness_negative`
  target (`.sh` ↔ `.ps1` parity preserved per #156).
- **`build/scripts/validate_bundle.sh`** — adds `harness_negative` to
  `TEST_TARGETS` so it can't be silently dropped (#129 hygiene).
- **`docs/BOOTSTRAP_TESTING.md`** — documents the self-test, the
  inversion contract, and why `hello_boot_negative` alone is insufficient.

## Validation

- `bash -n` on all modified shell scripts — clean.
- `qemu-system-x86_64` / `nasm` are not available on this runner, so end-to-end
  execution defers to CI (`build-and-validate`) which already runs
  `validate_bundle.sh`; the new target rides that pipeline.
- No kernel correctness change; independent of the open red-CI chain
  (#101 / #106 / #133).

## Follow-ups

- If the wrapper ever grows a stable contract for inverted-expectation
  testing (vs. the env-var escape hatch), wire `harness_negative` to that
  instead.
- Add a similar self-test for the `kernel_*` QEMU branches once their
  expected-status plumbing is unified with `hello_boot*`.