### PR TITLE
fix #195: CI manifest schema validation stage

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Kernel entry build
         run: ./build/scripts/build.sh kernel
 
+      - name: Manifest schema validation
+        # Lightweight gate: ensures every in-tree *.manifest.json validates
+        # against the canonical schema at manifests/schema/v0.json. Runs
+        # outside the toolchain container — uses only python3 stdlib so
+        # schema/example drift is caught before the heavier validate_bundle
+        # stage. See issue #195.
+        run: ./build/scripts/validate_manifests.sh
+
       - name: Full validation bundle (machine-readable)
         run: ./build/scripts/validate_bundle.sh
 

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|fs_service|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|manifest_schema|fs_service|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -51,6 +51,7 @@ $testScript = switch ($TestName) {
   "tls" { "./build/scripts/test_tls.sh" }
   "https" { "./build/scripts/test_https.sh" }
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
+  "manifest_schema" { "./build/scripts/validate_manifests.sh" }
   default {
     Write-Host "Unknown test: $TestName"
     Show-Usage

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|netlib_url_scheme|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|tls|https|netlib_url_scheme|manifest_schema|fs_service|app_runtime|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]
 
 Runs SecureOS test targets.
 EOF
@@ -105,6 +105,9 @@ case "$TEST_NAME" in
     "$ROOT_DIR/build/scripts/build_kernel_image.sh"
     "$ROOT_DIR/build/scripts/build_disk_image.sh"
     "$ROOT_DIR/build/scripts/run_qemu.sh" --test kernel_sessions
+    ;;
+  manifest_schema)
+    "$ROOT_DIR/build/scripts/validate_manifests.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -19,6 +19,7 @@ TEST_TARGETS=(
   capability_audit
     event_bus
     sof_format
+    manifest_schema
     fs_service
     app_runtime
     kernel_console

