### PR TITLE
docs(abi): spec IPC wire format + error model (closes #194)

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -18,8 +18,9 @@ changes are deliberate and reviewable rather than emergent.
   in `docs/architecture/CAPABILITIES.md`.
 - [manifest.md](manifest.md) — Launcher manifest schema: how an app declares
   the capabilities it needs and how the launcher mediates grants today.
-- [ipc-wire.md](ipc-wire.md) — IPC wire format + error model (stub; owned
-  by the M1 synchronous IPC plan, #180).
+- [ipc-wire.md](ipc-wire.md) — IPC wire format (`ipc_msg_v0`) + error
+  model (`ipc_result_t`) for `OS_ABI_VERSION = 0`. Specified by #194;
+  implementation tracked by the M1 sync-IPC plan (#180 / #185).
 - [versioning.md](versioning.md) — `OS_ABI_VERSION` policy, compat-shim
   window, and the process for adding / removing ABI surface.
 

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -1,64 +1,260 @@
-# SecureOS IPC Wire Format
+# SecureOS IPC Wire Format and Error Model
 
-> **Owner:** unassigned
-> **Status:** stub
+> **Owner:** kernel (M1 IPC primitive)
+> **Status:** draft `v0` — normative for `OS_ABI_VERSION = 0`
 > **Last reviewed:** 2026-05-20
 > **Applies to:** `OS_ABI_VERSION = 0`
 
-This document is the canonical home for the inter-process communication
-(IPC) wire format and error model — one of the four ABI surfaces that
-[`BUILD_ROADMAP.md` §7](../../BUILD_ROADMAP.md) requires to be defined and
-versioned early.
+This document is the canonical home for the SecureOS inter-process
+communication (IPC) wire format and error model — one of the four ABI
+surfaces that [`BUILD_ROADMAP.md` §7](../../BUILD_ROADMAP.md) requires to
+be defined and versioned early to prevent churn.
 
-## Status
+It tracks issue **#194** and is the spec counterpart to the M1
+synchronous IPC primitive plan
+[`plans/2026-05-19-m1-sync-ipc-primitive.md`](../../plans/2026-05-19-m1-sync-ipc-primitive.md)
+(closed by #185, parent issue #180). Implementation issues — port table,
+`ipc_send` / `ipc_recv` / `ipc_call`, deny-path tests — are enumerated in
+that plan; this document fixes the wire shape and error vocabulary they
+all must agree on.
 
-**Stub.** The wire format is not yet specified. M1 introduces the
-synchronous IPC primitive (BUILD_ROADMAP §5.1); that work, and the
-plan tracking it, will populate this document. Until then, do **not**
-treat any in-tree IPC helper as a stable contract.
+## 1. Scope
 
-## To be filled by
+In scope (v0):
 
-- **#180** — *Plan: M1 synchronous IPC primitive (BUILD_ROADMAP §5.1)*
-  is the parent tracking issue. The plan landing under that issue defines
-  the message envelope, endpoint identity, and capability-gated reply
-  path that this document must describe.
+- Message envelope layout (`ipc_msg_v0`): header fields, sizes, byte
+  order, alignment, padding.
+- Payload framing: maximum payload size, length field interpretation,
+  reserved bits.
+- Endpoint addressing: how `ipc_port_t` handles relate to the capability
+  handle representation in
+  [`capabilities.md`](./capabilities.md).
+- Operations and their synchronous semantics (`ipc_send`, `ipc_recv`,
+  `ipc_call`).
+- The IPC error class enum (`ipc_result_t`), including the
+  capability-denied path required by the capability-deny contract
+  ([#164 / `capability-deny-contract.md`](./capability-deny-contract.md)).
+- Versioning rule: how IPC frames declare and are gated against
+  `OS_ABI_VERSION` (anchored by [#150](./versioning.md)).
 
-Once #180's plan is accepted, this stub must grow to cover at minimum:
+Explicit v0 non-goals (and therefore explicit ABI non-promises):
 
-- Message envelope layout (header fields, alignment, endianness).
-- Endpoint addressing and how it maps to capability handles
-  (see [`capabilities.md`](./capabilities.md)).
-- Synchronous call / reply semantics and timeout behavior.
-- Error / status model — must reuse the `OS_STATUS_*` codes already used
-  by the syscall surface (see [`syscalls.md`](./syscalls.md)) rather than
-  introducing a parallel error space.
-- Capability-denied behavior on the IPC path — must align with the
-  capability-denied error + log marker contract tracked in **#164**.
-- Compatibility policy: what may change inside `OS_ABI_VERSION = 0`
-  versus what requires an `OS_ABI_VERSION` bump (per
-  [`versioning.md`](./versioning.md)).
+- No asynchronous, queued, or multicast IPC.
+- No zero-copy / shared-memory channels — envelopes are copied on every
+  `send` / `recv`.
+- No `try_send` / `try_recv` / timeouts. All operations block.
+- No cross-address-space delivery across separate processes — v0 runs
+  between two in-kernel test modules. The wire format is shaped so a
+  later process boundary can adopt it without breaking compatibility.
+- No user-space SDK helpers (deferred to M6 / #136).
 
-## Cross-references
+Adding any of the above is a strict-superset change and may land within
+`OS_ABI_VERSION = 0` (additive). Changing what is specified below in a
+non-additive way requires bumping `OS_ABI_VERSION` per
+[`versioning.md`](./versioning.md).
 
-- [`syscalls.md`](./syscalls.md) — user-facing `os_*` syscall surface
-  and `OS_STATUS_*` error model the IPC surface must reuse.
+## 2. Message envelope: `ipc_msg_v0`
+
+```c
+struct ipc_msg_v0 {
+    uint16_t abi_version;     // MUST equal OS_ABI_VERSION (= 0 in v0)
+    uint16_t flags;           // reserved, MBZ in v0
+    uint32_t sender_subject;  // cap_subject_id_t of the sender
+    uint32_t tag;             // caller-defined message tag (see §2.3)
+    uint32_t payload_len;     // 0..IPC_MSG_PAYLOAD_MAX
+    uint8_t  payload[IPC_MSG_PAYLOAD_MAX]; // IPC_MSG_PAYLOAD_MAX = 64
+};
+```
+
+### 2.1 Field semantics
+
+| Offset | Size | Field | Notes |
+| ------ | ---- | ----- | ----- |
+| 0      | 2    | `abi_version`    | `OS_ABI_VERSION` of the sender. Receiver MUST reject mismatches with `IPC_ERR_INVALID_MSG`. |
+| 2      | 2    | `flags`          | Reserved. **Must be zero** (`MBZ`) in v0. Non-zero ⇒ `IPC_ERR_INVALID_MSG`. |
+| 4      | 4    | `sender_subject` | Kernel-stamped on send (see §2.4). Senders MAY pre-populate; the IPC layer overwrites with the authenticated `cap_subject_id_t` of the calling subject before delivery. |
+| 8      | 4    | `tag`            | Opaque to the IPC layer; reserved bits used by `ipc_call` for reply-port encoding (§2.3). |
+| 12     | 4    | `payload_len`    | Number of valid bytes in `payload`. `> IPC_MSG_PAYLOAD_MAX` ⇒ `IPC_ERR_INVALID_MSG`. |
+| 16     | 64   | `payload[]`      | Fixed-size copy region. Bytes beyond `payload_len` are unspecified and MUST NOT be read by the receiver. |
+
+Total envelope size in v0: **80 bytes**. The size is fixed by the ABI;
+changing `IPC_MSG_PAYLOAD_MAX`, the header layout, or the trailing
+padding rule is **not** an additive change and requires an
+`OS_ABI_VERSION` bump.
+
+### 2.2 Byte order, alignment, padding
+
+- All multi-byte fields are **little-endian**.
+- All fields are **naturally aligned** at their offset; there is **no
+  implicit padding** anywhere in the struct.
+- The envelope is a value type — implementations MAY pass it by
+  reference but MUST treat it as a single contiguous 80-byte
+  copy-on-rendezvous unit.
+- `payload` MUST NOT be reinterpreted across the receive boundary
+  without the receiver also bounds-checking `payload_len`. Bytes in
+  `payload[payload_len .. IPC_MSG_PAYLOAD_MAX)` are unspecified.
+
+### 2.3 `tag` field and reply-port encoding (used by `ipc_call`)
+
+`tag` is opaque to `ipc_send` / `ipc_recv`. For `ipc_call` the layout
+inside `tag` is reserved for the reply-port handle plus a caller cookie;
+the exact bit allocation is fixed by the execute issue that lands
+`ipc_call` (per
+[`plans/2026-05-19-m1-sync-ipc-primitive.md`](../../plans/2026-05-19-m1-sync-ipc-primitive.md))
+and will be documented here in the same PR. Until then, `tag` is treated
+as caller-opaque in v0 — receivers MUST NOT decode it.
+
+### 2.4 Sender authentication
+
+`sender_subject` is **kernel-stamped**, not trusted from user input:
+
+- On `ipc_send` / `ipc_call`, the IPC layer overwrites
+  `msg->sender_subject` with the calling subject's `cap_subject_id_t`
+  immediately after the capability check and before the rendezvous copy.
+- Receivers MAY rely on `sender_subject` for policy decisions.
+- A receiver that observes a delivered envelope with
+  `sender_subject == 0` MUST treat it as `IPC_ERR_INVALID_MSG` — a
+  zero subject id is reserved as "unset".
+
+## 3. Endpoint addressing
+
+IPC endpoints are addressed by **opaque port handles**, not by name:
+
+- `ipc_port_t` is a 32-bit handle allocated from a kernel-owned port
+  table (`kernel/ipc/ipc_port.{c,h}` per the M1 plan).
+- The exact bit layout (generation counter vs. table index) is owned by
+  [`capabilities.md`](./capabilities.md) and shared with other
+  capability-handle types so that revocation semantics are uniform.
+- Each port carries an owning subject and the two capability ids
+  required to interact with it:
+  - `recv_cap` — required to receive on the port (default
+    `CAP_IPC_RECV`).
+  - `send_cap` — required to send to the port (default
+    `CAP_IPC_SEND`; ports MAY declare a more specific cap, e.g. a
+    future `CAP_CONSOLE_IPC`).
+
+A port handle is **not** a file descriptor and does not appear in the
+syscall ABI as one. It is a capability handle that the syscall layer
+([`syscalls.md`](./syscalls.md)) carries as an opaque `uint32_t`.
+
+## 4. Operations
+
+Three primitives in v0, all synchronous, all deny-by-default:
+
+| Op | Signature (sketch) | Required cap | Semantics |
+| -- | ------------------ | ------------ | --------- |
+| `ipc_send` | `(ipc_port_t target, const ipc_msg_v0 *msg) → ipc_result_t` | sender holds `target.send_cap` | Blocks until a receiver dequeues the envelope. |
+| `ipc_recv` | `(ipc_port_t self, ipc_msg_v0 *out) → ipc_result_t`         | caller owns `self` and holds `self.recv_cap` | Blocks until a sender rendezvouses on `self`. |
+| `ipc_call` | `(ipc_port_t target, const ipc_msg_v0 *req, ipc_msg_v0 *reply) → ipc_result_t` | sender holds `target.send_cap` and owns the reply port | `send` + `recv` round trip on a caller-owned reply port. Reply-port handle is embedded in `req.tag` (§2.3). |
+
+All three ops route through `cap_gate`-style helpers
+(`cap_ipc_send_gate`, `cap_ipc_recv_gate`) so the capability check
+emits `CAP_AUDIT_OP_CHECK` events into the existing
+`cap_audit_event_t` ring with **no new audit op codes**.
+
+There is no `try_send` / `try_recv` / `timeout` variant in v0. Their
+slot in the error enum (`IPC_ERR_WOULD_BLOCK`, §5) is reserved.
+
+## 5. Error model (`ipc_result_t`)
+
+The IPC layer surfaces a small, frozen-for-v0 error enum. It is the
+**only** vocabulary returned by `ipc_send` / `ipc_recv` / `ipc_call`.
+
+| Value | Name | Meaning |
+| ----- | ---- | ------- |
+| 0 | `IPC_OK` | Operation completed; for `ipc_recv` / `ipc_call`, the out-envelope is populated. |
+| 1 | `IPC_ERR_INVALID_PORT` | Port handle is not in the table, has been destroyed, or generation counter mismatched. (Transport fault — not a capability decision.) |
+| 2 | `IPC_ERR_INVALID_MSG` | `abi_version` mismatch, `payload_len > IPC_MSG_PAYLOAD_MAX`, reserved `flags` set, or `sender_subject == 0` on delivery. (Malformed message.) |
+| 3 | `IPC_ERR_CAP_DENIED` | Caller lacks the required capability for the requested op. Path **must** emit the capability-denied marker per [`capability-deny-contract.md`](./capability-deny-contract.md) (e.g. `CAP:DENY:<subject>:CAP_IPC_SEND`) **before** returning. This is the only IPC error that maps to a capability decision and the only one tests should treat as such. |
+| 4 | `IPC_ERR_WOULD_BLOCK` | Reserved for a future non-blocking path. V0 implementations MUST NOT return this — they block instead and ultimately return `IPC_OK`. Consumers MAY test for it for forward compatibility. |
+| 5 | `IPC_ERR_PEER_GONE` | Peer port was destroyed mid-rendezvous (`ipc_call` only). |
+
+### 5.1 Error class taxonomy
+
+`ipc_result_t` is partitioned into three classes (cross-references #194's
+"capability-denied vs. transport-fault vs. malformed-message" requirement
+and #164's deny-marker contract):
+
+- **Capability decision:** `IPC_ERR_CAP_DENIED`. Only this value indicates
+  that the kernel's capability check rejected the op. Deny-path tests
+  MUST assert on this value **and** on the standard capability-denied log
+  marker emitted per [`capability-deny-contract.md`](./capability-deny-contract.md).
+- **Malformed message:** `IPC_ERR_INVALID_MSG`. Indicates the envelope
+  itself is not parseable under `OS_ABI_VERSION`. MUST NOT be silently
+  collapsed into `IPC_ERR_CAP_DENIED`.
+- **Transport fault:** `IPC_ERR_INVALID_PORT`, `IPC_ERR_PEER_GONE`. The
+  envelope was well-formed and the caller was authorized, but the
+  rendezvous could not complete.
+
+### 5.2 Mapping to `os_status_t`
+
+Where an IPC error must surface through the syscall ABI's
+`os_status_t` ([`syscalls.md`](./syscalls.md)) — e.g. through a future
+`os_ipc_*` syscall — the mapping is:
+
+| `ipc_result_t` | `os_status_t` |
+| --- | --- |
+| `IPC_OK` | `OS_STATUS_OK` |
+| `IPC_ERR_CAP_DENIED` | `OS_STATUS_DENIED` |
+| `IPC_ERR_INVALID_PORT`, `IPC_ERR_PEER_GONE` | `OS_STATUS_ERROR` |
+| `IPC_ERR_INVALID_MSG`, `IPC_ERR_WOULD_BLOCK` | `OS_STATUS_ERROR` |
+
+This preserves the
+[`syscalls.md`](./syscalls.md) invariant that `OS_STATUS_DENIED` is
+the **only** denied result a caller ever observes for a missing
+capability and is never collapsed into `OS_STATUS_ERROR`.
+
+## 6. Versioning
+
+- Every envelope carries `abi_version`. Receivers MUST reject envelopes
+  whose `abi_version != OS_ABI_VERSION` with `IPC_ERR_INVALID_MSG`.
+- The single source of truth for `OS_ABI_VERSION` is the constant
+  anchored by [#150](./versioning.md). The IPC layer MUST consume that
+  constant rather than redefining its own.
+- Additive changes within `OS_ABI_VERSION = 0`:
+  - Adding new entries to `ipc_result_t` is **not** additive — the enum
+    is frozen for v0. Adding new error classes requires an
+    `OS_ABI_VERSION` bump.
+  - Defining new bits in `flags` (today MBZ) requires a bump because
+    existing receivers reject non-zero flags.
+  - Defining new structural meaning for bits inside `tag` is allowed
+    additively, because the IPC layer treats `tag` as opaque.
+  - Adding new operations (e.g. `ipc_try_send`) is additive, provided
+    they use a separate entry point and do not change the existing
+    envelope or error vocabulary.
+- Non-additive changes (header layout, `IPC_MSG_PAYLOAD_MAX`, byte
+  order, alignment, enum semantics) follow the bump policy in
+  [`versioning.md`](./versioning.md).
+
+## 7. Cross-references
+
+- [`syscalls.md`](./syscalls.md) — `OS_STATUS_*` model that IPC errors
+  map onto when surfaced through syscalls. The IPC layer MUST reuse
+  `os_status_t` rather than introducing a parallel surface code at the
+  syscall boundary.
 - [`capabilities.md`](./capabilities.md) — capability handle
-  representation; IPC endpoints are addressed via capability handles.
+  representation; `ipc_port_t` shares this representation and
+  revocation lifecycle.
+- [`capability-deny-contract.md`](./capability-deny-contract.md) —
+  authoritative shape of the capability-denied log marker that
+  `IPC_ERR_CAP_DENIED` MUST emit before returning (per #164).
 - [`versioning.md`](./versioning.md) — `OS_ABI_VERSION` policy that
-  this surface is bound to.
+  this surface is bound to (anchored by #150).
+- [`manifest.md`](./manifest.md) — how a module declares the IPC ports
+  it owns and the `send_cap` / `recv_cap` it requires (ties into the
+  manifest schema landed in #187).
+- [`plans/2026-05-19-m1-sync-ipc-primitive.md`](../../plans/2026-05-19-m1-sync-ipc-primitive.md)
+  — the M1 sync-IPC primitive plan that this document specifies the
+  wire format for (#180 / #185).
+- `BUILD_ROADMAP.md` §5.1 — M1 minimal kernel isolation + IPC
+  skeleton; §7 — ABI freeze plan.
 
-## Provenance
+## 8. Provenance
 
-Stub created to satisfy the §7 "four ABI surfaces" requirement called
-out in **#181**. The other three surfaces already have documents in this
-directory:
+Stub created under #181 (docs/abi scaffold) and filled by **#194** to
+specify the IPC wire format + error model before the M1 sync-IPC
+implementation work begins under #180 / #185. Implementation issues that
+must conform to this surface are enumerated in the M1 plan referenced
+above.
 
-- syscall ABI → [`syscalls.md`](./syscalls.md)
-- capability handle representation → [`capabilities.md`](./capabilities.md)
-- module manifest schema → [`manifest.md`](./manifest.md)
-
-IPC wire format was the remaining gap. This file fills it as a stub so
-the surface inventory is complete; substantive content is owned by #180.
-
-Last verified against commit: de24ea1
+Last verified against commit: c7f777d502b02e1f9e2542f42ff5650b8efce1d6


### PR DESCRIPTION
Closes #194.

Fills `docs/abi/ipc-wire.md` — previously a stub created under #181 and expanded to a placeholder by #191 — with the normative v0 IPC wire format and error model required by BUILD_ROADMAP §7 before M1 sync-IPC implementation begins under #180 / #185.

## What this PR specifies

- **`ipc_msg_v0` envelope** (80 bytes, fixed): `abi_version`, `flags` (MBZ in v0), `sender_subject` (kernel-stamped), `tag`, `payload_len`, 64-byte `payload[]`. Little-endian, naturally aligned, no implicit padding.
- **Endpoint addressing:** `ipc_port_t` handles share the capability-handle representation in `capabilities.md`; each port carries an owning subject plus `send_cap` / `recv_cap` (`CAP_IPC_SEND` / `CAP_IPC_RECV` defaults).
- **Operations:** `ipc_send` / `ipc_recv` / `ipc_call` synchronous semantics, all routed through `cap_gate` helpers so existing `CAP_AUDIT_OP_CHECK` events cover them with no new audit op codes.
- **Error model (`ipc_result_t`)** partitioned into the three classes #194 asks for:
  - capability decision → `IPC_ERR_CAP_DENIED`
  - malformed message → `IPC_ERR_INVALID_MSG`
  - transport fault → `IPC_ERR_INVALID_PORT`, `IPC_ERR_PEER_GONE`
- **`IPC_ERR_CAP_DENIED` must emit the #164 capability-denied marker** before returning, so deny-path tests have one grep contract.
- **`os_status_t` mapping** preserves `syscalls.md`'s invariant that `OS_STATUS_DENIED` is the only denied result and is never collapsed into `OS_STATUS_ERROR`.
- **Versioning:** every envelope carries `abi_version`, sourced from the #150 `OS_ABI_VERSION` anchor; explicit additive vs. bump rules listed.

## Cross-references (all required by #194 done-when)

- BUILD_ROADMAP §5.1 and §7 ✅
- #150 (`OS_ABI_VERSION` anchor) ✅
- #164 (capability-denied marker contract) ✅
- #180 / #185 (M1 sync-IPC plan that this surface is the wire spec for) ✅
- Linked from `docs/abi/README.md` index (entry upgraded from stub) ✅

## Validation

Doc-only change; no code paths touched.

- `docs/abi/ipc-wire.md` rewrites the stub into a normative spec.
- `docs/abi/README.md` index entry upgraded from stub to specified.
- `Last verified against commit` line bumped to current `main` HEAD.

No `build/scripts/test.sh` targets cover docs/; relying on the existing PR validation workflow.

## Follow-ups (not in this PR)

- The exact bit allocation inside `tag` for `ipc_call` reply-port encoding is reserved here and will be filled by the execute issue that lands `ipc_call` (per the M1 plan).
- Numeric IDs for `CAP_IPC_SEND` / `CAP_IPC_RECV` and `os_ipc_*` syscall numbers are owned by the capability + syscall execute issues enumerated in `plans/2026-05-19-m1-sync-ipc-primitive.md`.