### PR TITLE
fix #195: CI manifest schema validation stage (rebased on main)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Kernel entry build
         run: ./build/scripts/build.sh kernel
 
+      - name: Manifest schema validation
+        # Lightweight gate: ensures every in-tree *.manifest.json validates
+        # against the canonical schema at manifests/schema/v0.json. Runs
+        # outside the toolchain container — uses only python3 stdlib so
+        # schema/example drift is caught before the heavier validate_bundle
+        # stage. See issue #195.
+        run: ./build/scripts/validate_manifests.sh
+
       - name: Full validation bundle (machine-readable)
         run: ./build/scripts/validate_bundle.sh
 

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|manifest_schema|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -53,6 +53,7 @@ $testScript = switch ($TestName) {
   "https" { "./build/scripts/test_https.sh" }
   "bearssl_compile" { "./build/scripts/test_bearssl_compile.sh" }
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
+  "manifest_schema" { "./build/scripts/validate_manifests.sh" }
   default {
     Write-Host "Unknown test: $TestName"
     Show-Usage

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -23,7 +23,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|tls|https|netlib_url_scheme|bearssl_compile|manifest_schema|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report]
 
 Runs SecureOS test targets.
 EOF
@@ -129,6 +129,9 @@ case "$TEST_NAME" in
     "$ROOT_DIR/build/scripts/build_kernel_image.sh"
     "$ROOT_DIR/build/scripts/build_disk_image.sh"
     "$ROOT_DIR/build/scripts/run_qemu.sh" --test kernel_sessions
+    ;;
+  manifest_schema)
+    "$ROOT_DIR/build/scripts/validate_manifests.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -25,6 +25,7 @@ TEST_TARGETS=(
     sof_format
     tls
     https
+    manifest_schema
     fs_service
     app_runtime
     helloapp_allow

