### PR TITLE
docs(abi): manifest schema v0 + helloapp examples (closes #183)

### DIFF
--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -33,73 +33,144 @@ A non-launcher subject that calls the underlying gate directly without
 its own explicit grant is denied. The bypass-regression test in
 `tests/launcher_console_test.c` proves this.
 
-## Target manifest schema (sketch)
+## Manifest schema v0
+
+The machine-readable schema lives at
+[`manifests/schema/v0.json`](../../manifests/schema/v0.json) (JSON Schema
+draft 2020-12). Worked examples consumed by the HelloApp slice (#82)
+live under [`manifests/examples/`](../../manifests/examples/) —
+`helloapp.json` (allow) and `helloapp.deny.json` (deny).
+
+JSON was chosen over TOML for v0 because:
+
+1. The repo already ships JSON Schema for the task DAG
+   (`manifests/task-dag.schema.json`), so validators and tooling are
+   already pulled in.
+2. The on-image launcher parser stays trivial — no TOML library has to
+   land in the kernel-adjacent code path.
+3. "Unknown field = error" is straightforward to enforce with
+   `additionalProperties: false`, which matches the zero-trust posture.
+
+A representative document:
 
 ```jsonc
 {
   "manifest_version": 0,
+  "os_abi_version": 0,
   "app": {
     "id": "helloapp",
+    "version": "0.1.0",
     "subject_id": 2,
     "binary": "apps/helloapp.bin",
-    "signature": "apps/helloapp.bin.sig"
+    "signer_key_id": "secureos-dev-key-1"
   },
   "capabilities": {
-    "request": [
-      "CAP_CONSOLE_WRITE"
-    ],
+    "request": ["CAP_CONSOLE_WRITE"],
     "optional": []
   },
+  "provides": [],
   "launcher": {
     "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
     "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
   }
 }
 ```
 
-Field semantics we are committing to:
+Field semantics we are committing to at v0:
 
-- `manifest_version` is required and must match the current
-  `OS_ABI_VERSION` family. Unknown fields are an error, not a warning —
-  zero-trust applies to manifest parsing too.
-- `app.subject_id` is the `cap_subject_id_t` the launcher will register
-  for this app. It must be unique across loaded apps.
-- `capabilities.request` lists capabilities the app *may* use. The
-  launcher will refuse to grant anything not listed here.
-- `capabilities.optional` are capabilities the app can tolerate being
-  denied (it must check the `OS_STATUS_DENIED` result and degrade).
-- `launcher.auto_grant_at_launch` is the subset the launcher will grant
-  unconditionally at startup. Anything in `request` but not in
-  `auto_grant_at_launch` must go through `require_user_confirm` (future
-  broker slice, #85) or be explicitly granted by an admin.
-- Signatures are required for any non-bootstrap app once `CAP_APP_EXEC`
-  is enforced end-to-end; today this is bypassable only behind
-  `CAP_CODESIGN_BYPASS` in sealed-build mode.
+- `manifest_version` is required, must equal `0`, and is independent of
+  `os_abi_version` (the schema can iterate inside an ABI family).
+- `os_abi_version` must equal the kernel's `OS_ABI_VERSION` constant
+  (issue #150). Mismatches MUST be rejected by the launcher; this is the
+  hand-shake that ties the manifest to the ABI surface frozen in
+  [`versioning.md`](./versioning.md).
+- Unknown top-level or nested fields are an error, not a warning. This
+  matches `additionalProperties: false` in the schema — zero-trust
+  applies to manifest parsing too.
+- `app.id` is a stable identifier (`^[a-z0-9][a-z0-9_-]{0,62}$`).
+- `app.subject_id` is the `cap_subject_id_t` the launcher registers for
+  this app. It must be unique across loaded apps and fit inside
+  `CAP_TABLE_MAX_SUBJECTS = 8` (see
+  [`capabilities.md`](./capabilities.md)).
+- `capabilities.request` enumerates the capabilities the app *may* use.
+  The launcher will refuse to grant anything not listed here, even if
+  `launcher.auto_grant_at_launch` mentions it.
+- `capabilities.optional` MUST be a subset of `capabilities.request`.
+  Apps that list a capability here MUST check the `OS_STATUS_DENIED`
+  result and degrade gracefully (see
+  [`capability-deny-contract.md`](./capability-deny-contract.md)).
+- `provides[]` lists IPC endpoints the app exposes (see
+  [`ipc-wire.md`](./ipc-wire.md)). Endpoint names use a narrow
+  reverse-DNS-ish pattern.
+- `launcher.auto_grant_at_launch` is the subset the launcher grants
+  unconditionally at startup. It MUST be disjoint from
+  `launcher.require_user_confirm`; both MUST be subsets of
+  `capabilities.request`.
+- `signature` is required for any non-bootstrap app once `CAP_APP_EXEC`
+  is enforced end-to-end (post-#133 chain). At v0 it is permitted to be
+  omitted only for unsigned bootstrap apps under `CAP_CODESIGN_BYPASS`
+  in sealed-build mode.
+
+Validation of these constraints that go beyond pure JSON Schema (subset
+relationships, disjointness, unique subject ids across an image) is the
+launcher's responsibility and is tracked under #82 / #195. This issue
+deliberately does not wire the schema into CI; that is the follow-up in
+#195.
 
 ## Worked example: HelloApp (M2)
 
 The HelloApp slice (#82) registers a subject with the launcher, requests
-`CAP_CONSOLE_WRITE`, and is exercised under two manifests:
+`CAP_CONSOLE_WRITE`, and is exercised under two manifests, both checked
+into [`manifests/examples/`](../../manifests/examples/):
 
-- **Allow manifest** — `auto_grant_at_launch: ["CAP_CONSOLE_WRITE"]`.
-  The app prints its banner; the validator emits
+- **Allow** — [`helloapp.json`](../../manifests/examples/helloapp.json):
+  `auto_grant_at_launch: ["CAP_CONSOLE_WRITE"]`. The app prints its
+  banner; the validator emits
   `TEST:PASS:helloapp_console_write_allowed`.
-- **Deny manifest** — `auto_grant_at_launch: []`.
-  The app's `os_console_write` returns `OS_STATUS_DENIED`; the validator
-  emits `TEST:PASS:helloapp_denied_console_write` and a capability-audit
-  deny event is recorded (see #92 for the dedicated negative-path test
-  and #84 for the audit assertion).
+- **Deny** — [`helloapp.deny.json`](../../manifests/examples/helloapp.deny.json):
+  `auto_grant_at_launch: []`, with `CAP_CONSOLE_WRITE` marked
+  `optional` so the app is required to handle denial gracefully. The
+  app's `os_console_write` returns `OS_STATUS_DENIED`; the validator
+  emits `TEST:PASS:helloapp_denied_console_write` and a
+  capability-audit deny event is recorded (see #92 for the dedicated
+  negative-path test and #84 for the audit assertion).
 
 ## Compatibility policy
 
+`manifest_version` and `os_abi_version` are two intentionally separate
+knobs. `manifest_version` governs the *shape* of this document;
+`os_abi_version` governs the kernel/launcher surface it talks to (see
+[`versioning.md`](./versioning.md), issue #150).
+
 Until `OS_ABI_VERSION` bumps to 1:
 
-- Adding new optional manifest fields is allowed; loaders **must** reject
-  unknown fields on `manifest_version: 0` so behavior cannot silently
-  drift.
-- Adding new capability IDs to `request` is allowed (subject to the rules
-  in [capabilities.md](capabilities.md)).
-- Renaming a field is **not** allowed without bumping
-  `manifest_version`.
+- Adding new optional manifest fields is allowed *only* by also bumping
+  `manifest_version` — because v0 loaders are required to reject unknown
+  fields (`additionalProperties: false`), behavior cannot silently drift
+  in either direction.
+- Adding new capability IDs to `request` is allowed without a version
+  bump, subject to the rules in [`capabilities.md`](./capabilities.md);
+  the schema constrains the identifier *shape*, not the enum of valid
+  values.
+- Tightening a constraint (e.g. narrowing a pattern, making an optional
+  field required) requires a `manifest_version` bump.
+- Renaming or removing any field requires a `manifest_version` bump.
+
+When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
+[`versioning.md`](./versioning.md)):
+
+- A new `manifests/schema/v1.json` is added alongside `v0.json` — v0 is
+  retained for the rolling compat shim window.
+- `manifest_version: 0` documents continue to load on `os_abi_version: 1`
+  hosts *only* while the compat shim is in effect; the launcher emits a
+  deprecation marker when it does.
+- A `manifest_version: 1` document declaring `os_abi_version: 0` is
+  always rejected (you cannot target a newer manifest shape at an older
+  ABI host).
 
 Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,24 @@
+# SecureOS manifests
+
+This directory holds machine-readable manifest schemas and worked
+examples consumed by SecureOS tooling and the launcher.
+
+## Layout
+
+- `schema/v0.json` — App manifest schema, `OS_ABI_VERSION=0` family.
+  See [`docs/abi/manifest.md`](../docs/abi/manifest.md) for the prose
+  spec and field semantics, and [`docs/abi/versioning.md`](../docs/abi/versioning.md)
+  for the compatibility policy that governs schema bumps.
+- `examples/helloapp.json` — allow manifest used by the HelloApp slice
+  (#82). Grants `CAP_CONSOLE_WRITE` at launch.
+- `examples/helloapp.deny.json` — deny manifest counterpart. The app
+  must handle `OS_STATUS_DENIED` gracefully (capability marked
+  `optional`).
+- `task-dag.schema.json` / `task-dag.example.json` — agent task DAG
+  schema, unrelated to the app manifest above. See
+  [`docs/test-plans/task-schema.md`](../docs/test-plans/task-schema.md).
+
+## Wiring
+
+Issue #183 lands the schema and examples without CI enforcement. Wiring
+schema validation into CI is the follow-up tracked in #195.

--- a/manifests/examples/helloapp.deny.json
+++ b/manifests/examples/helloapp.deny.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": ["CAP_CONSOLE_WRITE"]
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": [],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/examples/helloapp.json
+++ b/manifests/examples/helloapp.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": []
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://secureos.dev/schemas/manifest/v0.json",
+  "title": "SecureOS App Manifest (v0)",
+  "description": "Launcher-consumed manifest schema for SecureOS app modules. Bound to OS_ABI_VERSION=0 (see docs/abi/versioning.md, issue #150). Loaders MUST reject unknown fields so behavior cannot silently drift; see docs/abi/manifest.md compatibility policy.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_version", "os_abi_version", "app", "capabilities"],
+  "properties": {
+    "manifest_version": {
+      "description": "Schema version of this document. v0 is the pre-freeze iterating shape; bumping requires updates in docs/abi/manifest.md §Compatibility policy.",
+      "type": "integer",
+      "const": 0
+    },
+    "os_abi_version": {
+      "description": "OS ABI family this manifest targets. Must match the kernel's OS_ABI_VERSION constant (issue #150). A manifest declaring an incompatible value MUST be rejected by the launcher.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "app": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "subject_id", "binary"],
+      "properties": {
+        "id": {
+          "description": "Stable app identifier. Lowercase letters, digits, dash, underscore.",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]{0,62}$"
+        },
+        "version": {
+          "description": "App version. SemVer is recommended but only a non-empty string is enforced at v0.",
+          "type": "string",
+          "minLength": 1
+        },
+        "subject_id": {
+          "description": "cap_subject_id_t the launcher registers for this app. Must be unique across loaded apps; see docs/abi/capabilities.md (CAP_TABLE_MAX_SUBJECTS = 8 at v0).",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 7
+        },
+        "binary": {
+          "description": "Path to the app binary, relative to image root (e.g. apps/helloapp.bin).",
+          "type": "string",
+          "minLength": 1
+        },
+        "signer_key_id": {
+          "description": "Identifier of the ed25519 signing key (see plans/2026-03-16-code-signing-ed25519-chain.md). Required once CAP_APP_EXEC is enforced end-to-end; optional during the M2/M3 transition.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["request"],
+      "properties": {
+        "request": {
+          "description": "Capabilities the app may use. The launcher will refuse to grant anything not listed here, even if launcher.auto_grant_at_launch references it.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capabilityId" }
+        },
+        "optional": {
+          "description": "Subset of `request` that the app tolerates being denied; the app MUST check OS_STATUS_DENIED and degrade gracefully (see docs/abi/capability-deny-contract.md).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capabilityId" },
+          "default": []
+        }
+      }
+    },
+    "provides": {
+      "description": "Services / endpoints this app exposes to other subjects via IPC (see docs/abi/ipc-wire.md). Empty/omitted means the app is a pure consumer.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["endpoint"],
+        "properties": {
+          "endpoint": {
+            "description": "Stable endpoint name. Reverse-DNS-ish recommended (e.g. os.console.write).",
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_.-]{0,127}$"
+          },
+          "requires_capability": {
+            "description": "Capability a caller must already hold to invoke this endpoint, if any. The provider still enforces deny-by-default at the gate.",
+            "$ref": "#/$defs/capabilityId"
+          }
+        }
+      }
+    },
+    "launcher": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auto_grant_at_launch": {
+          "description": "Subset of `capabilities.request` the launcher grants unconditionally at startup. Anything in `request` but not here is denied until brokered (#85) or admin-granted.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capabilityId" },
+          "default": []
+        },
+        "require_user_confirm": {
+          "description": "Subset of `capabilities.request` that must be confirmed by the user (or broker) at launch / on demand. MUST be disjoint from auto_grant_at_launch.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capabilityId" },
+          "default": []
+        }
+      }
+    },
+    "signature": {
+      "description": "Detached signature block. Required once CAP_APP_EXEC is enforced end-to-end (post-#133 chain). Optional at v0 only for unsigned bootstrap apps under CAP_CODESIGN_BYPASS in sealed-build mode.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "signature_path"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "enum": ["ed25519"]
+        },
+        "signer_key_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signature_path": {
+          "description": "Path (relative to image root) of the detached signature file covering `app.binary`.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "capabilityId": {
+      "description": "Capability identifier as listed in docs/abi/capabilities.md. Pattern is intentionally narrow so typos surface at validation time rather than at grant time.",
+      "type": "string",
+      "pattern": "^CAP_[A-Z0-9_]{2,62}$"
+    }
+  }
+}


