### PR TITLE
docs(abi): add ipc-wire.md stub to close §7 surface inventory gap (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - Roadmap: `BUILD_ROADMAP.md`
 - M0→M1 task registry: `docs/planning/M0-M1-task-registry.md`
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
-- ABI reference: `docs/abi/` (syscalls, capabilities, manifest, versioning)
+- ABI reference: `docs/abi/` (syscalls, capabilities, manifest, ipc-wire, versioning)
 - ADRs: `docs/adr/`
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -18,6 +18,8 @@ changes are deliberate and reviewable rather than emergent.
   in `docs/architecture/CAPABILITIES.md`.
 - [manifest.md](manifest.md) — Launcher manifest schema: how an app declares
   the capabilities it needs and how the launcher mediates grants today.
+- [ipc-wire.md](ipc-wire.md) — IPC wire format + error model (stub; owned
+  by the M1 synchronous IPC plan, #180).
 - [versioning.md](versioning.md) — `OS_ABI_VERSION` policy, compat-shim
   window, and the process for adding / removing ABI surface.
 

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -1,0 +1,64 @@
+# SecureOS IPC Wire Format
+
+> **Owner:** unassigned
+> **Status:** stub
+> **Last reviewed:** 2026-05-20
+> **Applies to:** `OS_ABI_VERSION = 0`
+
+This document is the canonical home for the inter-process communication
+(IPC) wire format and error model — one of the four ABI surfaces that
+[`BUILD_ROADMAP.md` §7](../../BUILD_ROADMAP.md) requires to be defined and
+versioned early.
+
+## Status
+
+**Stub.** The wire format is not yet specified. M1 introduces the
+synchronous IPC primitive (BUILD_ROADMAP §5.1); that work, and the
+plan tracking it, will populate this document. Until then, do **not**
+treat any in-tree IPC helper as a stable contract.
+
+## To be filled by
+
+- **#180** — *Plan: M1 synchronous IPC primitive (BUILD_ROADMAP §5.1)*
+  is the parent tracking issue. The plan landing under that issue defines
+  the message envelope, endpoint identity, and capability-gated reply
+  path that this document must describe.
+
+Once #180's plan is accepted, this stub must grow to cover at minimum:
+
+- Message envelope layout (header fields, alignment, endianness).
+- Endpoint addressing and how it maps to capability handles
+  (see [`capabilities.md`](./capabilities.md)).
+- Synchronous call / reply semantics and timeout behavior.
+- Error / status model — must reuse the `OS_STATUS_*` codes already used
+  by the syscall surface (see [`syscalls.md`](./syscalls.md)) rather than
+  introducing a parallel error space.
+- Capability-denied behavior on the IPC path — must align with the
+  capability-denied error + log marker contract tracked in **#164**.
+- Compatibility policy: what may change inside `OS_ABI_VERSION = 0`
+  versus what requires an `OS_ABI_VERSION` bump (per
+  [`versioning.md`](./versioning.md)).
+
+## Cross-references
+
+- [`syscalls.md`](./syscalls.md) — user-facing `os_*` syscall surface
+  and `OS_STATUS_*` error model the IPC surface must reuse.
+- [`capabilities.md`](./capabilities.md) — capability handle
+  representation; IPC endpoints are addressed via capability handles.
+- [`versioning.md`](./versioning.md) — `OS_ABI_VERSION` policy that
+  this surface is bound to.
+
+## Provenance
+
+Stub created to satisfy the §7 "four ABI surfaces" requirement called
+out in **#181**. The other three surfaces already have documents in this
+directory:
+
+- syscall ABI → [`syscalls.md`](./syscalls.md)
+- capability handle representation → [`capabilities.md`](./capabilities.md)
+- module manifest schema → [`manifest.md`](./manifest.md)
+
+IPC wire format was the remaining gap. This file fills it as a stub so
+the surface inventory is complete; substantive content is owned by #180.
+
+Last verified against commit: de24ea1


### PR DESCRIPTION
Closes the last open gap from #181's done-when list.

## What

Adds `docs/abi/ipc-wire.md` as a stub for the IPC wire format + error
model ABI surface, and links it from `docs/abi/README.md` and the
top-level `README.md` docs pointer.

## Why this PR (vs #184)

#181 required four ABI surface stubs (syscall, ipc-wire,
capability-handle, manifest). Three landed via already-merged work:

- syscall → `docs/abi/syscalls.md` (PR #97)
- capability handle → `docs/abi/capabilities.md` (PR #97)
- manifest → `docs/abi/manifest.md` (PR #187, closing #183)

The IPC-wire surface was the only remaining file missing on `main`.
PR #184 still has the original four-stub scaffold but now conflicts
with merged content under different filenames; this PR is a minimal
delta on top of current `main` to close the actual remaining gap.

## Contents of the stub

- Standard Owner / Status / Last-reviewed / Applies-to header.
- Points #180 (M1 synchronous IPC plan) at this file as the owner.
- Enumerates the sections #180 must populate: message envelope,
  endpoint addressing via capability handles, sync call/reply
  semantics, `OS_STATUS_*` reuse from the syscall surface,
  alignment with the capability-denied contract in #164, and the
  `OS_ABI_VERSION` compat policy from `versioning.md`.
- Cross-references the three sibling surface docs.

## Validation

Docs-only change. No build / test impact. Verified:

- `git grep` for `docs/abi/` shows the new file is linked from
  `docs/abi/README.md` and the top-level `README.md`.
- No other doc references the old four-file naming (`syscall.md`,
  `capability-handle.md`) on `main`.

## Follow-ups

- Substantive IPC-wire content is owned by #180, not this PR.
- Maintainer may want to close or retarget #184 now that the
  surface inventory is complete on `main`.