--- a/build/scripts/validate_manifests.ps1
+++ b/build/scripts/validate_manifests.ps1
@@ -1,0 +1,45 @@
+# Validate every in-tree *.manifest.json against the canonical schema.
+# Cross-platform peer: build/scripts/validate_manifests.sh (AGENTS.md / #156).
+[CmdletBinding()]
+param(
+  [string]$Schema = $null
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+if (-not $Schema) {
+  if ($env:MANIFEST_SCHEMA) {
+    $Schema = $env:MANIFEST_SCHEMA
+  } else {
+    $Schema = Join-Path $rootDir "manifests/schema/v0.json"
+  }
+}
+$validator = Join-Path $rootDir "tools/manifest_validate/validate.py"
+
+if (-not (Test-Path $Schema)) {
+  Write-Error "validate_manifests.ps1: schema not found: $Schema"
+  exit 2
+}
+if (-not (Test-Path $validator)) {
+  Write-Error "validate_manifests.ps1: validator not found: $validator"
+  exit 2
+}
+
+$manifests = Get-ChildItem -Path $rootDir -Recurse -File -Filter "*.manifest.json" |
+  Where-Object {
+    $rel = $_.FullName.Substring($rootDir.Length).TrimStart('\','/')
+    -not ($rel.StartsWith(".git") -or $rel.StartsWith("artifacts") -or $rel.StartsWith("build/docker") -or $rel.StartsWith("build\docker"))
+  } |
+  Sort-Object FullName
+
+if ($manifests.Count -eq 0) {
+  Write-Error "validate_manifests.ps1: no *.manifest.json found under $rootDir"
+  exit 2
+}
+
+Write-Host "validate_manifests.ps1: schema=$Schema, $($manifests.Count) manifest(s)"
+$argsList = @("--schema", $Schema) + ($manifests | ForEach-Object { $_.FullName })
+& python3 $validator @argsList
+exit $LASTEXITCODE

--- a/build/scripts/validate_manifests.sh
+++ b/build/scripts/validate_manifests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Validate every in-tree *.manifest.json against the canonical schema.
+# Cross-platform peer: build/scripts/validate_manifests.ps1 (AGENTS.md / #156).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCHEMA="${MANIFEST_SCHEMA:-$ROOT_DIR/manifests/schema/v0.json}"
+VALIDATOR="$ROOT_DIR/tools/manifest_validate/validate.py"
+
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "validate_manifests.sh: schema not found: $SCHEMA" >&2
+  exit 2
+fi
+
+if [[ ! -f "$VALIDATOR" ]]; then
+  echo "validate_manifests.sh: validator not found: $VALIDATOR" >&2
+  exit 2
+fi
+
+# Discover every manifest under the repo. Excludes build/ artifacts/.
+mapfile -t MANIFESTS < <(
+  find "$ROOT_DIR" \
+    \( -path "$ROOT_DIR/.git" -o -path "$ROOT_DIR/artifacts" -o -path "$ROOT_DIR/build/docker" \) -prune \
+    -o -type f -name "*.manifest.json" -print | sort
+)
+
+if [[ ${#MANIFESTS[@]} -eq 0 ]]; then
+  echo "validate_manifests.sh: no *.manifest.json found under $ROOT_DIR" >&2
+  exit 2
+fi
+
+echo "validate_manifests.sh: schema=$SCHEMA, ${#MANIFESTS[@]} manifest(s)"
+python3 "$VALIDATOR" --schema "$SCHEMA" "${MANIFESTS[@]}"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,30 @@
+# manifests/
+
+In-tree examples and the machine-readable schema for SecureOS module
+manifests. The normative specification lives at
+[`docs/abi/manifest.md`](../docs/abi/manifest.md) (issue #183).
+
+## Layout
+
+- `schema/v0.json` — JSON-Schema (draft 2020-12) validator for manifest v0.
+  Not yet wired into CI (see follow-up note in `docs/abi/manifest.md` §6).
+- `examples/helloapp.manifest.json` — reference manifest used by the
+  HelloApp acceptance tests (#92) and the M6 SDK template (#136).
+
+## Validating locally
+
+```bash
+# Either of these works:
+check-jsonschema --schemafile manifests/schema/v0.json \
+                 manifests/examples/helloapp.manifest.json
+
+ajv validate -s manifests/schema/v0.json \
+             -d manifests/examples/helloapp.manifest.json --spec=draft2020
+```
+
+## Status
+
+Manifest schema is at `manifest_version = 0` / `OS_ABI_VERSION = 0`. The
+field set, compatibility policy, and capability vocabulary may evolve until
+SDK beta freeze (BUILD_ROADMAP §7); see `docs/abi/manifest.md` §7 for the
+migration rules.

--- a/manifests/examples/helloapp.manifest.json
+++ b/manifests/examples/helloapp.manifest.json
@@ -1,0 +1,23 @@
+{
+  "os_abi_version": 0,
+  "manifest_version": 0,
+  "identity": {
+    "name": "helloapp",
+    "version": "0.1.0",
+    "signer_key_id": "ed25519:da39a3ee5e6b4b0d3255bfef95601890afd80709da39a3ee5e6b4b0d3255bfef9560"
+  },
+  "requested_capabilities": [
+    {
+      "id": "CAP_CONSOLE_WRITE",
+      "required": true,
+      "reason": "HelloApp prints 'hello, secureos' to the user-facing console (BUILD_ROADMAP §5.2 M2 / issue #92)."
+    }
+  ],
+  "provided_services": [],
+  "signature": {
+    "alg": "ed25519",
+    "binary_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/rwrife/SecureOS/manifests/schema/v0.json",
+  "title": "SecureOS module manifest v0",
+  "description": "Schema for SecureOS module manifests at OS_ABI_VERSION=0. See docs/abi/manifest.md (issue #183). Unknown top-level fields are NOT allowed (fail-closed).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "os_abi_version",
+    "manifest_version",
+    "identity",
+    "requested_capabilities",
+    "provided_services",
+    "signature"
+  ],
+  "properties": {
+    "os_abi_version": {
+      "type": "integer",
+      "const": 0,
+      "description": "Must equal the kernel's OS_ABI_VERSION (see #150)."
+    },
+    "manifest_version": {
+      "type": "integer",
+      "const": 0,
+      "description": "Schema revision. v0 only."
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "signer_key_id"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]{0,31}$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$",
+          "description": "SemVer 2.0.0."
+        },
+        "signer_key_id": {
+          "type": "string",
+          "pattern": "^ed25519:[0-9a-f]{64,}$",
+          "description": "v0 supports ed25519 only (per #133 / #137 / #138)."
+        }
+      }
+    },
+    "requested_capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "required"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "CAP_CONSOLE_WRITE",
+              "CAP_SERIAL_WRITE",
+              "CAP_DEBUG_EXIT",
+              "CAP_CAPABILITY_ADMIN",
+              "CAP_DISK_IO_REQUEST",
+              "CAP_FS_READ",
+              "CAP_FS_WRITE",
+              "CAP_EVENT_SUBSCRIBE",
+              "CAP_EVENT_PUBLISH",
+              "CAP_APP_EXEC",
+              "CAP_CODESIGN_BYPASS",
+              "CAP_NETWORK"
+            ]
+          },
+          "required": { "type": "boolean" },
+          "reason": { "type": "string", "maxLength": 512 }
+        }
+      }
+    },
+    "provided_services": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "ipc_endpoint", "stability"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
+          },
+          "ipc_endpoint": {
+            "type": "string",
+            "pattern": "^/[A-Za-z0-9._/-]+$"
+          },
+          "stability": {
+            "type": "string",
+            "enum": ["experimental", "stable", "deprecated"]
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["alg", "binary_sha256", "manifest_sha256", "sig"],
+      "properties": {
+        "alg": { "type": "string", "enum": ["ed25519"] },
+        "binary_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "manifest_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "sig": { "type": "string", "pattern": "^[0-9a-f]{128}$" }
+      }
+    }
+  }
+}

