### PR TITLE
feat(ci): capability matrix harness (closes #151)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Full validation bundle (machine-readable)
         run: ./build/scripts/validate_bundle.sh
 
+      - name: Capability matrix harness (non-blocking, nightly intent)
+        # Issue #151 / BUILD_ROADMAP §6.1 nightly + §6.2.
+        # Initially advisory: continue-on-error keeps this from deepening the
+        # current PR-red posture while the matrix cells stabilize. Flip to
+        # required once cell coverage and signal are trusted.
+        continue-on-error: true
+        run: ./build/scripts/test_matrix.sh
+
       - name: Upload kernel artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/build/scripts/test_matrix.ps1
+++ b/build/scripts/test_matrix.ps1
@@ -1,0 +1,128 @@
+# test_matrix.ps1 — Windows peer of test_matrix.sh.
+#
+# Capability matrix harness (BUILD_ROADMAP §6.1 nightly / §6.2). Iterates the
+# {cap_set, faux_policy, lifecycle_event} cells declared in
+# tests/matrix/capability_matrix.json and re-runs the corresponding existing
+# validator targets via build/scripts/test.ps1 once per cell. Per-cell logs
+# and a pass/fail JSON are written under artifacts/runs/matrix-<run-id>/,
+# plus a top-level matrix_report.json summary.
+#
+# Kept deliberately parallel to the Bash peer (issue #151, AGENTS.md
+# cross-platform rule, see also #156).
+#
+# Usage:
+#   .\build\scripts\test_matrix.ps1
+#   .\build\scripts\test_matrix.ps1 -CellIds minimal-faux_off-none
+#   $env:SECUREOS_MATRIX_FILE = "path\to\matrix.json"; .\build\scripts\test_matrix.ps1
+
+[CmdletBinding()]
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$CellIds = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$matrixFile = if ($env:SECUREOS_MATRIX_FILE) { $env:SECUREOS_MATRIX_FILE } else { Join-Path $rootDir "tests\matrix\capability_matrix.json" }
+
+if (-not (Test-Path $matrixFile)) {
+  Write-Error "test_matrix: matrix file not found: $matrixFile"
+  exit 2
+}
+
+$gitSha = "unknown"
+try { $gitSha = (& git -C $rootDir rev-parse HEAD 2>$null).Trim() } catch {}
+$gitShort = if ($gitSha -and $gitSha -ne "unknown") { $gitSha.Substring(0, [Math]::Min(7, $gitSha.Length)) } else { "nogit" }
+
+$runId = if ($env:SECUREOS_RUN_ID) { $env:SECUREOS_RUN_ID } else { "matrix-" + (Get-Date -AsUTC -Format "yyyyMMddTHHmmssZ") + "-" + $gitShort }
+$runDir = Join-Path $rootDir "artifacts\runs\$runId"
+$reportPath = Join-Path $runDir "matrix_report.json"
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$doc = Get-Content -Raw -Path $matrixFile | ConvertFrom-Json
+if (-not $doc.cells -or $doc.cells.Count -eq 0) {
+  Write-Error "test_matrix: no cells declared in $matrixFile"
+  exit 2
+}
+
+$overallRc = 0
+$cellResults = @()
+
+foreach ($cell in $doc.cells) {
+  if ($CellIds.Count -gt 0 -and ($CellIds -notcontains $cell.id)) {
+    continue
+  }
+
+  $cellDir = Join-Path $runDir $cell.id
+  New-Item -ItemType Directory -Force -Path $cellDir | Out-Null
+
+  $cellConfig = [ordered]@{
+    id              = $cell.id
+    cap_set         = $cell.cap_set
+    faux_policy     = $cell.faux_policy
+    lifecycle_event = $cell.lifecycle_event
+    targets         = @($cell.targets)
+  }
+  ($cellConfig | ConvertTo-Json -Depth 5) | Set-Content -Path (Join-Path $cellDir "cell.json") -Encoding utf8
+
+  $cellLog = Join-Path $cellDir "cell.log"
+  Set-Content -Path $cellLog -Value "" -Encoding utf8
+  $cellRc = 0
+  $targetStatuses = [ordered]@{}
+
+  foreach ($target in $cell.targets) {
+    $line = "::matrix:: cell=$($cell.id) target=$target"
+    Add-Content -Path $cellLog -Value $line
+    Write-Host $line
+
+    $env:SECUREOS_MATRIX_CELL = $cell.id
+    $env:SECUREOS_MATRIX_CAP_SET = $cell.cap_set
+    $env:SECUREOS_MATRIX_FAUX_POLICY = $cell.faux_policy
+    $env:SECUREOS_MATRIX_LIFECYCLE = $cell.lifecycle_event
+
+    & (Join-Path $PSScriptRoot "test.ps1") $target *>> $cellLog
+    if ($LASTEXITCODE -ne 0) {
+      $cellRc = 1
+      $overallRc = 1
+      $targetStatuses[$target] = "fail"
+    } else {
+      $targetStatuses[$target] = "pass"
+    }
+  }
+
+  $cellStatus = if ($cellRc -ne 0) { "fail" } else { "pass" }
+  $resultObj = [ordered]@{
+    cell    = $cell.id
+    status  = $cellStatus
+    targets = $targetStatuses
+    log     = $cellLog
+  }
+  ($resultObj | ConvertTo-Json -Depth 5) | Set-Content -Path (Join-Path $cellDir "result.json") -Encoding utf8
+
+  $cellResults += [ordered]@{
+    id              = $cell.id
+    cap_set         = $cell.cap_set
+    faux_policy     = $cell.faux_policy
+    lifecycle_event = $cell.lifecycle_event
+    status          = $cellStatus
+    targets         = $targetStatuses
+    artifacts       = $cellDir
+  }
+}
+
+$overallStatus = if ($overallRc -ne 0) { "fail" } else { "pass" }
+$report = [ordered]@{
+  schema       = "secureos.matrix_report.v0"
+  run_id       = $runId
+  generated_at = (Get-Date -AsUTC -Format "yyyy-MM-ddTHH:mm:ssZ")
+  git_sha      = $gitSha
+  matrix_file  = $matrixFile
+  status       = $overallStatus
+  cells        = $cellResults
+}
+($report | ConvertTo-Json -Depth 8) | Set-Content -Path $reportPath -Encoding utf8
+
+Write-Host "test_matrix: report written to $reportPath (status=$overallStatus)"
+exit $overallRc

--- a/build/scripts/test_matrix.sh
+++ b/build/scripts/test_matrix.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# test_matrix.sh — capability matrix harness (BUILD_ROADMAP §6.1 nightly / §6.2)
+#
+# Iterates the {cap_set, faux_policy, lifecycle_event} cells declared in
+# tests/matrix/capability_matrix.json and re-runs the corresponding existing
+# validator targets (see build/scripts/test.sh) once per cell. Per-cell logs
+# and a pass/fail JSON are written under artifacts/runs/matrix-<run-id>/, plus
+# a top-level matrix_report.json summary.
+#
+# Design notes (issue #151):
+#   * This is intentionally a thin orchestrator — it does NOT introduce new
+#     test binaries. Each cell composes onto today's deterministic targets so
+#     adding/removing a cell costs one JSON edit.
+#   * No yaml/jq dependency: matrix file is JSON, parsed with python3 (already
+#     a CI-installed dep per .github/workflows/iso-vm-build.yml).
+#   * Exit code: 0 if all cells pass, 1 otherwise. CI is expected to wire this
+#     as a non-blocking nightly stage until the matrix stabilizes.
+#
+# Usage:
+#   build/scripts/test_matrix.sh                  # run every cell
+#   build/scripts/test_matrix.sh <cell-id>...     # run only the named cells
+#   SECUREOS_MATRIX_FILE=path/to/matrix.json build/scripts/test_matrix.sh
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MATRIX_FILE="${SECUREOS_MATRIX_FILE:-$ROOT_DIR/tests/matrix/capability_matrix.json}"
+RUN_ID="${SECUREOS_RUN_ID:-matrix-$(date -u +"%Y%m%dT%H%M%SZ")-$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo nogit)}"
+RUN_DIR="$ROOT_DIR/artifacts/runs/$RUN_ID"
+REPORT_PATH="$RUN_DIR/matrix_report.json"
+
+mkdir -p "$RUN_DIR"
+
+if [[ ! -f "$MATRIX_FILE" ]]; then
+  echo "test_matrix: matrix file not found: $MATRIX_FILE" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "test_matrix: python3 is required to parse the matrix JSON" >&2
+  exit 2
+fi
+
+# Emit one whitespace-separated line per cell: "<id> <cap_set> <faux_policy> <lifecycle_event> <target1,target2,...>"
+mapfile -t CELLS < <(python3 - "$MATRIX_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    doc = json.load(fh)
+for cell in doc.get("cells", []):
+    targets = ",".join(cell.get("targets", []))
+    print(f"{cell['id']} {cell['cap_set']} {cell['faux_policy']} {cell['lifecycle_event']} {targets}")
+PY
+)
+
+if [[ ${#CELLS[@]} -eq 0 ]]; then
+  echo "test_matrix: no cells declared in $MATRIX_FILE" >&2
+  exit 2
+fi
+
+# Optional cell-id allowlist from positional args.
+SELECTED=()
+if [[ $# -gt 0 ]]; then
+  SELECTED=("$@")
+fi
+
+cell_selected() {
+  local id="$1"
+  if [[ ${#SELECTED[@]} -eq 0 ]]; then
+    return 0
+  fi
+  local s
+  for s in "${SELECTED[@]}"; do
+    [[ "$s" == "$id" ]] && return 0
+  done
+  return 1
+}
+
+OVERALL_RC=0
+CELL_JSON_FRAGMENTS=()
+
+for cell in "${CELLS[@]}"; do
+  # shellcheck disable=SC2206
+  fields=($cell)
+  CELL_ID="${fields[0]}"
+  CAP_SET="${fields[1]}"
+  FAUX_POLICY="${fields[2]}"
+  LIFECYCLE="${fields[3]}"
+  TARGETS_CSV="${fields[4]:-}"
+
+  if ! cell_selected "$CELL_ID"; then
+    continue
+  fi
+
+  CELL_DIR="$RUN_DIR/$CELL_ID"
+  mkdir -p "$CELL_DIR"
+
+  # Persist the cell config alongside its log for forensic replay.
+  cat > "$CELL_DIR/cell.json" <<EOF
+{
+  "id": "$CELL_ID",
+  "cap_set": "$CAP_SET",
+  "faux_policy": "$FAUX_POLICY",
+  "lifecycle_event": "$LIFECYCLE",
+  "targets": [$(printf '"%s",' ${TARGETS_CSV//,/ } | sed 's/,$//')]
+}
+EOF
+
+  CELL_LOG="$CELL_DIR/cell.log"
+  : > "$CELL_LOG"
+  CELL_RC=0
+  TARGET_STATUSES=()
+
+  IFS=',' read -r -a TARGETS <<< "$TARGETS_CSV"
+  for target in "${TARGETS[@]}"; do
+    [[ -z "$target" ]] && continue
+    echo "::matrix:: cell=$CELL_ID target=$target" | tee -a "$CELL_LOG"
+    if SECUREOS_MATRIX_CELL="$CELL_ID" \
+       SECUREOS_MATRIX_CAP_SET="$CAP_SET" \
+       SECUREOS_MATRIX_FAUX_POLICY="$FAUX_POLICY" \
+       SECUREOS_MATRIX_LIFECYCLE="$LIFECYCLE" \
+       "$ROOT_DIR/build/scripts/test.sh" "$target" >>"$CELL_LOG" 2>&1; then
+      TARGET_STATUSES+=("\"$target\":\"pass\"")
+    else
+      CELL_RC=1
+      OVERALL_RC=1
+      TARGET_STATUSES+=("\"$target\":\"fail\"")
+    fi
+  done
+
+  CELL_STATUS="pass"
+  [[ $CELL_RC -ne 0 ]] && CELL_STATUS="fail"
+
+  cat > "$CELL_DIR/result.json" <<EOF
+{
+  "cell": "$CELL_ID",
+  "status": "$CELL_STATUS",
+  "targets": { $(IFS=,; echo "${TARGET_STATUSES[*]}") },
+  "log": "$CELL_DIR/cell.log"
+}
+EOF
+
+  CELL_JSON_FRAGMENTS+=("{\"id\":\"$CELL_ID\",\"cap_set\":\"$CAP_SET\",\"faux_policy\":\"$FAUX_POLICY\",\"lifecycle_event\":\"$LIFECYCLE\",\"status\":\"$CELL_STATUS\",\"targets\":{$(IFS=,; echo "${TARGET_STATUSES[*]}")},\"artifacts\":\"$CELL_DIR\"}")
+done
+
+OVERALL_STATUS="pass"
+[[ $OVERALL_RC -ne 0 ]] && OVERALL_STATUS="fail"
+
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+GIT_SHA="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo unknown)"
+
+{
+  echo "{"
+  echo "  \"schema\": \"secureos.matrix_report.v0\","
+  echo "  \"run_id\": \"$RUN_ID\","
+  echo "  \"generated_at\": \"$GENERATED_AT\","
+  echo "  \"git_sha\": \"$GIT_SHA\","
+  echo "  \"matrix_file\": \"$MATRIX_FILE\","
+  echo "  \"status\": \"$OVERALL_STATUS\","
+  echo "  \"cells\": ["
+  IFS=,
+  echo "    ${CELL_JSON_FRAGMENTS[*]}"
+  unset IFS
+  echo "  ]"
+  echo "}"
+} > "$REPORT_PATH"
+
+echo "test_matrix: report written to $REPORT_PATH (status=$OVERALL_STATUS)"
+exit "$OVERALL_RC"

--- a/docs/test-plans/capability-matrix.md
+++ b/docs/test-plans/capability-matrix.md
@@ -1,0 +1,123 @@
+# Capability Matrix Harness
+
+Scope: BUILD_ROADMAP §6.1 (nightly matrix stage) and §6.2 (matrix dimensions).
+Tracking issue: #151.
+
+## Why
+
+The validator bundle (`build/scripts/validate_bundle.sh` + the per-target
+shells under `build/scripts/test_*.sh`) runs a single configuration per
+target. As the M2 / M3 / M4 acceptance slices land (#92, #108, #115), each
+adds *one* grant path and *one* deny path. Without a matrix runner, every
+new slice multiplies the validator surface manually and §6.3 ("no merge on
+failing capability regression tests") quietly degrades to "the one
+combination we happened to test."
+
+This harness is a thin orchestrator on top of the existing validator
+targets — it does not introduce new test binaries. Cells are declared in
+[`tests/matrix/capability_matrix.json`](../../tests/matrix/capability_matrix.json)
+as `{cap_set, faux_policy, lifecycle_event}` triples plus the list of
+existing `build/scripts/test.sh` targets each cell exercises.
+
+## Dimensions (§6.2)
+
+| Dimension          | Values today                              | Source of truth                              |
+|--------------------|-------------------------------------------|----------------------------------------------|
+| `cap_set`          | `minimal`, `typical`, (future: `full`)    | per-target manifest fixtures                 |
+| `faux_policy`      | `off`, `on`                                | M3 fs_service substitution                   |
+| `lifecycle_event`  | `none`, `owner_revoke`                    | M4/M5 broker revoke / owner-delete           |
+
+Each cell is exposed to the underlying `test.sh` target via four
+environment variables (`SECUREOS_MATRIX_CELL`, `SECUREOS_MATRIX_CAP_SET`,
+`SECUREOS_MATRIX_FAUX_POLICY`, `SECUREOS_MATRIX_LIFECYCLE`) so that
+individual targets can branch on them once they grow matrix-aware
+fixtures. The initial cells re-use existing deterministic targets
+unchanged; cells that the targets ignore today are still useful because
+they will start to bite the moment a target reads its env var.
+
+## Initial cells
+
+See [`tests/matrix/capability_matrix.json`](../../tests/matrix/capability_matrix.json).
+
+1. `minimal-faux_off-none` — today's default posture.
+2. `minimal-faux_on-none` — M3 substitution probe (helloapp_deny +
+   fs_service).
+3. `typical-faux_off-owner_revoke` — M4/M5 lifecycle probe (cap_broker +
+   capability_audit).
+
+## Running
+
+```bash
+# Linux / macOS
+build/scripts/test_matrix.sh                              # all cells
+build/scripts/test_matrix.sh minimal-faux_off-none        # one cell
+```
+
+```powershell
+# Windows
+.\build\scripts\test_matrix.ps1
+.\build\scripts\test_matrix.ps1 minimal-faux_off-none
+```
+
+Override the matrix file with `SECUREOS_MATRIX_FILE=path/to/matrix.json`.
+
+## Artifacts
+
+Each invocation creates `artifacts/runs/matrix-<run-id>/`:
+
+- `matrix_report.json` — top-level summary (`schema:
+  "secureos.matrix_report.v0"`).
+- `<cell-id>/cell.json` — cell config snapshot.
+- `<cell-id>/cell.log` — concatenated stdout/stderr per target.
+- `<cell-id>/result.json` — per-cell `pass`/`fail` + per-target statuses.
+
+The `matrix_report.json` shape mirrors the structure used by
+`validator_report.json` (#110) so reviewers can diff regressions across
+cells:
+
+```json
+{
+  "schema": "secureos.matrix_report.v0",
+  "run_id": "matrix-...",
+  "generated_at": "...",
+  "git_sha": "...",
+  "matrix_file": ".../capability_matrix.json",
+  "status": "pass",
+  "cells": [
+    {
+      "id": "minimal-faux_off-none",
+      "cap_set": "minimal",
+      "faux_policy": "off",
+      "lifecycle_event": "none",
+      "status": "pass",
+      "targets": { "cap_api_contract": "pass", "capability_gate": "pass" },
+      "artifacts": ".../minimal-faux_off-none"
+    }
+  ]
+}
+```
+
+## CI wiring
+
+`pr-build.yml` runs the harness as a **non-blocking nightly job** initially
+(`continue-on-error: true`) so it does not deepen the current PR-red
+situation. Once the cells stabilize the maintainer can flip the stage to
+required.
+
+## Adding cells
+
+1. Edit `tests/matrix/capability_matrix.json` — append a new object to the
+   `cells` array with a unique `id`.
+2. Pick the existing `test.sh` targets that exercise the new combination.
+3. If the targets need new behavior, file a follow-up issue rather than
+   muddying the harness — the matrix layer must stay thin.
+
+## Dependencies / cross-references
+
+- Builds on #110 (validator JSON report) — shares the `schema:` envelope
+  convention.
+- Coordinates with #92 / #108 / #115 (slice acceptance tests) — each new
+  slice should land with at least one cell that exercises both its grant
+  and deny path.
+- Cross-platform parity tracked under #156; the `.sh` ↔ `.ps1` peers are
+  expected to stay in lockstep.

--- a/tests/matrix/capability_matrix.json
+++ b/tests/matrix/capability_matrix.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 0,
+  "description": "Initial capability-matrix harness cells. See docs/test-plans/capability-matrix.md and BUILD_ROADMAP.md §6.1/§6.2. Each cell composes a {cap_set, faux_policy, lifecycle_event} triple onto one or more existing validator targets (see build/scripts/test.sh). The harness is a thin orchestrator: cells re-use today's deterministic targets — they do not introduce new test binaries.",
+  "cells": [
+    {
+      "id": "minimal-faux_off-none",
+      "cap_set": "minimal",
+      "faux_policy": "off",
+      "lifecycle_event": "none",
+      "description": "Today's default posture: only explicitly granted capabilities are honored, no faux substitution, no lifecycle revocation in flight.",
+      "targets": [
+        "cap_api_contract",
+        "capability_gate"
+      ]
+    },
+    {
+      "id": "minimal-faux_on-none",
+      "cap_set": "minimal",
+      "faux_policy": "on",
+      "lifecycle_event": "none",
+      "description": "M3 substitution probe: persistent FS denied, faux/ephemeral substitution legal. Exercises the helloapp deny-path and the ephemeral-write path served by the faux FS scope.",
+      "targets": [
+        "helloapp_deny",
+        "fs_service"
+      ]
+    },
+    {
+      "id": "typical-faux_off-owner_revoke",
+      "cap_set": "typical",
+      "faux_policy": "off",
+      "lifecycle_event": "owner_revoke",
+      "description": "M4/M5 lifecycle probe: capabilities granted by the broker, then revoked while still referenced. Asserts that revoke is durable and audited.",
+      "targets": [
+        "cap_broker",
+        "capability_audit"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #151.

## Summary

Adds a thin matrix runner on top of the existing validator targets so the BUILD_ROADMAP §6.1 nightly stage + §6.2 dimensions (`cap_set`, `faux_policy`, `lifecycle_event`) can be exercised without manually growing the per-target shells every time a new M2/M3/M4 slice lands.

## Changes

- `build/scripts/test_matrix.sh` + `.ps1` peer — iterates cells from a JSON matrix and re-runs `build/scripts/test.sh` targets once per cell; emits per-cell `cell.log` / `result.json` and a top-level `matrix_report.json` (`schema: secureos.matrix_report.v0`).
- `tests/matrix/capability_matrix.json` — three initial cells called out by the issue:
  - `minimal-faux_off-none` → `cap_api_contract`, `capability_gate`
  - `minimal-faux_on-none` → `helloapp_deny`, `fs_service` (M3 substitution probe)
  - `typical-faux_off-owner_revoke` → `cap_broker`, `capability_audit` (M4/M5 lifecycle probe)
- `docs/test-plans/capability-matrix.md` — design notes, dimensions table, report envelope, how to add cells without bloating the orchestrator.
- `.github/workflows/pr-build.yml` — wires the harness as a non-blocking advisory stage (`continue-on-error: true`) per the issue's "non-blocking nightly job initially so it does not deepen the current PR-red situation."

The harness is intentionally a thin orchestrator: cells re-use today's deterministic targets and expose the cell dimensions to each target via `SECUREOS_MATRIX_*` env vars, so individual targets can grow matrix-aware fixtures later without touching the orchestrator.

## Validation

- `bash -n build/scripts/test_matrix.sh` — clean
- `python3 -c 'import json; json.load(open("tests/matrix/capability_matrix.json"))'` — clean
- Smoke run with a synthetic single-cell matrix pointing at a bogus target: harness emitted a well-formed `matrix_report.json` (`status: fail`), exited non-zero, and per-cell artifacts (`cell.json`, `cell.log`, `result.json`) all materialized.
- No new C / kernel code; no behavior change to existing targets.

## Done-when checklist (from #151)

- [x] `build/scripts/test_matrix.sh` + `.ps1` iterate a matrix file
- [x] Initial matrix covers ≥3 cells (the three the issue listed)
- [x] Per-cell `artifacts/runs/matrix-<id>/` directory with config, log, pass/fail JSON
- [x] Top-level `matrix_report.json` summary
- [x] Wired into CI as non-blocking initially
- [x] Documented in `docs/test-plans/`

## Follow-ups

- Per-target matrix awareness: today the targets ignore `SECUREOS_MATRIX_*` envs; the dimensions still gate which target sets are exercised, but per-cell behavior differences will require fixture work in #92 / #108 / #115 follow-ups.
- A `full` `cap_set` value (per §6.2) is reserved but not yet exercised — add once we have a target that legitimately demands the full set.
- Coordinates with #110 (validator JSON report); share the `schema:` envelope convention.