### PR TITLE
feat(cap): tenant-scoped workflow rule layer (closes #77)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -48,6 +48,7 @@ test_sof_format
 test_sof_verify_at_rest
 test_tls
 test_validator_report
+test_workflow_rule
 
 # Shared bash helper module for os-* wrappers. Not a user-invoked entry
 # point; the PowerShell wrappers use common.ps1 instead.

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -62,6 +62,7 @@ $testScript = switch ($TestName) {
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
+  "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }
   default {
     Write-Host "Unknown test: $TestName"
     Show-Usage

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -114,6 +114,9 @@ case "$TEST_NAME" in
     ;;
   cap_broker)
     run_script "$ROOT_DIR/build/scripts/test_cap_broker.sh"
+    ;;
+  workflow_rule)
+    run_script "$ROOT_DIR/build/scripts/test_workflow_rule.sh"
     ;;
   launcher_console)
     run_script "$ROOT_DIR/build/scripts/test_launcher_console.sh"

--- a/build/scripts/test_workflow_rule.sh
+++ b/build/scripts/test_workflow_rule.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# test_workflow_rule.sh — Validator dispatcher for the workflow rule
+# slice (issue #77 / plan 2026-04-08-zero-trust-workflow-rule-hardening).
+#
+# Compiles `tests/workflow_rule_test.c` against the new
+# `kernel/cap/workflow_rule.c` translation unit and asserts every
+# expected TEST:PASS marker plus the TEST:DONE sentinel.
+#
+# Launched by build/scripts/test.sh (target: workflow_rule).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/workflow_rule.c" \
+  "$ROOT_DIR/tests/workflow_rule_test.c" \
+  -o "$OUT_DIR/workflow_rule_test"
+
+LOG_PATH="$OUT_DIR/workflow_rule_test.log"
+"$OUT_DIR/workflow_rule_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:workflow_rule_allow_path"           "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_cross_tenant_deny"    "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_scope_mismatch_deny"  "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_audit_non_interference" "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_input_validation"     "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_capacity"             "$LOG_PATH"
+grep -q "TEST:PASS:workflow_rule_audit_format"         "$LOG_PATH"
+grep -q "TEST:DONE:workflow_rule"                      "$LOG_PATH"