--- a/tools/manifest_validate/README.md
+++ b/tools/manifest_validate/README.md
@@ -1,0 +1,54 @@
+# tools/manifest_validate/
+
+Stdlib-only JSON-Schema validator for SecureOS manifests
+(`*.manifest.json`). Used by `build/scripts/validate_manifests.sh` and
+the `manifest-schema-validate` step in the PR validation workflow
+(issue #195).
+
+## Why a custom validator?
+
+- The toolchain image (`build/docker/Dockerfile.toolchain`) intentionally
+  has no Python JSON-Schema dependency. Pulling in `jsonschema` or
+  `check-jsonschema` would mean either re-pinning the toolchain digest
+  (heavy ABI churn) or running the schema check outside the container
+  (drift risk).
+- The schema (`manifests/schema/v0.json`) uses a small, fixed subset of
+  JSON-Schema 2020-12 keywords (`type`, `const`, `enum`, `required`,
+  `properties`, `additionalProperties: false`, `items`, `pattern`,
+  `minLength`, `maxLength`). The validator implements exactly that subset
+  and **rejects any schema that uses an unsupported keyword**, so adding
+  a new schema feature is a deliberate code change instead of a silent
+  no-op.
+
+## Usage
+
+```bash
+python3 tools/manifest_validate/validate.py \
+    --schema manifests/schema/v0.json \
+    manifests/examples/helloapp.manifest.json
+```
+
+Or, to walk the whole tree (the CI path):
+
+```bash
+build/scripts/validate_manifests.sh
+```
+
+External `check-jsonschema` / `ajv` remain valid alternatives for local
+development and are documented in `manifests/README.md`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | All inputs validated |
+| 1    | At least one manifest failed validation (stdout prints `FAIL <path> <pointer> <message>`) |
+| 2    | Usage error, missing schema, or invalid JSON in the schema |
+
+## Status
+
+This tool is intentionally tiny (~200 LOC) and lives inside the repo so
+that schema/example drift is caught with zero external dependencies. If
+the manifest schema grows beyond the supported keyword subset, prefer
+extending the validator rather than swapping it for a heavier dependency
+unless `Dockerfile.toolchain` is being rebuilt anyway.

--- a/tools/manifest_validate/validate.py
+++ b/tools/manifest_validate/validate.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+SecureOS manifest validator (stdlib-only).
+
+Validates one or more `*.manifest.json` files against a JSON-Schema 2020-12
+manifest schema (today: `manifests/schema/v0.json`). Implements only the
+subset of JSON-Schema keywords actually used by that schema so the
+toolchain image does not need an extra pip dependency. See follow-up
+issue #195 / BUILD_ROADMAP §7.
+
+Exit codes:
+  0  every input validated
+  1  validation failure (CLI prints offending file + JSON pointer + rule)
+  2  usage / I/O error
+
+Supported keywords: type, const, enum, required, properties,
+additionalProperties (false only), items (object), pattern, minLength,
+maxLength, description ($schema, $id, title are ignored). Anything else
+in the schema is treated as a hard failure so we never silently let
+unknown rules through.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+KNOWN_KEYWORDS = {
+    "$schema",
+    "$id",
+    "title",
+    "description",
+    "type",
+    "const",
+    "enum",
+    "required",
+    "properties",
+    "additionalProperties",
+    "items",
+    "pattern",
+    "minLength",
+    "maxLength",
+}
+
+
+class ValidationError(Exception):
+    def __init__(self, pointer: str, message: str) -> None:
+        super().__init__(f"{pointer}: {message}")
+        self.pointer = pointer
+        self.message = message
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    raise ValidationError("/", f"unsupported schema type: {expected!r}")
+
+
+def _check_unknown_keywords(schema: dict, pointer: str) -> None:
+    extra = set(schema) - KNOWN_KEYWORDS
+    if extra:
+        raise ValidationError(
+            pointer,
+            "schema uses unsupported keyword(s): " + ", ".join(sorted(extra)),
+        )
+
+
+def _validate(value: Any, schema: dict, pointer: str = "") -> None:
+    _check_unknown_keywords(schema, pointer)
+
+    if "type" in schema:
+        if not _type_matches(value, schema["type"]):
+            raise ValidationError(
+                pointer or "/",
+                f"expected type {schema['type']!r}, got {type(value).__name__}",
+            )
+
+    if "const" in schema and value != schema["const"]:
+        raise ValidationError(
+            pointer or "/", f"expected const {schema['const']!r}, got {value!r}"
+        )
+
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationError(
+            pointer or "/",
+            f"value {value!r} not in enum {schema['enum']!r}",
+        )
+
+    if isinstance(value, str):
+        if "pattern" in schema and not re.search(schema["pattern"], value):
+            raise ValidationError(
+                pointer or "/",
+                f"string {value!r} does not match pattern {schema['pattern']!r}",
+            )
+        if "minLength" in schema and len(value) < schema["minLength"]:
+            raise ValidationError(
+                pointer or "/", f"string shorter than minLength {schema['minLength']}"
+            )
+        if "maxLength" in schema and len(value) > schema["maxLength"]:
+            raise ValidationError(
+                pointer or "/", f"string longer than maxLength {schema['maxLength']}"
+            )
+
+    if isinstance(value, dict):
+        if "required" in schema:
+            for field in schema["required"]:
+                if field not in value:
+                    raise ValidationError(
+                        pointer or "/", f"missing required field {field!r}"
+                    )
+
+        props = schema.get("properties", {})
+        if schema.get("additionalProperties", True) is False:
+            for field in value:
+                if field not in props:
+                    raise ValidationError(
+                        f"{pointer}/{field}",
+                        "unknown field (additionalProperties: false)",
+                    )
+
+        for field, subschema in props.items():
+            if field in value:
+                _validate(value[field], subschema, f"{pointer}/{field}")
+
+    if isinstance(value, list) and "items" in schema:
+        for idx, item in enumerate(value):
+            _validate(item, schema["items"], f"{pointer}/{idx}")
+
+
+def validate_file(manifest_path: Path, schema: dict) -> list[ValidationError]:
+    try:
+        with manifest_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        return [ValidationError("/", f"invalid JSON: {exc}")]
+
+    try:
+        _validate(data, schema, "")
+    except ValidationError as exc:
+        return [exc]
+    return []
+
+
+def _expand_globs(patterns: Iterable[str]) -> list[Path]:
+    out: list[Path] = []
+    for pattern in patterns:
+        matches = sorted(Path(p) for p in glob.glob(pattern, recursive=True))
+        if not matches and not any(c in pattern for c in "*?[]"):
+            matches = [Path(pattern)]
+        out.extend(matches)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SecureOS manifest schema validator")
+    parser.add_argument(
+        "--schema",
+        required=True,
+        help="Path to JSON-Schema file (e.g. manifests/schema/v0.json).",
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="+",
+        help="One or more manifest paths or globs (e.g. 'manifests/examples/*.manifest.json').",
+    )
+    args = parser.parse_args(argv)
+
+    schema_path = Path(args.schema)
+    try:
+        with schema_path.open("r", encoding="utf-8") as handle:
+            schema = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"manifest-validate: cannot read schema {schema_path}: {exc}", file=sys.stderr)
+        return 2
+
+    manifest_paths = _expand_globs(args.manifests)
+    if not manifest_paths:
+        print("manifest-validate: no manifest files matched", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for path in manifest_paths:
+        errors = validate_file(path, schema)
+        if not errors:
+            print(f"PASS {path}")
+            continue
+        failures += 1
+        for err in errors:
+            print(f"FAIL {path} {err.pointer or '/'} {err.message}")
+
+    if failures:
+        print(
+            f"manifest-validate: {failures}/{len(manifest_paths)} manifest(s) failed",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"manifest-validate: {len(manifest_paths)} manifest(s) OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #195. Supersedes #201 (which targets the never-merged `issue-181-docs-abi-scaffold` stack).

## Why a new PR instead of retargeting #201

PR #201 was stacked on PR #184 (the docs/abi scaffold branch), which never merged because the same content landed via #97 / #187 / #191 on `main` under different file paths. Retargeting #201 to `main` would have a destructive rebase (its content + the v0 schema / example / docs from #187, which is *already on main* as `docs/abi/manifest.md` but with the JSON schema + example files only present on the orphan branch). This PR cherry-picks just the missing artifacts onto current `main` cleanly.

## What

Adds a `Manifest schema validation` step to the PR validation workflow so every PR re-validates the in-tree `*.manifest.json` files against the canonical `manifests/schema/v0.json`. Schema/example drift now fails CI instead of shipping silently.

Per BUILD_ROADMAP §7 the manifest schema is one of the four ABI surfaces frozen early to prevent churn (see #181 / #183 / #187). This PR locks in the value of that schema work.

## Changes

**Brought in from #187 (the v0 schema / example / docs that never made it to main):**
- `manifests/schema/v0.json` — canonical JSON-Schema (draft 2020-12) for manifest v0. Closed schema (`additionalProperties: false`) to enforce fail-closed posture from `docs/abi/manifest.md` §4.
- `manifests/examples/helloapp.manifest.json` — reference manifest used by HelloApp acceptance tests (#92) and the M6 SDK template (#136).
- `manifests/README.md` — local-validation pointers.

**Net-new for #195 (the actual deliverable):**
- `tools/manifest_validate/validate.py` — stdlib-only JSON-Schema 2020-12 subset validator (~220 LOC). Implements exactly the keywords the v0 schema uses and **rejects schemas using unknown keywords**, so adding a schema feature is always an explicit code change. No pip/npm deps → no toolchain image rebuild.
- `build/scripts/validate_manifests.{sh,ps1}` — cross-platform wrapper (AGENTS.md / #156) that finds every `*.manifest.json` under the repo (excluding `.git/`, `artifacts/`, `build/docker/`) and validates each against `MANIFEST_SCHEMA` (default `manifests/schema/v0.json`).
- `build/scripts/test.{sh,ps1}` — new `manifest_schema` target.
- `build/scripts/validate_bundle.sh` — adds `manifest_schema` to `TEST_TARGETS`.
- `.github/workflows/pr-build.yml` — dedicated `Manifest schema validation` step before `validate_bundle` so drift fails fast and outside the toolchain container.

## Validation performed

```
$ ./build/scripts/validate_manifests.sh
validate_manifests.sh: schema=.../manifests/schema/v0.json, 1 manifest(s)
PASS .../manifests/examples/helloapp.manifest.json
manifest-validate: 1 manifest(s) OK

$ ./build/scripts/test.sh manifest_schema
PASS .../manifests/examples/helloapp.manifest.json
manifest-validate: 1 manifest(s) OK
```

Negative-path spot check (removed required `identity` field):

```
$ python3 tools/manifest_validate/validate.py --schema manifests/schema/v0.json /tmp/bad.json
manifest-validate: 1/1 manifest(s) failed
FAIL /tmp/bad.json / missing required field 'identity'
exit=1
```

## Done-when mapping (issue #195)

- [x] PR validation workflow has a `manifest-schema-validate` stage on every PR
- [x] Stage passes today against the `helloapp` manifest
- [x] Intentional schema break makes the stage fail locally via the same wrapper script
- [x] No drift between `.sh` and `.ps1` wrappers
- [x] No changes to the schema itself

## Follow-ups (not in scope)

- Expand validator to additional schema files (e.g. `manifests/task-dag.schema.json`) once they are referenced by deployable manifests.
- Wire `OS_ABI_VERSION` constant (#150) so the schema's `const: 0` is cross-checked against the kernel header at the same CI step.
- Maintainer should close PR #201 as superseded by this one.

— cron:secureos-hourly-issue-work, 2026-05-21 ~01:30 UTC