--- a/build/scripts/validate_manifests.ps1
+++ b/build/scripts/validate_manifests.ps1
@@ -1,0 +1,45 @@
+# Validate every in-tree *.manifest.json against the canonical schema.
+# Cross-platform peer: build/scripts/validate_manifests.sh (AGENTS.md / #156).
+[CmdletBinding()]
+param(
+  [string]$Schema = $null
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+if (-not $Schema) {
+  if ($env:MANIFEST_SCHEMA) {
+    $Schema = $env:MANIFEST_SCHEMA
+  } else {
+    $Schema = Join-Path $rootDir "manifests/schema/v0.json"
+  }
+}
+$validator = Join-Path $rootDir "tools/manifest_validate/validate.py"
+
+if (-not (Test-Path $Schema)) {
+  Write-Error "validate_manifests.ps1: schema not found: $Schema"
+  exit 2
+}
+if (-not (Test-Path $validator)) {
+  Write-Error "validate_manifests.ps1: validator not found: $validator"
+  exit 2
+}
+
+$manifests = Get-ChildItem -Path $rootDir -Recurse -File -Filter "*.manifest.json" |
+  Where-Object {
+    $rel = $_.FullName.Substring($rootDir.Length).TrimStart('\','/')
+    -not ($rel.StartsWith(".git") -or $rel.StartsWith("artifacts") -or $rel.StartsWith("build/docker") -or $rel.StartsWith("build\docker"))
+  } |
+  Sort-Object FullName
+
+if ($manifests.Count -eq 0) {
+  Write-Error "validate_manifests.ps1: no *.manifest.json found under $rootDir"
+  exit 2
+}
+
+Write-Host "validate_manifests.ps1: schema=$Schema, $($manifests.Count) manifest(s)"
+$argsList = @("--schema", $Schema) + ($manifests | ForEach-Object { $_.FullName })
+& python3 $validator @argsList
+exit $LASTEXITCODE

--- a/build/scripts/validate_manifests.sh
+++ b/build/scripts/validate_manifests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Validate every in-tree *.manifest.json against the canonical schema.
+# Cross-platform peer: build/scripts/validate_manifests.ps1 (AGENTS.md / #156).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCHEMA="${MANIFEST_SCHEMA:-$ROOT_DIR/manifests/schema/v0.json}"
+VALIDATOR="$ROOT_DIR/tools/manifest_validate/validate.py"
+
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "validate_manifests.sh: schema not found: $SCHEMA" >&2
+  exit 2
+fi
+
+if [[ ! -f "$VALIDATOR" ]]; then
+  echo "validate_manifests.sh: validator not found: $VALIDATOR" >&2
+  exit 2
+fi
+
+# Discover every manifest under the repo. Excludes build/ artifacts/.
+mapfile -t MANIFESTS < <(
+  find "$ROOT_DIR" \
+    \( -path "$ROOT_DIR/.git" -o -path "$ROOT_DIR/artifacts" -o -path "$ROOT_DIR/build/docker" \) -prune \
+    -o -type f -name "*.manifest.json" -print | sort
+)
+
+if [[ ${#MANIFESTS[@]} -eq 0 ]]; then
+  echo "validate_manifests.sh: no *.manifest.json found under $ROOT_DIR" >&2
+  exit 2
+fi
+
+echo "validate_manifests.sh: schema=$SCHEMA, ${#MANIFESTS[@]} manifest(s)"
+python3 "$VALIDATOR" --schema "$SCHEMA" "${MANIFESTS[@]}"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -13,8 +13,20 @@ manifests. The normative specification lives at
 
 ## Validating locally
 
+The simplest path is the in-tree wrapper, which validates every
+`*.manifest.json` under the repo against `schema/v0.json` using only
+`python3` stdlib (no extra pip / npm deps required):
+
 ```bash
-# Either of these works:
+build/scripts/validate_manifests.sh
+# Windows peer:
+# build\scripts\validate_manifests.ps1
+```
+
+This is the same check the PR validation workflow runs (`manifest-schema-validate`
+stage, issue #195). External JSON-Schema tools also work if you prefer:
+
+```bash
 check-jsonschema --schemafile manifests/schema/v0.json \
                  manifests/examples/helloapp.manifest.json
 

--- a/tools/manifest_validate/README.md
+++ b/tools/manifest_validate/README.md
@@ -1,0 +1,54 @@
+# tools/manifest_validate/
+
+Stdlib-only JSON-Schema validator for SecureOS manifests
+(`*.manifest.json`). Used by `build/scripts/validate_manifests.sh` and
+the `manifest-schema-validate` step in the PR validation workflow
+(issue #195).
+
+## Why a custom validator?
+
+- The toolchain image (`build/docker/Dockerfile.toolchain`) intentionally
+  has no Python JSON-Schema dependency. Pulling in `jsonschema` or
+  `check-jsonschema` would mean either re-pinning the toolchain digest
+  (heavy ABI churn) or running the schema check outside the container
+  (drift risk).
+- The schema (`manifests/schema/v0.json`) uses a small, fixed subset of
+  JSON-Schema 2020-12 keywords (`type`, `const`, `enum`, `required`,
+  `properties`, `additionalProperties: false`, `items`, `pattern`,
+  `minLength`, `maxLength`). The validator implements exactly that subset
+  and **rejects any schema that uses an unsupported keyword**, so adding
+  a new schema feature is a deliberate code change instead of a silent
+  no-op.
+
+## Usage
+
+```bash
+python3 tools/manifest_validate/validate.py \
+    --schema manifests/schema/v0.json \
+    manifests/examples/helloapp.manifest.json
+```
+
+Or, to walk the whole tree (the CI path):
+
+```bash
+build/scripts/validate_manifests.sh
+```
+
+External `check-jsonschema` / `ajv` remain valid alternatives for local
+development and are documented in `manifests/README.md`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | All inputs validated |
+| 1    | At least one manifest failed validation (stdout prints `FAIL <path> <pointer> <message>`) |
+| 2    | Usage error, missing schema, or invalid JSON in the schema |
+
+## Status
+
+This tool is intentionally tiny (~200 LOC) and lives inside the repo so
+that schema/example drift is caught with zero external dependencies. If
+the manifest schema grows beyond the supported keyword subset, prefer
+extending the validator rather than swapping it for a heavier dependency
+unless `Dockerfile.toolchain` is being rebuilt anyway.

--- a/tools/manifest_validate/validate.py
+++ b/tools/manifest_validate/validate.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+SecureOS manifest validator (stdlib-only).
+
+Validates one or more `*.manifest.json` files against a JSON-Schema 2020-12
+manifest schema (today: `manifests/schema/v0.json`). Implements only the
+subset of JSON-Schema keywords actually used by that schema so the
+toolchain image does not need an extra pip dependency. See follow-up
+issue #195 / BUILD_ROADMAP §7.
+
+Exit codes:
+  0  every input validated
+  1  validation failure (CLI prints offending file + JSON pointer + rule)
+  2  usage / I/O error
+
+Supported keywords: type, const, enum, required, properties,
+additionalProperties (false only), items (object), pattern, minLength,
+maxLength, description ($schema, $id, title are ignored). Anything else
+in the schema is treated as a hard failure so we never silently let
+unknown rules through.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+KNOWN_KEYWORDS = {
+    "$schema",
+    "$id",
+    "title",
+    "description",
+    "type",
+    "const",
+    "enum",
+    "required",
+    "properties",
+    "additionalProperties",
+    "items",
+    "pattern",
+    "minLength",
+    "maxLength",
+}
+
+
+class ValidationError(Exception):
+    def __init__(self, pointer: str, message: str) -> None:
+        super().__init__(f"{pointer}: {message}")
+        self.pointer = pointer
+        self.message = message
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    raise ValidationError("/", f"unsupported schema type: {expected!r}")
+
+
+def _check_unknown_keywords(schema: dict, pointer: str) -> None:
+    extra = set(schema) - KNOWN_KEYWORDS
+    if extra:
+        raise ValidationError(
+            pointer,
+            "schema uses unsupported keyword(s): " + ", ".join(sorted(extra)),
+        )
+
+
+def _validate(value: Any, schema: dict, pointer: str = "") -> None:
+    _check_unknown_keywords(schema, pointer)
+
+    if "type" in schema:
+        if not _type_matches(value, schema["type"]):
+            raise ValidationError(
+                pointer or "/",
+                f"expected type {schema['type']!r}, got {type(value).__name__}",
+            )
+
+    if "const" in schema and value != schema["const"]:
+        raise ValidationError(
+            pointer or "/", f"expected const {schema['const']!r}, got {value!r}"
+        )
+
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationError(
+            pointer or "/",
+            f"value {value!r} not in enum {schema['enum']!r}",
+        )
+
+    if isinstance(value, str):
+        if "pattern" in schema and not re.search(schema["pattern"], value):
+            raise ValidationError(
+                pointer or "/",
+                f"string {value!r} does not match pattern {schema['pattern']!r}",
+            )
+        if "minLength" in schema and len(value) < schema["minLength"]:
+            raise ValidationError(
+                pointer or "/", f"string shorter than minLength {schema['minLength']}"
+            )
+        if "maxLength" in schema and len(value) > schema["maxLength"]:
+            raise ValidationError(
+                pointer or "/", f"string longer than maxLength {schema['maxLength']}"
+            )
+
+    if isinstance(value, dict):
+        if "required" in schema:
+            for field in schema["required"]:
+                if field not in value:
+                    raise ValidationError(
+                        pointer or "/", f"missing required field {field!r}"
+                    )
+
+        props = schema.get("properties", {})
+        if schema.get("additionalProperties", True) is False:
+            for field in value:
+                if field not in props:
+                    raise ValidationError(
+                        f"{pointer}/{field}",
+                        "unknown field (additionalProperties: false)",
+                    )
+
+        for field, subschema in props.items():
+            if field in value:
+                _validate(value[field], subschema, f"{pointer}/{field}")
+
+    if isinstance(value, list) and "items" in schema:
+        for idx, item in enumerate(value):
+            _validate(item, schema["items"], f"{pointer}/{idx}")
+
+
+def validate_file(manifest_path: Path, schema: dict) -> list[ValidationError]:
+    try:
+        with manifest_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        return [ValidationError("/", f"invalid JSON: {exc}")]
+
+    try:
+        _validate(data, schema, "")
+    except ValidationError as exc:
+        return [exc]
+    return []
+
+
+def _expand_globs(patterns: Iterable[str]) -> list[Path]:
+    out: list[Path] = []
+    for pattern in patterns:
+        matches = sorted(Path(p) for p in glob.glob(pattern, recursive=True))
+        if not matches and not any(c in pattern for c in "*?[]"):
+            matches = [Path(pattern)]
+        out.extend(matches)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SecureOS manifest schema validator")
+    parser.add_argument(
+        "--schema",
+        required=True,
+        help="Path to JSON-Schema file (e.g. manifests/schema/v0.json).",
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="+",
+        help="One or more manifest paths or globs (e.g. 'manifests/examples/*.manifest.json').",
+    )
+    args = parser.parse_args(argv)
+
+    schema_path = Path(args.schema)
+    try:
+        with schema_path.open("r", encoding="utf-8") as handle:
+            schema = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"manifest-validate: cannot read schema {schema_path}: {exc}", file=sys.stderr)
+        return 2
+
+    manifest_paths = _expand_globs(args.manifests)
+    if not manifest_paths:
+        print("manifest-validate: no manifest files matched", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for path in manifest_paths:
+        errors = validate_file(path, schema)
+        if not errors:
+            print(f"PASS {path}")
+            continue
+        failures += 1
+        for err in errors:
+            print(f"FAIL {path} {err.pointer or '/'} {err.message}")
+
+    if failures:
+        print(
+            f"manifest-validate: {failures}/{len(manifest_paths)} manifest(s) failed",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"manifest-validate: {len(manifest_paths)} manifest(s) OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #195.

## What

Adds a `Manifest schema validation` step to the PR validation workflow so
every PR re-validates the in-tree `*.manifest.json` files (today: just
`manifests/examples/helloapp.manifest.json`) against the canonical
`manifests/schema/v0.json`. Schema/example drift now fails CI instead of
shipping silently.

Per BUILD_ROADMAP §7 the manifest schema is one of the four ABI surfaces
frozen early to prevent churn (see #181 / #183 / #187). This PR locks in
the value of that schema work.

## Changes

- `tools/manifest_validate/validate.py` — stdlib-only JSON-Schema 2020-12
  subset validator (~200 LOC). Implements exactly the keywords the v0
  schema uses and **rejects schemas using unknown keywords**, so adding a
  schema feature is always an explicit code change, never a silent no-op.
  No pip/npm deps → no toolchain image rebuild needed.
- `build/scripts/validate_manifests.sh` + `.ps1` — cross-platform wrapper
  (AGENTS.md / #156) that finds every `*.manifest.json` under the repo
  (excluding `.git/`, `artifacts/`, `build/docker/`) and validates it
  against `MANIFEST_SCHEMA` (defaults to `manifests/schema/v0.json`).
- `build/scripts/test.{sh,ps1}` — new `manifest_schema` target.
- `build/scripts/validate_bundle.sh` — adds `manifest_schema` to
  `TEST_TARGETS`.
- `.github/workflows/pr-build.yml` — dedicated `Manifest schema validation`
  step before `validate_bundle` so drift fails fast and outside the
  toolchain container.
- `manifests/README.md` / `tools/manifest_validate/README.md` — updated
  pointers.

## Validation performed

- `./build/scripts/test.sh manifest_schema` → **PASS** on the in-tree
  `helloapp.manifest.json`.
- Negative-path spot checks against `/tmp` copies of the manifest:
  - Removed required `identity` field → **FAIL** (`missing required field`)
  - Added unknown top-level field → **FAIL** (`additionalProperties: false`)
  - Changed `os_abi_version` to a string → **FAIL** (`expected type integer`)

All three exit with code 1 and print `FAIL <path> <pointer> <message>`.

## Done-when mapping (issue #195)

- [x] PR validation workflow has a `manifest-schema-validate` stage on every PR
- [x] Stage passes today against the `helloapp` manifest landed in #187
- [x] Intentional schema break makes the stage fail locally via the same wrapper script
- [x] No drift between `.sh` and `.ps1` wrappers
- [x] No changes to the schema itself

## Base branch

Targeting `issue-181-docs-abi-scaffold` (PR #184), because the schema and
example files this PR validates come from #187's content which currently
only lives on that branch — they are not yet on `main`. Once #184 merges,
this PR can be retargeted to `main` (or merged as part of the same stack).
If a maintainer prefers a different stacking, happy to rebase.

## Follow-ups (not in scope)

- Expand the validator to additional schema files (e.g.
  `manifests/task-dag.schema.json`) once they are referenced by deployable
  manifests.
- Wire `OS_ABI_VERSION` constant (#150) so the schema's `const: 0` is
  cross-checked against the kernel header at the same CI step.

— cron:secureos-hourly-issue-work, 2026-05-20 ~20:00 UTC