### PR TITLE
fix #212: negative-path harness self-test (intentionally failing canary)

### DIFF
--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -61,6 +61,7 @@ $testScript = switch ($TestName) {
   "bearssl_compile" { "./build/scripts/test_bearssl_compile.sh" }
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
+  "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   default {
     Write-Host "Unknown test: $TestName"
     Show-Usage

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -193,6 +193,12 @@ case "$TEST_NAME" in
   harness_defense)
     # Self-test for the defensive dispatcher (see test_harness_defense.sh).
     run_script "$ROOT_DIR/build/scripts/test_harness_defense.sh"
+    ;;
+  canary_must_fail)
+    # Intentionally failing canary (issue #212). The harness must
+    # observe TEST:FAIL:_canary_must_fail and exit status 1; the bundle
+    # treats this as the *expected* outcome via EXPECTED_FAIL_TARGETS.
+    run_script "$ROOT_DIR/tests/integration/_canary_must_fail/canary_must_fail.sh"
     ;;
   *)
     echo "Unknown test: $TEST_NAME"

--- a/build/scripts/test_validator_report.sh
+++ b/build/scripts/test_validator_report.sh
@@ -72,6 +72,18 @@ sample = {
             "reasonCode": "harness_error",
             "artifacts": [],
         },
+        {
+            "name": "_canary_must_fail",
+            "status": "pass",
+            "pass": True,
+            "durationSeconds": 0,
+            "logPath": None,
+            "reasonCode": None,
+            "artifacts": [],
+            "expectedFail": True,
+            "observed": "fail",
+            "classification": "ok",
+        },
     ],
     "checks": [
         {"name": "sample_pass", "status": "pass", "pass": True, "durationSeconds": 2},

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -42,6 +42,15 @@ TEST_TARGETS=(
 # or blocked on the disk-image perms chain (#106 / PR #107 for kernel_sessions).
 # Add each here as the corresponding fix lands, so the bundle stays green.
 
+# Issue #212: targets that MUST fail. The bundle's pass condition is
+# "every TEST_TARGETS target passes AND every EXPECTED_FAIL_TARGETS
+# target fails". Each entry here is a permanent canary that proves the
+# harness still classifies a deliberate failure as a failure (defends
+# against #90 / #129 / #140 style silent no-ops).
+EXPECTED_FAIL_TARGETS=(
+  canary_must_fail
+)
+
 STATUS_LINES=()
 FAILED_TESTS=()
 
@@ -68,7 +77,44 @@ for target in "${TEST_TARGETS[@]}"; do
   fi
   test_finished="$(date +%s)"
   duration="$((test_finished - test_started))"
-  STATUS_LINES+=("${target}|${status}|${duration}")
+  STATUS_LINES+=("${target}|${status}|${duration}|expected_pass")
+done
+
+# Issue #212: expected-fail canaries. We INVERT the pass condition: a
+# canary that *fails* (rc=1) is the green path and is recorded as
+# status=pass with expectedFail=true / observed=fail / classification=ok
+# in the JSON report. A canary that unexpectedly *passes* (rc=0) flips
+# the bundle to FAIL with the deterministic marker
+# `BUNDLE_FAIL: canary did not fail`. A harness error (rc=78) is still
+# reported as harness_error so infra breakage stays distinguishable.
+for target in "${EXPECTED_FAIL_TARGETS[@]}"; do
+  test_started="$(date +%s)"
+  set +e
+  bash "$ROOT_DIR/build/scripts/test.sh" "$target"
+  rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
+    # Canary did NOT fail -- this is the regression we exist to catch.
+    status="fail"
+    observed="pass"
+    classification="anomaly"
+    FAILED_TESTS+=("$target")
+    echo "BUNDLE_FAIL: canary did not fail" >&2
+    echo "BUNDLE_FAIL: canary did not fail (target=$target)"
+  elif [[ $rc -eq $HARNESS_ERROR_EXIT ]]; then
+    status="harness_error"
+    observed="harness_error"
+    classification="harness_error"
+    FAILED_TESTS+=("$target")
+  else
+    # Expected failure observed -- this is the green path for canaries.
+    status="pass"
+    observed="fail"
+    classification="ok"
+  fi
+  test_finished="$(date +%s)"
+  duration="$((test_finished - test_started))"
+  STATUS_LINES+=("${target}|${status}|${duration}|expected_fail|${observed}|${classification}")
 done
 
 # Copy known QEMU artifacts when present.
@@ -160,18 +206,39 @@ def _resolve_log_and_artifacts(target_name: str):
     return log_rel, artifacts_rel
 
 for line in status_lines:
-    name, status, duration = line.split("|", 2)
+    parts = line.split("|")
+    # New format (issue #212): name|status|duration|kind[|observed|classification]
+    # Legacy format: name|status|duration
+    if len(parts) >= 4:
+        name = parts[0]
+        status = parts[1]
+        duration = parts[2]
+        kind = parts[3]
+        observed = parts[4] if len(parts) > 4 else None
+        classification = parts[5] if len(parts) > 5 else None
+    else:
+        name, status, duration = parts[0], parts[1], parts[2]
+        kind = "expected_pass"
+        observed = None
+        classification = None
     if status not in ("pass", "fail", "harness_error"):
         # Defensive: treat unknown statuses as fail rather than crash the JSON.
         status = "fail"
-    checks.append({
+    check_entry = {
         "name": name,
         "status": status,
         "pass": status == "pass",
         "durationSeconds": int(duration),
-    })
+    }
+    if kind == "expected_fail":
+        check_entry["expectedFail"] = True
+        if observed is not None:
+            check_entry["observed"] = observed
+        if classification is not None:
+            check_entry["classification"] = classification
+    checks.append(check_entry)
     log_path, artifacts_for_target = _resolve_log_and_artifacts(name)
-    targets.append({
+    target_entry = {
         "name": name,
         "status": status,
         "pass": status == "pass",
@@ -179,7 +246,14 @@ for line in status_lines:
         "logPath": log_path,
         "reasonCode": None if status == "pass" else status,
         "artifacts": artifacts_for_target,
-    })
+    }
+    if kind == "expected_fail":
+        target_entry["expectedFail"] = True
+        if observed is not None:
+            target_entry["observed"] = observed
+        if classification is not None:
+            target_entry["classification"] = classification
+    targets.append(target_entry)
     if status == "harness_error":
         harness_errors.append(name)
         failed.append(name)

--- a/docs/test-plans/validator-report.schema.json
+++ b/docs/test-plans/validator-report.schema.json
@@ -65,6 +65,9 @@
           "durationSeconds": { "type": "integer", "minimum": 0 },
           "logPath":         { "type": ["string", "null"] },
           "reasonCode":      { "type": ["string", "null"] },
+          "expectedFail":    { "type": "boolean", "description": "Issue #212: target is a deliberate failure canary; bundle pass requires observed=='fail'." },
+          "observed":        { "type": "string", "enum": ["pass", "fail", "harness_error"], "description": "Raw outcome of the canary run, before expected-fail inversion." },
+          "classification":  { "type": "string", "enum": ["ok", "anomaly", "harness_error"], "description": "Validator's verdict: ok=expected outcome, anomaly=canary unexpectedly passed, harness_error=infra failure." },
           "artifacts": {
             "type": "array",
             "items": { "type": "string" }
@@ -83,7 +86,10 @@
           "name":            { "type": "string" },
           "status":          { "type": "string", "enum": ["pass", "fail", "harness_error"] },
           "pass":            { "type": "boolean" },
-          "durationSeconds": { "type": "integer", "minimum": 0 }
+          "durationSeconds": { "type": "integer", "minimum": 0 },
+          "expectedFail":    { "type": "boolean" },
+          "observed":        { "type": "string", "enum": ["pass", "fail", "harness_error"] },
+          "classification":  { "type": "string", "enum": ["ok", "anomaly", "harness_error"] }
         }
       }
     },