--- a/kernel/cap/workflow_rule.c
+++ b/kernel/cap/workflow_rule.c
@@ -1,0 +1,444 @@
+/**
+ * @file workflow_rule.c
+ * @brief Tenant-scoped, scope-explicit workflow rule layer (issue #77).
+ *
+ * Implementation of the slice described in
+ * `plans/2026-04-08-zero-trust-workflow-rule-hardening.md` and the
+ * companion header `workflow_rule.h`.
+ *
+ * Design notes:
+ *   - All state lives in this translation unit. No heap, no globals
+ *     exposed across modules. The slice is intentionally self-contained
+ *     so it cannot regress existing capability or audit semantics.
+ *   - Evaluation is a single function (`workflow_rule_eval_locked`)
+ *     parameterized by the requested scope; the public `_read` and
+ *     `_write` wrappers exist solely to make scope explicit at the
+ *     call site (no implicit READ_WRITE path).
+ *   - Cross-tenant lookups, scope mismatches, and unknown rule ids
+ *     all collapse to a single `WORKFLOW_ERR_MISSING` result so the
+ *     existence of a rule does not leak between tenants.
+ *   - Audit recording is non-interfering: the evaluator computes the
+ *     result first, then records, then returns. A full audit ring
+ *     drops the oldest record (bounded volume) but does not change
+ *     the returned result.
+ *
+ * Used by:
+ *   - tests/workflow_rule_test.c (allow/deny/scope-mismatch coverage),
+ *   - build/scripts/test_workflow_rule.sh (validator dispatcher).
+ *
+ * Not yet used by:
+ *   - kernel boot path / persistence (out of scope for this slice;
+ *     tracked in the plan follow-ups).
+ */
+
+#include "workflow_rule.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+  uint8_t              in_use;
+  workflow_tenant_id_t tenant_id;
+  workflow_rule_id_t   rule_id;
+  workflow_scope_t     scope;
+  cap_subject_id_t     subject_id;
+  capability_id_t      capability_id;
+  workflow_reason_t    reason;
+} workflow_rule_slot_t;
+
+static workflow_rule_slot_t   g_rules[WORKFLOW_RULE_MAX_RULES];
+static workflow_audit_event_t g_audit_ring[WORKFLOW_AUDIT_EVENT_MAX];
+static size_t                 g_audit_count;
+static size_t                 g_audit_dropped;
+static uint64_t               g_audit_next_sequence;
+
+/* ------------------------------------------------------------------ */
+/* Internal helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+static int scope_is_directional(workflow_scope_t scope) {
+  return scope == WORKFLOW_SCOPE_READ || scope == WORKFLOW_SCOPE_WRITE;
+}
+
+static int reason_is_valid(workflow_reason_t reason) {
+  switch (reason) {
+    case WORKFLOW_REASON_TENANT_POLICY:
+    case WORKFLOW_REASON_OPERATOR:
+    case WORKFLOW_REASON_AUTOMATION:
+      return 1;
+    case WORKFLOW_REASON_NONE:
+    default:
+      return 0;
+  }
+}
+
+static int capability_is_known(capability_id_t cap) {
+  switch (cap) {
+    case CAP_CONSOLE_WRITE:
+    case CAP_SERIAL_WRITE:
+    case CAP_DEBUG_EXIT:
+    case CAP_CAPABILITY_ADMIN:
+    case CAP_DISK_IO_REQUEST:
+    case CAP_FS_READ:
+    case CAP_FS_WRITE:
+    case CAP_EVENT_SUBSCRIBE:
+    case CAP_EVENT_PUBLISH:
+    case CAP_APP_EXEC:
+    case CAP_CODESIGN_BYPASS:
+    case CAP_NETWORK:
+      return 1;
+  }
+  return 0;
+}
+
+static workflow_rule_slot_t *find_slot_for_tenant(workflow_tenant_id_t tenant_id,
+                                                  workflow_rule_id_t   rule_id) {
+  for (size_t i = 0; i < WORKFLOW_RULE_MAX_RULES; ++i) {
+    workflow_rule_slot_t *slot = &g_rules[i];
+    if (!slot->in_use) {
+      continue;
+    }
+    if (slot->tenant_id == tenant_id && slot->rule_id == rule_id) {
+      return slot;
+    }
+  }
+  return NULL;
+}
+
+static workflow_rule_slot_t *find_free_slot(void) {
+  for (size_t i = 0; i < WORKFLOW_RULE_MAX_RULES; ++i) {
+    if (!g_rules[i].in_use) {
+      return &g_rules[i];
+    }
+  }
+  return NULL;
+}
+
+static workflow_audit_outcome_t result_to_outcome(workflow_result_t result) {
+  return (result == WORKFLOW_OK) ? WORKFLOW_AUDIT_OUTCOME_ALLOW
+                                 : WORKFLOW_AUDIT_OUTCOME_DENY;
+}
+
+static void audit_record(workflow_audit_op_t       operation,
+                         workflow_tenant_id_t      tenant_id,
+                         workflow_rule_id_t        rule_id,
+                         workflow_scope_t          scope_requested,
+                         cap_subject_id_t          subject_id,
+                         capability_id_t           capability_id,
+                         workflow_reason_t         reason,
+                         workflow_result_t         result) {
+  workflow_audit_event_t event;
+  event.sequence_id     = g_audit_next_sequence++;
+  event.operation       = operation;
+  event.tenant_id       = tenant_id;
+  event.rule_id         = rule_id;
+  event.scope_requested = scope_requested;
+  event.subject_id      = subject_id;
+  event.capability_id   = capability_id;
+  event.reason          = reason;
+  event.result          = result;
+  event.outcome         = result_to_outcome(result);
+
+  if (g_audit_count < WORKFLOW_AUDIT_EVENT_MAX) {
+    g_audit_ring[g_audit_count++] = event;
+    return;
+  }
+
+  /* Ring is full. Drop the oldest, shift, append. Bounded volume,
+   * non-interfering with the just-computed result. */
+  for (size_t i = 1; i < WORKFLOW_AUDIT_EVENT_MAX; ++i) {
+    g_audit_ring[i - 1] = g_audit_ring[i];
+  }
+  g_audit_ring[WORKFLOW_AUDIT_EVENT_MAX - 1] = event;
+  g_audit_dropped++;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+void workflow_rule_reset_for_tests(void) {
+  memset(g_rules, 0, sizeof(g_rules));
+  memset(g_audit_ring, 0, sizeof(g_audit_ring));
+  g_audit_count = 0;
+  g_audit_dropped = 0;
+  g_audit_next_sequence = 0;
+}
+
+workflow_result_t workflow_rule_register(workflow_tenant_id_t tenant_id,
+                                         workflow_rule_id_t   rule_id,
+                                         workflow_scope_t     scope,
+                                         cap_subject_id_t     subject_id,
+                                         capability_id_t      capability_id,
+                                         workflow_reason_t    reason) {
+  if (tenant_id == WORKFLOW_RULE_TENANT_INVALID) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_TENANT_INVALID);
+    return WORKFLOW_ERR_TENANT_INVALID;
+  }
+  if (rule_id == WORKFLOW_RULE_ID_INVALID) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_RULE_INVALID);
+    return WORKFLOW_ERR_RULE_INVALID;
+  }
+  if (!scope_is_directional(scope)) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_SCOPE_INVALID);
+    return WORKFLOW_ERR_SCOPE_INVALID;
+  }
+  if (subject_id == 0u) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_SUBJECT_INVALID);
+    return WORKFLOW_ERR_SUBJECT_INVALID;
+  }
+  if (!capability_is_known(capability_id)) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_CAPABILITY_INVALID);
+    return WORKFLOW_ERR_CAPABILITY_INVALID;
+  }
+  if (!reason_is_valid(reason)) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_REASON_INVALID);
+    return WORKFLOW_ERR_REASON_INVALID;
+  }
+
+  if (find_slot_for_tenant(tenant_id, rule_id) != NULL) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_DUPLICATE);
+    return WORKFLOW_ERR_DUPLICATE;
+  }
+
+  workflow_rule_slot_t *slot = find_free_slot();
+  if (slot == NULL) {
+    audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+                 subject_id, capability_id, reason,
+                 WORKFLOW_ERR_NO_SLOT);
+    return WORKFLOW_ERR_NO_SLOT;
+  }
+
+  slot->in_use        = 1u;
+  slot->tenant_id     = tenant_id;
+  slot->rule_id       = rule_id;
+  slot->scope         = scope;
+  slot->subject_id    = subject_id;
+  slot->capability_id = capability_id;
+  slot->reason        = reason;
+
+  audit_record(WORKFLOW_AUDIT_OP_REGISTER, tenant_id, rule_id, scope,
+               subject_id, capability_id, reason, WORKFLOW_OK);
+  return WORKFLOW_OK;
+}
+
+static workflow_result_t eval_locked(workflow_audit_op_t  audit_op,
+                                     workflow_scope_t     requested_scope,
+                                     workflow_tenant_id_t caller_tenant_id,
+                                     workflow_rule_id_t   rule_id,
+                                     cap_subject_id_t     subject_id,
+                                     capability_id_t      capability_id) {
+  /* Fail-closed input checks. Note: we deliberately do *not* surface
+   * distinct error codes for tenant-mismatch vs missing-rule vs
+   * scope-mismatch on the evaluation path — they all collapse to
+   * WORKFLOW_ERR_MISSING so existence does not leak across tenants. */
+
+  workflow_result_t result;
+
+  if (caller_tenant_id == WORKFLOW_RULE_TENANT_INVALID ||
+      rule_id == WORKFLOW_RULE_ID_INVALID ||
+      !scope_is_directional(requested_scope) ||
+      subject_id == 0u ||
+      !capability_is_known(capability_id)) {
+    result = WORKFLOW_ERR_MISSING;
+    audit_record(audit_op, caller_tenant_id, rule_id, requested_scope,
+                 subject_id, capability_id, WORKFLOW_REASON_NONE, result);
+    return result;
+  }
+
+  workflow_rule_slot_t *slot = find_slot_for_tenant(caller_tenant_id, rule_id);
+  if (slot == NULL) {
+    result = WORKFLOW_ERR_MISSING;
+    audit_record(audit_op, caller_tenant_id, rule_id, requested_scope,
+                 subject_id, capability_id, WORKFLOW_REASON_NONE, result);
+    return result;
+  }
+
+  if (slot->scope != requested_scope ||
+      slot->subject_id != subject_id ||
+      slot->capability_id != capability_id) {
+    result = WORKFLOW_ERR_MISSING;
+    audit_record(audit_op, caller_tenant_id, rule_id, requested_scope,
+                 subject_id, capability_id, slot->reason, result);
+    return result;
+  }
+
+  result = WORKFLOW_OK;
+  audit_record(audit_op, caller_tenant_id, rule_id, requested_scope,
+               subject_id, capability_id, slot->reason, result);
+  return result;
+}
+
+workflow_result_t workflow_rule_eval_read(workflow_tenant_id_t caller_tenant_id,
+                                          workflow_rule_id_t   rule_id,
+                                          cap_subject_id_t     subject_id,
+                                          capability_id_t      capability_id) {
+  return eval_locked(WORKFLOW_AUDIT_OP_EVAL_READ,
+                     WORKFLOW_SCOPE_READ,
+                     caller_tenant_id, rule_id, subject_id, capability_id);
+}
+
+workflow_result_t workflow_rule_eval_write(workflow_tenant_id_t caller_tenant_id,
+                                           workflow_rule_id_t   rule_id,
+                                           cap_subject_id_t     subject_id,
+                                           capability_id_t      capability_id) {
+  return eval_locked(WORKFLOW_AUDIT_OP_EVAL_WRITE,
+                     WORKFLOW_SCOPE_WRITE,
+                     caller_tenant_id, rule_id, subject_id, capability_id);
+}
+
+size_t workflow_audit_count_for_tests(void) {
+  return g_audit_count;
+}
+
+size_t workflow_audit_dropped_for_tests(void) {
+  return g_audit_dropped;
+}
+
+workflow_result_t workflow_audit_get_for_tests(size_t index,
+                                               workflow_audit_event_t *out_event) {
+  if (out_event == NULL) {
+    return WORKFLOW_ERR_MISSING;
+  }
+  if (index >= g_audit_count) {
+    return WORKFLOW_ERR_MISSING;
+  }
+  *out_event = g_audit_ring[index];
+  return WORKFLOW_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* Formatter                                                           */
+/* ------------------------------------------------------------------ */
+
+static const char *audit_op_name(workflow_audit_op_t op) {
+  switch (op) {
+    case WORKFLOW_AUDIT_OP_REGISTER:   return "REGISTER";
+    case WORKFLOW_AUDIT_OP_EVAL_READ:  return "EVAL_READ";
+    case WORKFLOW_AUDIT_OP_EVAL_WRITE: return "EVAL_WRITE";
+  }
+  return "UNKNOWN";
+}
+
+static const char *scope_name(workflow_scope_t scope) {
+  switch (scope) {
+    case WORKFLOW_SCOPE_NONE:  return "NONE";
+    case WORKFLOW_SCOPE_READ:  return "READ";
+    case WORKFLOW_SCOPE_WRITE: return "WRITE";
+  }
+  return "UNKNOWN";
+}
+
+static const char *reason_name(workflow_reason_t reason) {
+  switch (reason) {
+    case WORKFLOW_REASON_NONE:          return "NONE";
+    case WORKFLOW_REASON_TENANT_POLICY: return "TENANT_POLICY";
+    case WORKFLOW_REASON_OPERATOR:      return "OPERATOR";
+    case WORKFLOW_REASON_AUTOMATION:    return "AUTOMATION";
+  }
+  return "UNKNOWN";
+}
+
+static const char *result_name(workflow_result_t result) {
+  switch (result) {
+    case WORKFLOW_OK:                     return "OK";
+    case WORKFLOW_ERR_MISSING:            return "MISSING";
+    case WORKFLOW_ERR_TENANT_INVALID:     return "TENANT_INVALID";
+    case WORKFLOW_ERR_RULE_INVALID:       return "RULE_INVALID";
+    case WORKFLOW_ERR_SCOPE_INVALID:      return "SCOPE_INVALID";
+    case WORKFLOW_ERR_SUBJECT_INVALID:    return "SUBJECT_INVALID";
+    case WORKFLOW_ERR_CAPABILITY_INVALID: return "CAPABILITY_INVALID";
+    case WORKFLOW_ERR_REASON_INVALID:     return "REASON_INVALID";
+    case WORKFLOW_ERR_DUPLICATE:          return "DUPLICATE";
+    case WORKFLOW_ERR_NO_SLOT:            return "NO_SLOT";
+  }
+  return "UNKNOWN";
+}
+
+static const char *outcome_name(workflow_audit_outcome_t outcome) {
+  switch (outcome) {
+    case WORKFLOW_AUDIT_OUTCOME_ALLOW: return "ALLOW";
+    case WORKFLOW_AUDIT_OUTCOME_DENY:  return "DENY";
+  }
+  return "UNKNOWN";
+}
+
+/* Tiny unsigned-to-decimal helper so the formatter has no libc deps
+ * beyond <string.h>. Writes into `buf` at `*pos` and bumps `*pos`. */
+static int u64_emit(char *buf, size_t buf_size, size_t *pos, uint64_t value) {
+  char tmp[24];
+  size_t n = 0;
+  if (value == 0) {
+    tmp[n++] = '0';
+  } else {
+    while (value > 0 && n < sizeof(tmp)) {
+      tmp[n++] = (char)('0' + (value % 10u));
+      value /= 10u;
+    }
+  }
+  if (*pos + n >= buf_size) {
+    return -1;
+  }
+  for (size_t i = 0; i < n; ++i) {
+    buf[*pos + i] = tmp[n - 1 - i];
+  }
+  *pos += n;
+  return 0;
+}
+
+static int str_emit(char *buf, size_t buf_size, size_t *pos, const char *s) {
+  size_t n = strlen(s);
+  if (*pos + n >= buf_size) {
+    return -1;
+  }
+  memcpy(buf + *pos, s, n);
+  *pos += n;
+  return 0;
+}
+
+int workflow_audit_format_event(const workflow_audit_event_t *event,
+                                char *buf,
+                                size_t buf_size) {
+  if (event == NULL || buf == NULL || buf_size == 0) {
+    return -1;
+  }
+  size_t pos = 0;
+  if (str_emit(buf, buf_size, &pos, "WORKFLOW_AUDIT:seq=") != 0) return -1;
+  if (u64_emit(buf, buf_size, &pos, event->sequence_id) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":op=") != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, audit_op_name(event->operation)) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":tenant=") != 0) return -1;
+  if (u64_emit(buf, buf_size, &pos, (uint64_t)event->tenant_id) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":rule=") != 0) return -1;
+  if (u64_emit(buf, buf_size, &pos, (uint64_t)event->rule_id) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":scope=") != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, scope_name(event->scope_requested)) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":subject=") != 0) return -1;
+  if (u64_emit(buf, buf_size, &pos, (uint64_t)event->subject_id) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":cap=") != 0) return -1;
+  if (u64_emit(buf, buf_size, &pos, (uint64_t)event->capability_id) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":reason=") != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, reason_name(event->reason)) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":result=") != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, result_name(event->result)) != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, ":outcome=") != 0) return -1;
+  if (str_emit(buf, buf_size, &pos, outcome_name(event->outcome)) != 0) return -1;
+
+  buf[pos] = '\0';
+  return (int)pos;
+}

