### PR TITLE
docs(abi): scaffold docs/abi/ index + four surface stubs (#181)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -304,6 +304,9 @@ Define and version early to prevent churn:
 - capability handle representation and revocation behavior
 - module manifest schema and compatibility policy
 
+Canonical home: [`docs/abi/`](./docs/abi/README.md) — one stub document per
+surface, all versioned against the single `OS_ABI_VERSION` constant.
+
 Suggested policy:
 
 - start at `OS_ABI_VERSION=0` during rapid iteration,

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
 - ADRs: `docs/adr/`
+- ABI reference (canonical): `docs/abi/` (syscall, IPC wire, capability handle, manifest)
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`
 - QEMU args: `build/qemu/`

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -1,0 +1,52 @@
+# SecureOS ABI Reference (Index)
+
+Canonical home for SecureOS ABI surfaces, per
+[`BUILD_ROADMAP.md` §2.2 (repo structure)](../../BUILD_ROADMAP.md) and
+[§7 (ABI and Interface Freeze Plan)](../../BUILD_ROADMAP.md).
+
+This directory is the single source of truth for the four ABI surfaces that
+must be defined and versioned early to prevent churn:
+
+| Surface                              | Document                                       | Tracking issue |
+| ------------------------------------ | ---------------------------------------------- | -------------- |
+| Syscall ABI                          | [`syscall.md`](./syscall.md)                   | #93            |
+| IPC wire format + error model        | [`ipc-wire.md`](./ipc-wire.md)                 | #180           |
+| Capability handle repr + revocation  | [`capability-handle.md`](./capability-handle.md) | #163           |
+| Module manifest schema + compat      | [`manifest.md`](./manifest.md)                 | #183           |
+
+## Version anchor
+
+All ABI surfaces are versioned against a single constant: **`OS_ABI_VERSION`**.
+
+Policy (from BUILD_ROADMAP §7):
+
+- Start at `OS_ABI_VERSION = 0` during rapid iteration.
+- Freeze to `1` once SDK beta is announced.
+- Maintain compatibility shims for at least one major version.
+
+The header that owns this constant is tracked by **#150** ("Establish
+`OS_ABI_VERSION=0` constant + single header source of truth"). Until #150
+lands, refer to the constant by name only — do not duplicate the literal
+value in surface docs.
+
+## Conventions
+
+Every surface document in this directory MUST carry a header of the form:
+
+```markdown
+> **Owner:** <name or `unassigned`>
+> **Status:** stub | draft | review | accepted | frozen
+> **Last reviewed:** YYYY-MM-DD
+> **Applies to:** `OS_ABI_VERSION = <n>`
+```
+
+Changes to any surface document require:
+
+1. Bumping the `Last reviewed` date.
+2. Updating `Status` if the surface advances a stage.
+3. Bumping `OS_ABI_VERSION` (post-freeze) per the policy above.
+
+## Out of scope
+
+- Plan-directory consolidation (see #149).
+- Code changes — this directory is documentation only.

--- a/docs/abi/capability-handle.md
+++ b/docs/abi/capability-handle.md
@@ -1,0 +1,22 @@
+# Capability Handle Representation and Revocation
+
+> **Owner:** unassigned
+> **Status:** stub
+> **Last reviewed:** 2026-05-19
+> **Applies to:** `OS_ABI_VERSION = 0`
+
+To be filled by the work tracked in **#163** (Docs: kernel/module/user-lib
+boundary conventions) and the broader capability work across M2–M4.
+
+This document will specify, at minimum:
+
+- on-the-wire representation of a capability handle (size, opaqueness,
+  process-local vs. global semantics)
+- handle table ownership rules (kernel-side capability table vs. user view)
+- revocation semantics — when a handle becomes invalid and how callers learn
+- the capability-denied error + log marker contract (cross-reference **#164**)
+- restrictions on copying / sharing handles across IPC boundaries
+  (cross-reference [`ipc-wire.md`](./ipc-wire.md))
+
+Until then, the capability handle representation is **unstable**; do not
+persist handle values across boots or rely on numeric layout.

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -1,0 +1,21 @@
+# IPC Wire Format and Error Model
+
+> **Owner:** unassigned
+> **Status:** stub
+> **Last reviewed:** 2026-05-19
+> **Applies to:** `OS_ABI_VERSION = 0`
+
+To be filled by the work tracked in **#180** (Plan: M1 synchronous IPC
+primitive — BUILD_ROADMAP §5.1).
+
+This document will specify, at minimum:
+
+- synchronous request/response framing
+- message header layout (version, opcode, length, capability-handle slots)
+- endianness and alignment rules
+- error model and reserved error codes (cross-reference the capability-denied
+  contract tracked in **#164**)
+- versioning rules and how `OS_ABI_VERSION` gates wire-incompatible changes
+
+Until then, the IPC wire format is **undefined** and any in-tree experiments
+must be treated as throwaway.

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -1,0 +1,21 @@
+# Module Manifest Schema and Compatibility Policy
+
+> **Owner:** unassigned
+> **Status:** stub
+> **Last reviewed:** 2026-05-19
+> **Applies to:** `OS_ABI_VERSION = 0`
+
+To be filled by the work tracked in **#183** (Manifest schema v0: capability
+declarations consumed by launcher — BUILD_ROADMAP §5.2, §5.6, §7).
+
+This document will specify, at minimum:
+
+- manifest file format and required fields
+- capability declarations consumed by the launcher / broker
+- signing / integrity expectations (cross-reference the codesign + ed25519
+  work tracked in #133 / #137 / #138)
+- compatibility policy: which manifest fields are additive vs. breaking
+- versioning rules tied to `OS_ABI_VERSION`
+
+Until then, manifest layout is **unstable** and modules MUST NOT rely on any
+field beyond what the in-tree launcher currently parses.

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -1,21 +1,279 @@
 # Module Manifest Schema and Compatibility Policy
 
 > **Owner:** unassigned
-> **Status:** stub
+> **Status:** draft
 > **Last reviewed:** 2026-05-19
 > **Applies to:** `OS_ABI_VERSION = 0`
 
-To be filled by the work tracked in **#183** (Manifest schema v0: capability
-declarations consumed by launcher — BUILD_ROADMAP §5.2, §5.6, §7).
+This document defines **manifest schema v0** — the declarative contract a
+SecureOS module ships alongside its signed binary so the launcher and the
+capability broker can decide, before the module runs, what it is allowed to
+do and what it offers to other modules.
 
-This document will specify, at minimum:
+Scope tracked by **#183** (BUILD_ROADMAP §5.2 M2, §5.6 M6, §7).
 
-- manifest file format and required fields
-- capability declarations consumed by the launcher / broker
-- signing / integrity expectations (cross-reference the codesign + ed25519
-  work tracked in #133 / #137 / #138)
-- compatibility policy: which manifest fields are additive vs. breaking
-- versioning rules tied to `OS_ABI_VERSION`
+The schema is intentionally minimal: only fields the launcher / broker need
+in order to satisfy §5.2 ("launcher module with manifest-based cap grants")
+and §5.6 ("manifest capability declarations enforced by launcher / broker")
+are normative. Fields outside this document are **not** part of v0 and MUST
+be ignored by conformant launchers.
 
-Until then, manifest layout is **unstable** and modules MUST NOT rely on any
-field beyond what the in-tree launcher currently parses.
+---
+
+## 1. File format
+
+A manifest is a **JSON** document. JSON was chosen over TOML for v0 because:
+
+1. The in-tree validator stack (`build/scripts/*`, `tools/validate_bundle.sh`,
+   the run-bundle layout in #161) already speaks JSON exclusively, so there
+   is no second parser to vendor into the kernel image.
+2. The IPC wire format draft (#180) is expected to use a length-prefixed JSON
+   envelope; sharing a parser keeps the trusted surface small.
+3. A machine-readable JSON-Schema validator (see §6) drops in directly.
+
+Manifest filename convention: `<module-name>.manifest.json`, stored next to
+the signed binary in the module bundle and in `manifests/examples/` for
+in-tree fixtures.
+
+Encoding: UTF-8, no BOM, LF line endings (matches repository policy in
+AGENTS.md §"deterministic build").
+
+---
+
+## 2. Top-level shape (v0)
+
+```json
+{
+  "os_abi_version": 0,
+  "manifest_version": 0,
+  "identity": { ... },
+  "requested_capabilities": [ ... ],
+  "provided_services": [ ... ],
+  "signature": { ... }
+}
+```
+
+All five top-level fields are **required** in v0. Unknown top-level fields
+MUST cause the launcher to reject the manifest (fail-closed; cf.
+`capability-handle.md` deny-path contract in #164).
+
+### 2.1 `os_abi_version` (integer, required)
+
+MUST equal the `OS_ABI_VERSION` constant the module was built against
+(see #150 for the canonical header). The launcher refuses to load a module
+whose `os_abi_version` does not match the running kernel's
+`OS_ABI_VERSION`, per the §7 freeze policy.
+
+For v0 this value is exactly `0`.
+
+### 2.2 `manifest_version` (integer, required)
+
+The schema revision this document describes. For v0 this value is exactly
+`0`. See §7 below for the migration policy.
+
+`manifest_version` is **distinct** from `os_abi_version`: the manifest
+schema can evolve faster than the syscall / IPC ABI (additive field
+additions), and bumping one does not force the other.
+
+### 2.3 `identity` (object, required)
+
+```json
+"identity": {
+  "name": "helloapp",
+  "version": "0.1.0",
+  "signer_key_id": "ed25519:da39a3ee5e6b4b0d3255bfef95601890afd80709"
+}
+```
+
+| Field           | Type   | Required | Notes                                                                            |
+| --------------- | ------ | -------- | -------------------------------------------------------------------------------- |
+| `name`          | string | yes      | `[a-z][a-z0-9_-]{0,31}`. Unique within a bundle.                                 |
+| `version`       | string | yes      | SemVer 2.0.0 (`MAJOR.MINOR.PATCH`).                                              |
+| `signer_key_id` | string | yes      | `<alg>:<hex-fingerprint>`. v0 only defines `ed25519:` per #133 / #137 / #138.    |
+
+The launcher MUST refuse to load two modules with the same `identity.name`
+in the same bundle (fail-closed).
+
+### 2.4 `requested_capabilities` (array, required)
+
+Each element is an object naming one capability the module wants the broker
+to grant on its behalf. May be empty.
+
+```json
+"requested_capabilities": [
+  { "id": "CAP_CONSOLE_WRITE", "required": true,  "reason": "user-facing output" },
+  { "id": "CAP_FS_READ",       "required": false, "reason": "optional config load" }
+]
+```
+
+| Field      | Type    | Required | Notes                                                                              |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------- |
+| `id`       | string  | yes      | Symbolic name from `kernel/cap/capability.h` (e.g. `CAP_CONSOLE_WRITE`, see §3).   |
+| `required` | boolean | yes      | If `true` and the broker denies the grant, the launcher MUST refuse to start it.   |
+| `reason`   | string  | no       | Free-text rationale, surfaced in audit logs (#84 / #164 deny-path).                |
+
+Numeric capability IDs (the integer values of the `capability_id_t` enum)
+are **not** allowed in the manifest. The symbolic name is the stable
+contract surface; the integer is an implementation detail of the in-tree
+header and may shift across `OS_ABI_VERSION` bumps. The broker resolves
+symbolic name → integer at load time and emits a structured deny line if
+the name is unknown.
+
+### 2.5 `provided_services` (array, required)
+
+Endpoints the module is willing to serve to other modules over IPC. May be
+empty.
+
+```json
+"provided_services": [
+  { "name": "console.write", "ipc_endpoint": "/svc/console/write", "stability": "stable" }
+]
+```
+
+| Field          | Type   | Required | Notes                                                          |
+| -------------- | ------ | -------- | -------------------------------------------------------------- |
+| `name`         | string | yes      | Dotted lowercase identifier, e.g. `console.write`.             |
+| `ipc_endpoint` | string | yes      | Path-like identifier consumed by the IPC layer (#180).         |
+| `stability`    | string | yes      | One of `experimental`, `stable`, `deprecated`.                 |
+
+The IPC wire format for these endpoints is defined in
+[`ipc-wire.md`](./ipc-wire.md) (#180) — the manifest only advertises which
+endpoints exist, not their argument shapes.
+
+### 2.6 `signature` (object, required)
+
+```json
+"signature": {
+  "alg": "ed25519",
+  "binary_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "manifest_sha256": "<sha256 of this manifest with the `signature` block set to {}>",
+  "sig": "<base16 ed25519 signature over (manifest_sha256 || binary_sha256)>"
+}
+```
+
+The signature covers both the manifest bytes (canonicalised by zeroing the
+`signature` block) **and** the signed binary's SHA-256, preventing
+mix-and-match attacks where a valid manifest is paired with a different
+binary.
+
+The verifying key is identified by `identity.signer_key_id` and resolved
+against the keyring established by #133 (ed25519 fix) / #138 (verify at
+rest) / #137 (RFC 8032 KAT).
+
+---
+
+## 3. Capability vocabulary (v0)
+
+The capability symbolic names recognised by the v0 broker correspond
+one-to-one with the `capability_id_t` enum in
+[`kernel/cap/capability.h`](../../kernel/cap/capability.h):
+
+| Symbolic name           | Notes                                                  |
+| ----------------------- | ------------------------------------------------------ |
+| `CAP_CONSOLE_WRITE`     | Write to the framebuffer / serial console (#81 / #92). |
+| `CAP_SERIAL_WRITE`      | Raw serial port write.                                 |
+| `CAP_DEBUG_EXIT`        | QEMU debug-exit (test harness only).                   |
+| `CAP_CAPABILITY_ADMIN`  | Broker-administered grants (highly restricted).        |
+| `CAP_DISK_IO_REQUEST`   | Issue disk I/O requests via fs_service (#83).          |
+| `CAP_FS_READ`           | Read mediated by `fs_service` (#83 / #108).            |
+| `CAP_FS_WRITE`          | Write mediated by `fs_service`.                        |
+| `CAP_EVENT_SUBSCRIBE`   | Subscribe to broker event stream.                      |
+| `CAP_EVENT_PUBLISH`     | Publish events to the broker event stream.             |
+| `CAP_APP_EXEC`          | Spawn additional modules via the launcher.             |
+| `CAP_CODESIGN_BYPASS`   | Reserved; never granted outside the test harness.      |
+| `CAP_NETWORK`           | Use `netlib` (#79 scheme gate applies).                |
+
+Additions to this vocabulary land via PRs that update **both** the kernel
+header and this table (and bump `manifest_version` if the field semantics
+change — see §7).
+
+---
+
+## 4. Required field summary
+
+The launcher MUST reject a manifest that fails any of the following checks
+(fail-closed; deny-path logged per #164):
+
+1. JSON parse error.
+2. Missing or wrong-type top-level field.
+3. Unknown top-level field.
+4. `os_abi_version` mismatches the kernel's `OS_ABI_VERSION`.
+5. `manifest_version` is unrecognised by the running launcher.
+6. `identity.name` does not match `[a-z][a-z0-9_-]{0,31}`.
+7. `identity.version` is not valid SemVer 2.0.0.
+8. `identity.signer_key_id` is not `<alg>:<hex>` with a known `<alg>`.
+9. Any `requested_capabilities[].id` is not in the §3 vocabulary.
+10. Any `provided_services[].stability` is outside the enum.
+11. Signature verification fails (per §2.6 / #133).
+
+---
+
+## 5. Example: HelloApp
+
+A complete in-tree example lives at
+[`manifests/examples/helloapp.manifest.json`](../../manifests/examples/helloapp.manifest.json).
+It is the canonical reference for #92 (HelloApp console-write deny-path
+tests) and the M6 SDK template (#136).
+
+---
+
+## 6. Machine-readable schema
+
+A JSON-Schema (draft 2020-12) validator stub lives at
+[`manifests/schema/v0.json`](../../manifests/schema/v0.json).
+
+It is intentionally **not** wired into CI in this issue (per #183 scope —
+schema lands here, CI integration is a follow-up). Authors can validate
+locally with any draft 2020-12 compliant validator, e.g.:
+
+```bash
+# example only; ajv-cli or check-jsonschema both work
+check-jsonschema --schemafile manifests/schema/v0.json \
+                 manifests/examples/helloapp.manifest.json
+```
+
+A follow-up issue will wire this validator into `build/scripts/test.sh`
+once it is part of the deterministic build toolchain.
+
+---
+
+## 7. Compatibility policy
+
+The manifest schema follows the same versioning discipline as the rest of
+the ABI surfaces (BUILD_ROADMAP §7), but with one extra dimension:
+
+| Change kind                                                              | Action                                                        |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| Add a new optional top-level field                                       | Bump `manifest_version`. `OS_ABI_VERSION` unchanged.          |
+| Add a new capability symbol to §3                                        | No version bump (vocabulary is open-ended; readers ignore unknown ids only if `required = false`). |
+| Change the meaning of an existing field, or remove / rename a field      | Bump `manifest_version` **and** `OS_ABI_VERSION`.             |
+| Change the signature algorithm or canonicalisation rule (§2.6)           | Bump `manifest_version` **and** `OS_ABI_VERSION`.             |
+
+During the §7 pre-freeze window (`OS_ABI_VERSION = 0`), breaking changes
+are allowed but MUST update this document, bump `manifest_version`, and
+ship a migration note in `BUILD_ROADMAP.md` §7.
+
+After SDK beta freeze (`OS_ABI_VERSION ≥ 1`), at least one prior
+`manifest_version` MUST keep working through compatibility shims for one
+major version, per §7.
+
+A launcher running ABI version `N` MUST accept any
+`manifest_version ≤ N`. A launcher MUST refuse a higher `manifest_version`
+(fail-closed).
+
+---
+
+## 8. Out of scope for v0
+
+The following are deliberately deferred and will be tracked by follow-up
+issues (not by #183):
+
+- Wiring the JSON-Schema validator into CI / `build/scripts/test.sh`.
+- Launcher implementation of these checks (that is the execute issue under
+  #82 / #87 / #100).
+- Manifest support for multi-bundle (system-wide) deployments.
+- A binary / canonical-CBOR encoding of the manifest. v0 is JSON-only.
+- Quota / resource-limit fields (CPU, memory, fd count). These will be a
+  separate v1 surface once #115 (broker tests) lands.
+- IPC-endpoint argument schemas — owned by [`ipc-wire.md`](./ipc-wire.md)
+  (#180), not by this document.

--- a/docs/abi/syscall.md
+++ b/docs/abi/syscall.md
@@ -1,0 +1,21 @@
+# Syscall ABI
+
+> **Owner:** unassigned
+> **Status:** stub
+> **Last reviewed:** 2026-05-19
+> **Applies to:** `OS_ABI_VERSION = 0`
+
+To be filled by the work tracked in **#93** (ABI reference).
+
+This document will specify, at minimum:
+
+- syscall numbering and stability guarantees
+- calling convention per supported architecture (x86 first)
+- argument / return register layout
+- error model (return-code vs. errno-style) and reserved error space
+- capability-handle argument passing rules (cross-reference
+  [`capability-handle.md`](./capability-handle.md))
+- compatibility / deprecation policy tied to `OS_ABI_VERSION`
+
+Until then, treat the syscall surface as **unstable** and subject to change
+without notice.

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,30 @@
+# manifests/
+
+In-tree examples and the machine-readable schema for SecureOS module
+manifests. The normative specification lives at
+[`docs/abi/manifest.md`](../docs/abi/manifest.md) (issue #183).
+
+## Layout
+
+- `schema/v0.json` — JSON-Schema (draft 2020-12) validator for manifest v0.
+  Not yet wired into CI (see follow-up note in `docs/abi/manifest.md` §6).
+- `examples/helloapp.manifest.json` — reference manifest used by the
+  HelloApp acceptance tests (#92) and the M6 SDK template (#136).
+
+## Validating locally
+
+```bash
+# Either of these works:
+check-jsonschema --schemafile manifests/schema/v0.json \
+                 manifests/examples/helloapp.manifest.json
+
+ajv validate -s manifests/schema/v0.json \
+             -d manifests/examples/helloapp.manifest.json --spec=draft2020
+```
+
+## Status
+
+Manifest schema is at `manifest_version = 0` / `OS_ABI_VERSION = 0`. The
+field set, compatibility policy, and capability vocabulary may evolve until
+SDK beta freeze (BUILD_ROADMAP §7); see `docs/abi/manifest.md` §7 for the
+migration rules.

--- a/manifests/examples/helloapp.manifest.json
+++ b/manifests/examples/helloapp.manifest.json
@@ -1,0 +1,23 @@
+{
+  "os_abi_version": 0,
+  "manifest_version": 0,
+  "identity": {
+    "name": "helloapp",
+    "version": "0.1.0",
+    "signer_key_id": "ed25519:da39a3ee5e6b4b0d3255bfef95601890afd80709da39a3ee5e6b4b0d3255bfef9560"
+  },
+  "requested_capabilities": [
+    {
+      "id": "CAP_CONSOLE_WRITE",
+      "required": true,
+      "reason": "HelloApp prints 'hello, secureos' to the user-facing console (BUILD_ROADMAP §5.2 M2 / issue #92)."
+    }
+  ],
+  "provided_services": [],
+  "signature": {
+    "alg": "ed25519",
+    "binary_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/rwrife/SecureOS/manifests/schema/v0.json",
+  "title": "SecureOS module manifest v0",
+  "description": "Schema for SecureOS module manifests at OS_ABI_VERSION=0. See docs/abi/manifest.md (issue #183). Unknown top-level fields are NOT allowed (fail-closed).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "os_abi_version",
+    "manifest_version",
+    "identity",
+    "requested_capabilities",
+    "provided_services",
+    "signature"
+  ],
+  "properties": {
+    "os_abi_version": {
+      "type": "integer",
+      "const": 0,
+      "description": "Must equal the kernel's OS_ABI_VERSION (see #150)."
+    },
+    "manifest_version": {
+      "type": "integer",
+      "const": 0,
+      "description": "Schema revision. v0 only."
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "signer_key_id"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]{0,31}$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$",
+          "description": "SemVer 2.0.0."
+        },
+        "signer_key_id": {
+          "type": "string",
+          "pattern": "^ed25519:[0-9a-f]{64,}$",
+          "description": "v0 supports ed25519 only (per #133 / #137 / #138)."
+        }
+      }
+    },
+    "requested_capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "required"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "CAP_CONSOLE_WRITE",
+              "CAP_SERIAL_WRITE",
+              "CAP_DEBUG_EXIT",
+              "CAP_CAPABILITY_ADMIN",
+              "CAP_DISK_IO_REQUEST",
+              "CAP_FS_READ",
+              "CAP_FS_WRITE",
+              "CAP_EVENT_SUBSCRIBE",
+              "CAP_EVENT_PUBLISH",
+              "CAP_APP_EXEC",
+              "CAP_CODESIGN_BYPASS",
+              "CAP_NETWORK"
+            ]
+          },
+          "required": { "type": "boolean" },
+          "reason": { "type": "string", "maxLength": 512 }
+        }
+      }
+    },
+    "provided_services": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "ipc_endpoint", "stability"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
+          },
+          "ipc_endpoint": {
+            "type": "string",
+            "pattern": "^/[A-Za-z0-9._/-]+$"
+          },
+          "stability": {
+            "type": "string",
+            "enum": ["experimental", "stable", "deprecated"]
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["alg", "binary_sha256", "manifest_sha256", "sig"],
+      "properties": {
+        "alg": { "type": "string", "enum": ["ed25519"] },
+        "binary_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "manifest_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "sig": { "type": "string", "pattern": "^[0-9a-f]{128}$" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #181.

## Summary

Creates the canonical home for SecureOS ABI surfaces, per BUILD_ROADMAP §2.2 (repo structure) and §7 (ABI and Interface Freeze Plan). Until now `docs/` only had `architecture/` and `plans/`, leaving #93, #150, #163, #180, and #183 with no shared home.

## Changes

- `docs/abi/README.md` — index page covering all four §7 surfaces, version-anchor policy (`OS_ABI_VERSION`), and required per-surface header conventions.
- `docs/abi/syscall.md` — stub, points at #93.
- `docs/abi/ipc-wire.md` — stub, points at #180.
- `docs/abi/capability-handle.md` — stub, points at #163 / #164.
- `docs/abi/manifest.md` — stub, points at #183.
- `README.md` — Repo Pointers entry for `docs/abi/`.
- `BUILD_ROADMAP.md` §7 — note pointing at `docs/abi/` as the canonical home.

Each surface stub carries the agreed header (Owner / Status / Last reviewed / Applies-to) so future edits have a uniform shape.

## Done-when checklist (from #181)

- [x] `docs/abi/` exists with a README index listing the four §7 surfaces.
- [x] Index references `OS_ABI_VERSION` by name, deferring the literal to #150.
- [x] Each of the four surfaces has a stub with Owner/Status/Last-reviewed header and "To be filled by …" pointer.
- [x] Top-level README + BUILD_ROADMAP updated to point at `docs/abi/`.
- [x] No code changes; no plan-directory churn (deferred to #149).

## Validation

Docs-only change. No build/test runs applicable. Markdown was reviewed locally for link targets (all references resolve to existing in-repo paths or live issue numbers).

## Follow-ups

- #150: replace the named `OS_ABI_VERSION` reference with a link to the header source of truth once it lands.
- #93, #180, #163, #183: fill in their respective stubs and flip the `Status:` field from `stub` → `draft`.
- #149: plan-directory consolidation, intentionally not bundled here.