--- a/tests/integration/_canary_must_fail/README.md
+++ b/tests/integration/_canary_must_fail/README.md
@@ -1,0 +1,79 @@
+# `_canary_must_fail` — DO NOT "FIX" THIS TEST
+
+This is an **intentionally failing** test target. It exists so the
+SecureOS validator (`build/scripts/validate_bundle.sh` +
+`build/scripts/test.sh` + `validator_report.json` schema, see #110/#112)
+proves end-to-end that a real, deliberate failure is **classified as a
+failure** — not silently skipped, no-op'd, or mis-counted as a pass.
+
+## Why this exists
+
+BUILD_ROADMAP §3.4 (validation tests) and §8 item 9 explicitly require a
+*negative test*: an intentionally failing target that the harness must
+catch. We have repeatedly hit cases where missing `+x` bits (#90), stale
+`TEST_TARGETS` allowlists (#129), or stale linker inputs (#140) caused a
+test to be effectively a no-op while CI stayed green. Without a permanent
+canary, those regressions only surface when an unrelated test starts
+misbehaving.
+
+This canary closes that gap. It is wired into the validator as an
+`EXPECTED_FAIL_TARGETS` entry: the bundle's pass condition is
+
+> every `TEST_TARGETS` target passes **AND** every `EXPECTED_FAIL_TARGETS`
+> target fails.
+
+If the canary ever stops failing (e.g. someone "fixes" it, deletes its
+`TEST:FAIL:` line, or the dispatcher silently no-ops it), the bundle
+exits non-zero with the marker:
+
+```
+BUNDLE_FAIL: canary did not fail
+```
+
+That marker is the contract — do not change it.
+
+## What it does
+
+`canary_must_fail.sh` emits exactly:
+
+```
+TEST:START:_canary_must_fail
+TEST:FAIL:_canary_must_fail:intentional
+```
+
+…and exits with status `1`. That's the entire program. Anything more
+elaborate would risk the canary failing for *the wrong reason* and would
+defeat the point.
+
+## How it's wired
+
+- `build/scripts/test.sh canary_must_fail` → runs this script.
+- `build/scripts/validate_bundle.sh` lists `canary_must_fail` under
+  `EXPECTED_FAIL_TARGETS` (separate from `TEST_TARGETS`). The bundle:
+  - runs the canary,
+  - records `expectedFail: true`, `observed: <pass|fail|harness_error>`,
+    `classification: <ok|anomaly|harness_error>` in
+    `validator_report.json`,
+  - **fails the bundle** if `observed != "fail"`.
+- `docs/test-plans/validator-report.schema.json` documents the new
+  `expectedFail` / `observed` / `classification` fields (optional;
+  existing consumers still validate).
+
+## If you are tempted to "fix" this
+
+Don't. If the canary fails for an unexpected reason (e.g. the dispatcher
+crashes), the validator will surface it as `harness_error` /
+`classification: harness_error`, not as a green run. Investigate that
+instead.
+
+If the canary contract genuinely needs to change (new marker shape, new
+classification value, etc.), update *all of*:
+
+- this README,
+- `canary_must_fail.sh`,
+- `build/scripts/validate_bundle.sh` `EXPECTED_FAIL_TARGETS` handling,
+- `docs/test-plans/validator-report.schema.json`,
+- and the `BUNDLE_FAIL: canary did not fail` marker text consumed by
+  log scrapers.
+
+Tracks #212.

--- a/tests/integration/_canary_must_fail/canary_must_fail.sh
+++ b/tests/integration/_canary_must_fail/canary_must_fail.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# tests/integration/_canary_must_fail/canary_must_fail.sh
+#
+# Intentionally failing canary test target. See README.md in this
+# directory for the full rationale; this file is deliberately tiny so
+# it cannot fail for the wrong reason.
+#
+# Contract (do not change without updating the validator harness in
+# build/scripts/validate_bundle.sh and the validator-report schema):
+#
+#   * Emits exactly one TEST:START line and one TEST:FAIL line.
+#   * Exits with status 1 (a real test failure -- NOT 78, which is
+#     reserved for harness errors).
+#
+# Issue: #212.
+
+set -u
+
+printf 'TEST:START:_canary_must_fail\n'
+printf 'TEST:FAIL:_canary_must_fail:intentional\n'
+exit 1


### PR DESCRIPTION
Closes #212.

## What

Adds a permanent, intentionally-failing canary target — `canary_must_fail` — that the bundle validator **expects to fail**. If a regression (the kind tracked in #90 / #129 / #140) silently no-ops a test, this canary will start *passing*, which flips the bundle to FAIL with the deterministic marker:

```
BUNDLE_FAIL: canary did not fail
```

Per BUILD_ROADMAP §3.4 / §8 item 9, this is the negative-path harness self-test the validator chain has been missing. Independent of (and complementary to) #173, which covers the `run_qemu.sh`-only fixture at a different layer.

## Changes

- `tests/integration/_canary_must_fail/canary_must_fail.sh` — emits exactly `TEST:START:_canary_must_fail` + `TEST:FAIL:_canary_must_fail:intentional` and exits 1. Deliberately tiny so it can't fail for the wrong reason.
- `tests/integration/_canary_must_fail/README.md` — explains why this exists so a future agent doesn't 'fix' it.
- `build/scripts/test.sh` / `build/scripts/test.ps1` — register the `canary_must_fail` target and update the help string. Cross-platform parity preserved (AGENTS.md / #156).
- `build/scripts/validate_bundle.sh` — adds `EXPECTED_FAIL_TARGETS=(canary_must_fail)` with an inverted pass condition. The Python report emitter records new optional fields per target:
  - `expectedFail: true`
  - `observed: pass | fail | harness_error` — raw outcome before inversion
  - `classification: ok | anomaly | harness_error` — validator's verdict
- `docs/test-plans/validator-report.schema.json` — schema gains those three optional fields (additive, existing consumers still validate).
- `build/scripts/test_validator_report.sh` — sample now exercises the canary shape against the schema, both with and without `jsonschema`.

## Acceptance criteria mapping (issue #212)

- [x] Canary target exists, deliberately fails, and its failure is *required* for the bundle to pass overall.
- [x] `docs/test-plans/validator-report.schema.json` updated for the new fields; existing consumers still validate (additive only).
- [x] Validator JSON report shows the canary as `expectedFail=true, observed=fail, classification=ok` on the green path.
- [x] If someone deletes the canary or makes it pass, `validate_bundle.sh` exits non-zero with a clear `BUNDLE_FAIL: canary did not fail` message.
- [x] README in `tests/integration/_canary_must_fail/` explains why this exists so a future agent doesn't 'fix' it.

## Validation performed

```
$ bash build/scripts/test.sh canary_must_fail
TEST:START:_canary_must_fail
TEST:FAIL:_canary_must_fail:intentional
rc=1

$ bash build/scripts/test_validator_report.sh
TEST:PASS:test_validator_report:schema_present
TEST:PASS:test_validator_report:sample_validates
TEST:PASS:test_validator_report:rejects_invalid_status
TEST:PASS:test_validator_report
```

Plus a Python smoke of the validate_bundle STATUS_LINES emitter that confirmed both the canary-fails-as-expected (`classification: ok`) and canary-unexpectedly-passes (`classification: anomaly`) paths produce the right shape. Full `validate_bundle.sh` requires the toolchain Docker image, which the CI workflow runs on its own.

## Out of scope / follow-ups

- The `run_qemu.sh`-level negative fixture (#173) — different layer, can land in either order.
- Generalising the canary helper to multiple expected-fail targets — schema/emitter already supports it; only the one canary is wired today.

— cron:secureos-hourly-issue-work, 2026-05-21