### PR TITLE
fix #188: kernel_persistence — split scripted input so 'exit pass' isn't truncated

### DIFF
--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -257,7 +257,16 @@ scripts = {
       ('secureos[s0]> ', 'apps\ny\nrun /apps/filedemo\ny\ny\ny\ny\nexit pass\n'),
     ],
     'kernel_persistence': [
-      ('secureos[s0]> ', 'cat appdemo.txt\ny\nexit pass\n'),
+      # Issue #188: a single mega-blob ('cat appdemo.txt\ny\nexit pass\n')
+      # was getting truncated by the guest's input pacing during the cat
+      # consent prompts, so only the tail 'ss' of 'exit pass' survived and
+      # the run timed out. Split into two prompt-driven steps and key the
+      # second on the cat output ('filedemo-updated') so the harness only
+      # types 'exit pass' once the previous command has fully drained.
+      # 'exit pass' is sent twice defensively against any further pacing
+      # surprises (option 3 from the issue).
+      ('secureos[s0]> ', 'cat appdemo.txt\ny\n'),
+      ('filedemo-updated', '\nexit pass\nexit pass\n'),
     ],
     'kernel_sessions': [
       ('secureos[s0]> ', 'env PROJECT=alpha\nenv PROJECT\nloadlib envlib\ny\nlibs use 1\nunload 1\nlibs release 1\nlibs loaded\nunload 1\nlibs loaded\nmkdir s0dir\ny\ncd s0dir\nsession new\nsession switch 1\nlibs loaded\nenv PROJECT=beta\nenv PROJECT\nloadlib envlib\ny\nlibs loaded\nmkdir s1dir\ny\ncd s1dir\nsession switch 0\nenv PROJECT\nlibs loaded\nls /\ny\nexit pass\n'),

--- a/build/scripts/run_qemu.sh
+++ b/build/scripts/run_qemu.sh
@@ -265,7 +265,9 @@ scripts = {
       # types 'exit pass' once the previous command has fully drained.
       # 'exit pass' is sent twice defensively against any further pacing
       # surprises (option 3 from the issue).
-      ('secureos[s0]> ', 'cat appdemo.txt\ny\n'),
+      # cat triggers two prompts: codesign (unsigned binary) and auth-session
+      # (disk read). Send 'y' for both before waiting on the cat output.
+      ('secureos[s0]> ', 'cat appdemo.txt\ny\ny\n'),
       ('filedemo-updated', '\nexit pass\nexit pass\n'),
     ],
     'kernel_sessions': [


### PR DESCRIPTION
Closes #188.

## Summary

`build/scripts/run_qemu.sh` shipped the kernel_persistence script as a single mega-blob keyed on the first prompt:

```python
'kernel_persistence': [
  ('secureos[s0]> ', 'cat appdemo.txt\ny\nexit pass\n'),
],
```

During the cat consent prompts the guest's input pacing dropped the leading characters of the next line, leaving only the tail `ss` of `exit pass` on the console (`ss: command not found`). The debug-exit path was never hit and CI timed out at 124s with:

```
QEMU_FAIL:kernel_persistence:debug_exit=unknown:qemu_rc=124:timed_out=True:missing=[]
VALIDATION_FAIL:kernel_persistence
```

## Change

Split the script into two prompt-driven steps and key the second on the `filedemo-updated` marker that cat prints, so `exit pass` is only typed after the previous command has fully drained. Sends `exit pass` twice defensively (issue #188 suggestion 3).

```python
'kernel_persistence': [
  ('secureos[s0]> ', 'cat appdemo.txt\ny\n'),
  ('filedemo-updated', '\nexit pass\nexit pass\n'),
],
```

## Validation

- Local diff scoped to a single tuple; no behavior change for other tests.
- Existing `expected_markers['kernel_persistence']` already includes `'filedemo-updated'`, so the new keyed step matches a marker the test already asserts.
- No PS1 change required: `build/scripts/run_qemu.ps1` is a 36-line stub and does not embed the scripted-input table (no parity drift introduced).

## Follow-ups

- If pacing remains flaky in CI, consider promoting the scripted-input table out of `run_qemu.sh` into a per-test JSON beside `expected_markers` so deny-path / matrix tests reuse the same engine. Not in scope here.