--- a/kernel/cap/workflow_rule.h
+++ b/kernel/cap/workflow_rule.h
@@ -1,0 +1,198 @@
+#ifndef SECUREOS_WORKFLOW_RULE_H
+#define SECUREOS_WORKFLOW_RULE_H
+
+/**
+ * @file workflow_rule.h
+ * @brief Tenant-scoped, scope-explicit workflow rule layer (issue #77).
+ *
+ * Purpose:
+ *   Minimal persisted workflow-rule table whose evaluation is:
+ *     - tenant-scoped end-to-end (no ambient or cross-tenant lookups),
+ *     - explicit per-direction (READ vs WRITE, no implicit READ_WRITE),
+ *     - deny-by-default for missing, malformed, or scope-mismatched rules.
+ *
+ *   This is the planning companion to plan
+ *   `plans/2026-04-08-zero-trust-workflow-rule-hardening.md`. It is
+ *   deliberately a small, self-contained slice: it does not change
+ *   console, capability-table, or audit-ring semantics, and ships its
+ *   own deterministic, serial-first audit hook for tests and CI.
+ *
+ * Used by:
+ *   - kernel/cap/workflow_rule.c (implementation),
+ *   - tests/workflow_rule_test.c (allow/deny/scope-mismatch coverage),
+ *   - build/scripts/test_workflow_rule.sh dispatcher.
+ *
+ * Not used by (out of scope for this slice):
+ *   - persistence layer (filesystem service) — see plan 2026-04-16,
+ *   - capability broker share workflow — see plan 2026-04-21.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "capability.h"
+
+/*
+ * Sizing.
+ *
+ * Kept intentionally small. The slice is about correctness of the
+ * tenant/scope discipline, not capacity. Persistence/scale follow-ups
+ * are tracked in the plan doc.
+ */
+#define WORKFLOW_RULE_MAX_RULES 16u
+
+/*
+ * Reserved tenant id. Zero is *never* a valid tenant id — rule
+ * construction with tenant_id == 0 must fail closed. This keeps
+ * "uninitialized" memory from accidentally satisfying a tenant check.
+ */
+#define WORKFLOW_RULE_TENANT_INVALID ((workflow_tenant_id_t)0u)
+
+/*
+ * Reserved rule id. Zero is *never* a valid rule id. Same fail-closed
+ * rationale as the tenant id above.
+ */
+#define WORKFLOW_RULE_ID_INVALID ((workflow_rule_id_t)0u)
+
+typedef uint32_t workflow_tenant_id_t;
+typedef uint32_t workflow_rule_id_t;
+
+/*
+ * Explicit, single-direction scope. There is *no* READ_WRITE value:
+ * the plan calls out that missing or implicit widening must deny.
+ * Callers that need both directions must register two rules.
+ */
+typedef enum {
+  WORKFLOW_SCOPE_NONE  = 0,
+  WORKFLOW_SCOPE_READ  = 1,
+  WORKFLOW_SCOPE_WRITE = 2,
+} workflow_scope_t;
+
+/*
+ * Reason code attached to every rule for audit. Free-form text is
+ * intentionally not supported on the rule (the plan calls this out
+ * explicitly) to keep audit volume bounded and machine-comparable.
+ */
+typedef enum {
+  WORKFLOW_REASON_NONE          = 0,
+  WORKFLOW_REASON_TENANT_POLICY = 1,
+  WORKFLOW_REASON_OPERATOR      = 2,
+  WORKFLOW_REASON_AUTOMATION    = 3,
+} workflow_reason_t;
+
+typedef enum {
+  WORKFLOW_OK                          = 0,
+  WORKFLOW_ERR_MISSING                 = 1, /* deny: no rule, wrong tenant, scope mismatch */
+  WORKFLOW_ERR_TENANT_INVALID          = 2,
+  WORKFLOW_ERR_RULE_INVALID            = 3,
+  WORKFLOW_ERR_SCOPE_INVALID           = 4,
+  WORKFLOW_ERR_SUBJECT_INVALID         = 5,
+  WORKFLOW_ERR_CAPABILITY_INVALID      = 6,
+  WORKFLOW_ERR_REASON_INVALID          = 7,
+  WORKFLOW_ERR_DUPLICATE               = 8,
+  WORKFLOW_ERR_NO_SLOT                 = 9,
+} workflow_result_t;
+
+/*
+ * Audit event recorded once per evaluation. The non-interference
+ * contract is the same as the capability audit ring: formatting these
+ * events must never mutate evaluation state, and recording them must
+ * never flip an allow into a deny (or vice versa).
+ */
+typedef enum {
+  WORKFLOW_AUDIT_OP_REGISTER = 0,
+  WORKFLOW_AUDIT_OP_EVAL_READ  = 1,
+  WORKFLOW_AUDIT_OP_EVAL_WRITE = 2,
+} workflow_audit_op_t;
+
+typedef enum {
+  WORKFLOW_AUDIT_OUTCOME_ALLOW = 0,
+  WORKFLOW_AUDIT_OUTCOME_DENY  = 1,
+} workflow_audit_outcome_t;
+
+typedef struct {
+  uint64_t                  sequence_id;
+  workflow_audit_op_t       operation;
+  workflow_tenant_id_t      tenant_id;
+  workflow_rule_id_t        rule_id;
+  workflow_scope_t          scope_requested;
+  cap_subject_id_t          subject_id;
+  capability_id_t           capability_id;
+  workflow_reason_t         reason;
+  workflow_result_t         result;
+  workflow_audit_outcome_t  outcome;
+} workflow_audit_event_t;
+
+#define WORKFLOW_AUDIT_EVENT_MAX 32u
+
+/*
+ * Lifecycle.
+ *
+ * Reset is the single test-only helper. The plan called this out as
+ * the deterministic seam for serial-first tests; production code paths
+ * never call it (the kernel boot path will, exactly once, when
+ * eventually wired up).
+ */
+void workflow_rule_reset_for_tests(void);
+
+/*
+ * Register a persisted rule. The rule is bound to its tenant for life
+ * and never visible from another tenant. Duplicate (tenant, rule_id)
+ * fails closed with WORKFLOW_ERR_DUPLICATE rather than overwriting,
+ * so writers must explicitly reset before re-registering.
+ */
+workflow_result_t workflow_rule_register(workflow_tenant_id_t tenant_id,
+                                         workflow_rule_id_t   rule_id,
+                                         workflow_scope_t     scope,
+                                         cap_subject_id_t     subject_id,
+                                         capability_id_t      capability_id,
+                                         workflow_reason_t    reason);
+
+/*
+ * Read-direction evaluator. Returns WORKFLOW_OK only when:
+ *   - tenant_id is valid and matches the rule's tenant,
+ *   - rule_id is valid and exists within that tenant,
+ *   - the rule's declared scope is exactly WORKFLOW_SCOPE_READ,
+ *   - subject_id and capability_id match the rule.
+ * Any other condition returns WORKFLOW_ERR_MISSING (no existence
+ * leak across tenants, no softer error for scope mismatch).
+ */
+workflow_result_t workflow_rule_eval_read(workflow_tenant_id_t caller_tenant_id,
+                                          workflow_rule_id_t   rule_id,
+                                          cap_subject_id_t     subject_id,
+                                          capability_id_t      capability_id);
+
+/*
+ * Write-direction evaluator. Mirror of the read evaluator above; the
+ * rule's scope must be exactly WORKFLOW_SCOPE_WRITE.
+ */
+workflow_result_t workflow_rule_eval_write(workflow_tenant_id_t caller_tenant_id,
+                                           workflow_rule_id_t   rule_id,
+                                           cap_subject_id_t     subject_id,
+                                           capability_id_t      capability_id);
+
+/*
+ * Audit accessors. Read-only, non-mutating, bounded by the ring size.
+ * The audit ring is independent from the capability audit ring so
+ * this slice cannot regress existing audit-log invariants.
+ */
+size_t            workflow_audit_count_for_tests(void);
+size_t            workflow_audit_dropped_for_tests(void);
+workflow_result_t workflow_audit_get_for_tests(size_t index,
+                                               workflow_audit_event_t *out_event);
+
+/*
+ * Stable, serial-first textual formatter for one event. Pure function
+ * of its inputs; safe to call any number of times. Returns the number
+ * of bytes written excluding the terminator, or a negative value on
+ * truncation / bad input. Line shape:
+ *
+ *   WORKFLOW_AUDIT:seq=N:op=EVAL_READ:tenant=T:rule=R:scope=READ
+ *                  :subject=S:cap=C:reason=TENANT_POLICY
+ *                  :result=OK:outcome=ALLOW
+ */
+int workflow_audit_format_event(const workflow_audit_event_t *event,
+                                char *buf,
+                                size_t buf_size);
+
+#endif /* SECUREOS_WORKFLOW_RULE_H */