### PR DESCRIPTION
Closes #183.

## Summary

Lands the v0 SecureOS app manifest schema and two worked HelloApp manifests, and fleshes out the prose spec to match. Pure docs + JSON; no code, no launcher wiring, no CI changes.

## Changes

- `manifests/schema/v0.json` — JSON Schema (draft 2020-12) for the v0 app manifest. Covers:
  - module identity (`app.id`, `app.version`, `app.subject_id`, `app.binary`, optional `signer_key_id`)
  - `capabilities.request` / `capabilities.optional` (typed `CAP_*` identifiers)
  - `provides[]` IPC endpoints (see `docs/abi/ipc-wire.md`)
  - `launcher.auto_grant_at_launch` / `require_user_confirm`
  - `signature` block (ed25519, per #133 chain)
  - explicit `os_abi_version` handshake referencing #150
  - `additionalProperties: false` everywhere (unknown field = error, zero-trust on parsing)
- `manifests/examples/helloapp.json` — allow manifest (auto-grants `CAP_CONSOLE_WRITE`).
- `manifests/examples/helloapp.deny.json` — deny manifest counterpart (capability marked `optional` so app must handle `OS_STATUS_DENIED`).
- `docs/abi/manifest.md` — replaces the sketch section with the concrete v0 shape, justifies JSON over TOML, separates `manifest_version` (document shape) from `os_abi_version` (kernel surface), and documents the compat policy through the eventual `OS_ABI_VERSION=1` freeze.
- `manifests/README.md` — directory map, points CI wiring at follow-up #195.

## Done-when (from #183)

- [x] `docs/abi/manifest.md` filled with the v0 schema definition.
- [x] Schema covers module identity, requested capabilities, provided endpoints, `os_abi_version`, signature block.
- [x] Example manifest under `manifests/examples/helloapp.json` (JSON chosen; rationale in the doc).
- [x] Machine-readable validator stub at `manifests/schema/v0.json`.
- [x] Compatibility policy documenting v0 → v1 interaction with `OS_ABI_VERSION` freeze.
- [x] No code changes; no launcher wiring.

## Validation

- Both example manifests validate against `schema/v0.json` with a `jsonschema` Draft202012Validator (0 errors each).
- `Draft202012Validator.check_schema` accepts `schema/v0.json`.

## Follow-ups

- #195 — wire schema validation into CI (intentionally out of scope here, per the issue).
- #82 / #115 — launcher consumes `capabilities.request` / `launcher.auto_grant_at_launch` and enforces subset/disjointness invariants beyond pure JSON Schema.
- #150 — `os_abi_version` field is wired to whatever single source of truth lands from that issue.