--- a/tests/workflow_rule_test.c
+++ b/tests/workflow_rule_test.c
@@ -1,0 +1,276 @@
+/**
+ * @file workflow_rule_test.c
+ * @brief Deterministic tests for the workflow rule layer (issue #77).
+ *
+ * Coverage matches the validation matrix in
+ * `plans/2026-04-08-zero-trust-workflow-rule-hardening.md` §"Phase 4":
+ *
+ *   1. allow-path: same tenant + matching scope + matching subject/cap
+ *      => WORKFLOW_OK.
+ *   2. cross-tenant deny: a rule registered under tenant A is invisible
+ *      to tenant B; lookup returns WORKFLOW_ERR_MISSING (no existence
+ *      leak) and is recorded as a deny in the workflow audit ring.
+ *   3. scope-mismatch deny: read request against a write-only rule
+ *      (and vice versa) returns WORKFLOW_ERR_MISSING, not a softer
+ *      error.
+ *   4. audit non-interference: formatting an event multiple times does
+ *      not change the audit ring contents or flip the recorded
+ *      outcome.
+ *   5. input validation: invalid tenant / rule id / scope / subject /
+ *      capability / reason all fail closed.
+ *
+ * Launched by:
+ *   build/scripts/test_workflow_rule.sh
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/workflow_rule.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:workflow_rule:%s\n", reason);
+  exit(1);
+}
+
+static void expect_eq_u64(uint64_t got, uint64_t want, const char *reason) {
+  if (got != want) {
+    fprintf(stderr, "expected %llu got %llu for %s\n",
+            (unsigned long long)want, (unsigned long long)got, reason);
+    fail(reason);
+  }
+}
+
+static void expect_result(workflow_result_t got,
+                          workflow_result_t want,
+                          const char *reason) {
+  if (got != want) {
+    fprintf(stderr, "expected result %d got %d for %s\n",
+            (int)want, (int)got, reason);
+    fail(reason);
+  }
+}
+
+int main(void) {
+  printf("TEST:START:workflow_rule\n");
+
+  /* ---------------- Phase 1: allow path ---------------- */
+  workflow_rule_reset_for_tests();
+
+  const workflow_tenant_id_t tenant_a = 7u;
+  const workflow_tenant_id_t tenant_b = 9u;
+  const workflow_rule_id_t   rule_read  = 100u;
+  const workflow_rule_id_t   rule_write = 200u;
+  const cap_subject_id_t     subject    = 3u;
+  const capability_id_t      cap        = CAP_FS_READ;
+
+  expect_result(
+      workflow_rule_register(tenant_a, rule_read, WORKFLOW_SCOPE_READ,
+                             subject, cap, WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_OK, "register_read_rule");
+  expect_result(
+      workflow_rule_eval_read(tenant_a, rule_read, subject, cap),
+      WORKFLOW_OK, "allow_path_same_tenant_matching_scope");
+  printf("TEST:PASS:workflow_rule_allow_path\n");
+
+  /* ---------------- Phase 2: cross-tenant deny ---------------- */
+  expect_result(
+      workflow_rule_eval_read(tenant_b, rule_read, subject, cap),
+      WORKFLOW_ERR_MISSING,
+      "cross_tenant_lookup_must_collapse_to_missing");
+
+  /* Existence-leak guard: same rule id under tenant_b must remain
+   * available for registration; cross-tenant probe must not have
+   * created or revealed any tenant_a state to tenant_b. */
+  expect_result(
+      workflow_rule_register(tenant_b, rule_read, WORKFLOW_SCOPE_READ,
+                             subject, cap, WORKFLOW_REASON_OPERATOR),
+      WORKFLOW_OK, "tenant_b_can_register_same_rule_id");
+  printf("TEST:PASS:workflow_rule_cross_tenant_deny\n");
+
+  /* ---------------- Phase 3: scope-mismatch deny ---------------- */
+  expect_result(
+      workflow_rule_register(tenant_a, rule_write, WORKFLOW_SCOPE_WRITE,
+                             subject, cap, WORKFLOW_REASON_AUTOMATION),
+      WORKFLOW_OK, "register_write_rule");
+
+  /* Read request against a write-only rule => missing. */
+  expect_result(
+      workflow_rule_eval_read(tenant_a, rule_write, subject, cap),
+      WORKFLOW_ERR_MISSING,
+      "read_against_write_rule_must_deny");
+  /* Write request against a read-only rule => missing. */
+  expect_result(
+      workflow_rule_eval_write(tenant_a, rule_read, subject, cap),
+      WORKFLOW_ERR_MISSING,
+      "write_against_read_rule_must_deny");
+  /* Mismatched subject => missing (no widening). */
+  expect_result(
+      workflow_rule_eval_read(tenant_a, rule_read, subject + 1u, cap),
+      WORKFLOW_ERR_MISSING,
+      "mismatched_subject_must_deny");
+  /* Mismatched capability => missing. */
+  expect_result(
+      workflow_rule_eval_read(tenant_a, rule_read, subject, CAP_FS_WRITE),
+      WORKFLOW_ERR_MISSING,
+      "mismatched_capability_must_deny");
+  printf("TEST:PASS:workflow_rule_scope_mismatch_deny\n");
+
+  /* ---------------- Phase 4: audit non-interference ---------------- */
+  /* Snapshot ring state before formatting. */
+  size_t count_before   = workflow_audit_count_for_tests();
+  size_t dropped_before = workflow_audit_dropped_for_tests();
+
+  workflow_audit_event_t snap[WORKFLOW_AUDIT_EVENT_MAX];
+  if (count_before > WORKFLOW_AUDIT_EVENT_MAX) {
+    fail("count_before_exceeds_ring");
+  }
+  for (size_t i = 0; i < count_before; ++i) {
+    expect_result(workflow_audit_get_for_tests(i, &snap[i]),
+                  WORKFLOW_OK, "audit_snapshot_get");
+  }
+
+  /* Format every event several times. The formatter must be pure
+   * and must not perturb the ring or alter the recorded outcome. */
+  char buf[256];
+  for (int round = 0; round < 4; ++round) {
+    for (size_t i = 0; i < count_before; ++i) {
+      int n = workflow_audit_format_event(&snap[i], buf, sizeof(buf));
+      if (n <= 0) {
+        fail("format_event_failed");
+      }
+      if ((size_t)n != strlen(buf)) {
+        fail("format_event_length_mismatch");
+      }
+    }
+  }
+
+  expect_eq_u64(workflow_audit_count_for_tests(), count_before,
+                "count_changed_by_formatting");
+  expect_eq_u64(workflow_audit_dropped_for_tests(), dropped_before,
+                "dropped_changed_by_formatting");
+  for (size_t i = 0; i < count_before; ++i) {
+    workflow_audit_event_t now;
+    expect_result(workflow_audit_get_for_tests(i, &now),
+                  WORKFLOW_OK, "audit_reread_get");
+    if (memcmp(&snap[i], &now, sizeof(now)) != 0) {
+      fail("audit_event_mutated_by_formatting");
+    }
+  }
+  printf("TEST:PASS:workflow_rule_audit_non_interference\n");
+
+  /* Allow path must remain ALLOW after every audit round. */
+  expect_result(
+      workflow_rule_eval_read(tenant_a, rule_read, subject, cap),
+      WORKFLOW_OK, "allow_path_stable_after_audit_format");
+
+  /* ---------------- Phase 5: input validation ---------------- */
+  workflow_rule_reset_for_tests();
+
+  expect_result(
+      workflow_rule_register(WORKFLOW_RULE_TENANT_INVALID, 1u,
+                             WORKFLOW_SCOPE_READ, 1u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_TENANT_INVALID, "register_rejects_invalid_tenant");
+  expect_result(
+      workflow_rule_register(1u, WORKFLOW_RULE_ID_INVALID,
+                             WORKFLOW_SCOPE_READ, 1u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_RULE_INVALID, "register_rejects_invalid_rule_id");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_NONE,
+                             1u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_SCOPE_INVALID, "register_rejects_scope_none");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             0u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_SUBJECT_INVALID, "register_rejects_zero_subject");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, (capability_id_t)9999,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_CAPABILITY_INVALID,
+      "register_rejects_unknown_capability");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_FS_READ, WORKFLOW_REASON_NONE),
+      WORKFLOW_ERR_REASON_INVALID, "register_rejects_reason_none");
+
+  /* Duplicate detection: register once, then again. */
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_OK, "register_initial_succeeds");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_WRITE,
+                             2u, CAP_FS_WRITE,
+                             WORKFLOW_REASON_OPERATOR),
+      WORKFLOW_ERR_DUPLICATE,
+      "register_duplicate_must_fail_closed");
+
+  /* Eval input validation collapses everything to MISSING (no leak). */
+  expect_result(
+      workflow_rule_eval_read(WORKFLOW_RULE_TENANT_INVALID, 1u, 1u, CAP_FS_READ),
+      WORKFLOW_ERR_MISSING, "eval_rejects_invalid_tenant_as_missing");
+  expect_result(
+      workflow_rule_eval_read(1u, WORKFLOW_RULE_ID_INVALID, 1u, CAP_FS_READ),
+      WORKFLOW_ERR_MISSING, "eval_rejects_invalid_rule_as_missing");
+  expect_result(
+      workflow_rule_eval_read(1u, 1u, 0u, CAP_FS_READ),
+      WORKFLOW_ERR_MISSING, "eval_rejects_zero_subject_as_missing");
+  expect_result(
+      workflow_rule_eval_read(1u, 1u, 1u, (capability_id_t)9999),
+      WORKFLOW_ERR_MISSING, "eval_rejects_unknown_cap_as_missing");
+  printf("TEST:PASS:workflow_rule_input_validation\n");
+
+  /* ---------------- Phase 6: capacity / ring drop ---------------- */
+  workflow_rule_reset_for_tests();
+  for (uint32_t i = 0; i < WORKFLOW_RULE_MAX_RULES; ++i) {
+    expect_result(
+        workflow_rule_register(42u, i + 1u, WORKFLOW_SCOPE_READ,
+                               1u, CAP_FS_READ,
+                               WORKFLOW_REASON_TENANT_POLICY),
+        WORKFLOW_OK, "register_fills_slot");
+  }
+  expect_result(
+      workflow_rule_register(42u, WORKFLOW_RULE_MAX_RULES + 1u,
+                             WORKFLOW_SCOPE_READ, 1u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_NO_SLOT, "register_overflow_must_fail_closed");
+  printf("TEST:PASS:workflow_rule_capacity\n");
+
+  /* ---------------- Phase 7: audit format spot-check ---------------- */
+  workflow_rule_reset_for_tests();
+  expect_result(
+      workflow_rule_register(7u, 100u, WORKFLOW_SCOPE_READ,
+                             3u, CAP_FS_READ,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_OK, "audit_fmt_setup_register");
+  expect_result(
+      workflow_rule_eval_read(7u, 100u, 3u, CAP_FS_READ),
+      WORKFLOW_OK, "audit_fmt_setup_eval");
+
+  workflow_audit_event_t e;
+  expect_result(workflow_audit_get_for_tests(1u, &e),
+                WORKFLOW_OK, "audit_fmt_get_eval_event");
+  char line[256];
+  int n = workflow_audit_format_event(&e, line, sizeof(line));
+  if (n <= 0) {
+    fail("audit_fmt_returned_negative");
+  }
+  const char *expected =
+      "WORKFLOW_AUDIT:seq=1:op=EVAL_READ:tenant=7:rule=100:scope=READ"
+      ":subject=3:cap=6:reason=TENANT_POLICY:result=OK:outcome=ALLOW";
+  if (strcmp(line, expected) != 0) {
+    fprintf(stderr, "got:  %s\nwant: %s\n", line, expected);
+    fail("audit_fmt_line_mismatch");
+  }
+  printf("TEST:PASS:workflow_rule_audit_format\n");
+
+  printf("TEST:DONE:workflow_rule\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #77.

Implements the plan in `plans/2026-04-08-zero-trust-workflow-rule-hardening.md` as a small, self-contained vertical slice. Cited as still-open and not covered by any PR in the daily review #205 — picking it up so it is no longer a stranded plan.

## Summary

Adds a minimal workflow-rule layer with **tenant-scoped, scope-explicit, deny-by-default** evaluation. Rules live in their own module (no changes to the existing capability table, broker, or audit ring), so the slice is fully additive and independent of the in-flight M2/M3/M4 PR stack.

## Changes

- `kernel/cap/workflow_rule.h` / `workflow_rule.c`
  - Persisted rule record: `(tenant_id, rule_id, scope, subject_id, capability_id, reason)`.
  - Tenant id `0` and rule id `0` are reserved-invalid (fail-closed against zeroed memory).
  - Scope is **single-direction only** — `READ` or `WRITE`, no implicit `READ_WRITE`.
  - `workflow_rule_eval_read` / `workflow_rule_eval_write` collapse cross-tenant lookups, unknown rule ids, scope mismatches, and subject/capability mismatches all to `WORKFLOW_ERR_MISSING` so rule existence does not leak across tenants.
  - Independent bounded audit ring (`WORKFLOW_AUDIT_EVENT_MAX = 32`) with serial-first textual formatter:
    `WORKFLOW_AUDIT:seq=...:op=EVAL_READ:tenant=...:rule=...:scope=READ:subject=...:cap=...:reason=...:result=...:outcome=...`
  - Formatter is a pure function of its inputs (non-interference); recording is post-decision and cannot flip an allow into a deny.
- `tests/workflow_rule_test.c`
  - Covers every Phase-4 acceptance bullet from the plan: allow path, cross-tenant deny + existence-leak guard, scope mismatch (both directions) + subject/cap mismatch, audit non-interference under repeated formatting, full input validation, capacity overflow, and a literal audit-format spot-check.
- `build/scripts/test_workflow_rule.sh` (new validator dispatcher) wired into `build/scripts/test.sh` and `test.ps1` as a new `workflow_rule` target — keeps the `.sh` ↔ `.ps1` parity discipline from #156 intact (test.ps1 dispatches the bash script through the toolchain container, matching every other validator).

## Validation

```
$ bash build/scripts/test.sh workflow_rule
TEST:START:workflow_rule
TEST:PASS:workflow_rule_allow_path
TEST:PASS:workflow_rule_cross_tenant_deny
TEST:PASS:workflow_rule_scope_mismatch_deny
TEST:PASS:workflow_rule_audit_non_interference
TEST:PASS:workflow_rule_input_validation
TEST:PASS:workflow_rule_capacity
TEST:PASS:workflow_rule_audit_format
TEST:DONE:workflow_rule
```

Built with `cc -std=c11 -Wall -Wextra -Werror` (no warnings).

## Why now / safety

- Pure additive: no edits to `kernel/cap/capability.{c,h}`, `cap_table.*`, `cap_broker.*`, the existing audit ring, or any boot path.
- New TEST target only; nothing existing dispatches into `workflow_rule`.
- No new build-graph dependencies, no kernel link changes.

## Follow-ups (out of scope, tracked in the plan)

- Persist rules across reboots once the fs-service slice (plan 2026-04-16) lands.
- Surface workflow decisions through the capability broker share workflow (plan 2026-04-21).
- Wire the validator into the bundle / nightly matrix once #112 / #151 dust settles.