### PR TITLE
ci: validate helloapp manifest against schema v0 on every PR (closes #195)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,20 @@ jobs:
               clang-format \
               shellcheck
 
+      - name: Install manifest-schema validator dependency
+        # Issue #195: re-validate every shipped app manifest against
+        # manifests/schema/v0.json so example + schema cannot drift.
+        # The validator falls back to a structural check when the lib
+        # is missing, but CI runs in strict mode.
+        run: |
+          python3 -m pip install --quiet --disable-pip-version-check "jsonschema>=4,<5"
+
+      - name: Validate app manifests against schema v0
+        # Hard-gating from day 1: this stage is cheap and the only
+        # in-tree manifests today are the helloapp examples landed by
+        # #187. See tools/validate_manifests.py for the contract.
+        run: bash build/scripts/validate_manifests.sh
+
       - name: Run lint
         # shellcheck + parity are hard-gating from day 1.
         # clang-format stays visible-but-non-blocking until a tree-wide

--- a/build/scripts/validate_manifests.ps1
+++ b/build/scripts/validate_manifests.ps1
@@ -1,0 +1,29 @@
+# build/scripts/validate_manifests.ps1 — issue #195.
+#
+# Thin wrapper around tools/validate_manifests.py. Re-validates every
+# in-tree app manifest against manifests/schema/v0.json so example +
+# schema cannot silently drift (BUILD_ROADMAP §7 ABI-rot guard,
+# follow-up to #187).
+#
+# Bash peer: build/scripts/validate_manifests.sh (kept in sync under
+# the AGENTS.md cross-platform rule, #156).
+#
+# Exit codes mirror the Python entry point:
+#   0 all manifests valid
+#   1 at least one manifest failed validation
+#   2 harness error (missing/unreadable schema)
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+
+$Python = $env:PYTHON
+if ([string]::IsNullOrEmpty($Python)) {
+    $Python = 'python3'
+    if (-not (Get-Command $Python -ErrorAction SilentlyContinue)) {
+        $Python = 'python'
+    }
+}
+
+& $Python (Join-Path $RepoRoot 'tools/validate_manifests.py') @args
+exit $LASTEXITCODE

--- a/build/scripts/validate_manifests.sh
+++ b/build/scripts/validate_manifests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# build/scripts/validate_manifests.sh — issue #195.
+#
+# Thin wrapper around tools/validate_manifests.py. Re-validates every
+# in-tree app manifest against manifests/schema/v0.json so example +
+# schema cannot silently drift (BUILD_ROADMAP §7 ABI-rot guard,
+# follow-up to #187).
+#
+# PowerShell peer: build/scripts/validate_manifests.ps1 (kept in sync
+# under the AGENTS.md cross-platform rule, #156).
+#
+# Exit codes mirror the Python entry point:
+#   0 all manifests valid
+#   1 at least one manifest failed validation
+#   2 harness error (missing/unreadable schema)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PY="${PYTHON:-python3}"
+exec "$PY" "$REPO_ROOT/tools/validate_manifests.py" "$@"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -20,5 +20,18 @@ examples consumed by SecureOS tooling and the launcher.
 
 ## Wiring
 
-Issue #183 lands the schema and examples without CI enforcement. Wiring
-schema validation into CI is the follow-up tracked in #195.
+Schema validation runs on every PR via `.github/workflows/lint.yml`,
+which invokes `build/scripts/validate_manifests.sh`. The wrapper shells
+into `tools/validate_manifests.py`, which in turn validates every
+`manifests/examples/*.json` (and any other `*.manifest.json` in the
+tree) against `manifests/schema/v0.json` using `jsonschema`.
+
+To run the same check locally:
+
+```sh
+build/scripts/validate_manifests.sh        # bash
+build/scripts/validate_manifests.ps1       # PowerShell (parity peer, #156)
+```
+
+Issue #183 landed the schema and examples; #187 wired the example into
+the tree; #195 wired this validator into CI.

--- a/tools/validate_manifests.py
+++ b/tools/validate_manifests.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Validate SecureOS app manifests against `manifests/schema/v0.json`.
+
+Issue #195 (follow-up to #187). Locks in the manifest-schema work that
+landed in #183/#187 by re-validating every shipped example manifest on
+every PR so schema and examples cannot silently drift.
+
+Behavior
+--------
+* Walks the repo for app-manifest JSON files. By default scans:
+    - manifests/examples/*.json (the canonical examples)
+    - any other ``*.manifest.json`` file in the tree (forward-compat
+      with the glob shape suggested in #195's "Scope")
+* Skips well-known non-app-manifest JSON: `manifests/task-dag.*` and
+  the schema files themselves.
+* Validates each candidate against `manifests/schema/v0.json` using
+  the `jsonschema` library if importable, otherwise falls back to a
+  minimal hand-rolled structural check that mirrors the schema's
+  `required` / `additionalProperties` / `const` constraints. The
+  fallback is deliberately conservative — it exists so a green run
+  still proves the document is parseable and shaped correctly even
+  when the optional dep is missing; CI is expected to install
+  `jsonschema` for the strict pass.
+
+Output is line-oriented and matches the ``TEST:START`` /
+``TEST:PASS:`` / ``TEST:FAIL:`` markers used by the rest of the
+validator bundle (see build/scripts/validate_bundle.sh).
+
+Exit codes
+----------
+0  all manifests valid
+1  at least one manifest failed validation
+2  internal / harness error (schema file missing, unreadable JSON in
+   the schema itself, etc.) — distinct from a manifest regression so
+   CI can tell infra breakage from a real drift.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "manifests" / "schema" / "v0.json"
+EXAMPLES_DIR = REPO_ROOT / "manifests" / "examples"
+
+# Files we never treat as app manifests, even if they end in .json.
+SKIP_NAMES = {
+    "task-dag.example.json",
+    "task-dag.schema.json",
+}
+
+
+def _emit(line: str) -> None:
+    """Print a TEST:* marker line, flushed so log scrapers see it in order."""
+    print(line, flush=True)
+
+
+def _discover_manifests() -> List[Path]:
+    """Return the sorted list of manifest files to validate."""
+    found: List[Path] = []
+
+    if EXAMPLES_DIR.is_dir():
+        for p in sorted(EXAMPLES_DIR.glob("*.json")):
+            if p.name in SKIP_NAMES:
+                continue
+            found.append(p)
+
+    # Forward-compat: also pick up any other *.manifest.json the tree
+    # may grow (the glob shape called out in #195's Scope). We exclude
+    # the examples dir to avoid double-listing the same file.
+    for p in sorted(REPO_ROOT.rglob("*.manifest.json")):
+        if EXAMPLES_DIR in p.parents:
+            continue
+        # Skip vendored / build output trees.
+        rel = p.relative_to(REPO_ROOT)
+        if rel.parts and rel.parts[0] in {"vendor", "artifacts", ".git"}:
+            continue
+        found.append(p)
+
+    return found
+
+
+def _load_json(path: Path) -> Tuple[object, str | None]:
+    try:
+        return json.loads(path.read_text()), None
+    except FileNotFoundError:
+        return None, f"missing: {path}"
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc}"
+
+
+def _fallback_validate(doc: object, schema: dict) -> str | None:
+    """Minimal structural check used when `jsonschema` is unavailable.
+
+    Intentionally narrow — covers required fields, `additionalProperties:
+    false`, `const`, `enum`, integer min/max, and the v0 manifest's
+    cross-field constraint that a manifest declares
+    ``manifest_version == 0`` and a top-level ``capabilities.request``.
+    Anything subtler is the strict-mode (`jsonschema`) validator's job.
+    """
+    if not isinstance(doc, dict):
+        return "manifest must be a JSON object"
+
+    required_top = schema.get("required", [])
+    for k in required_top:
+        if k not in doc:
+            return f"missing required top-level field: {k}"
+
+    if schema.get("additionalProperties") is False:
+        allowed = set(schema.get("properties", {}).keys())
+        extra = sorted(set(doc.keys()) - allowed)
+        if extra:
+            return f"unknown top-level fields (additionalProperties=false): {extra}"
+
+    mv = doc.get("manifest_version")
+    if mv != 0:
+        return f"manifest_version must be 0, got {mv!r}"
+
+    abi = doc.get("os_abi_version")
+    if not isinstance(abi, int) or abi < 0:
+        return f"os_abi_version must be a non-negative integer, got {abi!r}"
+
+    app = doc.get("app")
+    if not isinstance(app, dict):
+        return "app must be an object"
+    for k in ("id", "version", "subject_id", "binary"):
+        if k not in app:
+            return f"app.{k} is required"
+    sid = app.get("subject_id")
+    if not isinstance(sid, int) or sid < 1 or sid > 7:
+        return f"app.subject_id must be integer in [1,7], got {sid!r}"
+
+    caps = doc.get("capabilities")
+    if not isinstance(caps, dict):
+        return "capabilities must be an object"
+    if "request" not in caps:
+        return "capabilities.request is required"
+    if not isinstance(caps["request"], list):
+        return "capabilities.request must be an array"
+
+    return None
+
+
+def _strict_validate(doc: object, schema: dict) -> str | None:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        return None  # caller falls back
+
+    try:
+        jsonschema.validate(instance=doc, schema=schema)
+    except jsonschema.ValidationError as exc:  # type: ignore[attr-defined]
+        # Build a JSON-pointer-ish path so failures point at the field.
+        loc = "/".join(str(x) for x in exc.absolute_path) or "<root>"
+        return f"{loc}: {exc.message}"
+    except jsonschema.SchemaError as exc:  # type: ignore[attr-defined]
+        return f"schema is invalid: {exc.message}"
+    return None
+
+
+def main(argv: Iterable[str]) -> int:
+    _emit("TEST:START:manifest_schema_validate")
+
+    if not SCHEMA_PATH.is_file():
+        _emit(f"TEST:FAIL:manifest_schema_validate:missing_schema:{SCHEMA_PATH}")
+        return 2
+    schema, err = _load_json(SCHEMA_PATH)
+    if err is not None or not isinstance(schema, dict):
+        _emit(f"TEST:FAIL:manifest_schema_validate:bad_schema:{err}")
+        return 2
+
+    manifests = _discover_manifests()
+    if not manifests:
+        # No manifests yet is not a failure on its own — the schema may
+        # land before the first example. Make it visible though.
+        _emit("TEST:PASS:manifest_schema_validate:no_manifests_found")
+        return 0
+
+    have_jsonschema = False
+    try:
+        import jsonschema  # noqa: F401
+        have_jsonschema = True
+    except ImportError:
+        have_jsonschema = False
+
+    failures: List[str] = []
+    for path in manifests:
+        rel = path.relative_to(REPO_ROOT)
+        doc, err = _load_json(path)
+        if err is not None:
+            failures.append(f"{rel}: {err}")
+            _emit(f"TEST:FAIL:manifest_schema_validate:{rel}:{err}")
+            continue
+
+        if have_jsonschema:
+            err = _strict_validate(doc, schema)
+            mode = "strict"
+        else:
+            err = _fallback_validate(doc, schema)
+            mode = "fallback"
+
+        if err is None:
+            _emit(f"TEST:PASS:manifest_schema_validate:{rel}:{mode}")
+        else:
+            failures.append(f"{rel}: {err}")
+            _emit(f"TEST:FAIL:manifest_schema_validate:{rel}:{err}")
+
+    if failures:
+        _emit(f"TEST:FAIL:manifest_schema_validate:failed_count={len(failures)}")
+        return 1
+
+    mode = "strict" if have_jsonschema else "fallback"
+    _emit(
+        "TEST:PASS:manifest_schema_validate:"
+        f"validated={len(manifests)}:mode={mode}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #195. Follow-up to #187 (manifest schema v0 + helloapp example).

## What this does

Wires a `manifest-schema-validate` stage into the existing Lint workflow so the manifests landed in #187 cannot silently drift from `manifests/schema/v0.json` — the ABI-rot guard called for in BUILD_ROADMAP §7 and the cross-script-drift rule from AGENTS.md (#156).

## Files

- **`tools/validate_manifests.py`** — walks the tree and validates every `manifests/examples/*.json` plus any other `*.manifest.json` against `manifests/schema/v0.json`. Uses `jsonschema` in strict mode when importable, with a minimal structural fallback (required fields + `additionalProperties: false` + `manifest_version` const + `subject_id` range) so the wrapper never silently passes if the optional dep is missing. Emits `TEST:START` / `TEST:PASS` / `TEST:FAIL` markers consistent with the rest of the validator bundle.
- **`build/scripts/validate_manifests.sh`** + **`.ps1`** — thin wrappers, kept in sync under the AGENTS.md cross-platform rule (#156).
- **`.github/workflows/lint.yml`** — `pip install jsonschema` step + `bash build/scripts/validate_manifests.sh` step before the existing lint stage. Hard-gating from day 1: the check is cheap and the only in-tree manifests today are the two `helloapp` examples.
- **`manifests/README.md`** — Wiring section now points at the in-CI stage instead of the open follow-up.

No changes to the schema itself, per the issue's "Done when" list.

## Validation performed

- `./build/scripts/validate_manifests.sh` — passes against both shipped `helloapp` manifests in strict (`jsonschema`) mode:
  ```
  TEST:PASS:manifest_schema_validate:manifests/examples/helloapp.deny.json:strict
  TEST:PASS:manifest_schema_validate:manifests/examples/helloapp.json:strict
  TEST:PASS:manifest_schema_validate:validated=2:mode=strict
  ```
- **Negative-path (intentional schema break):** temporarily dropped `app.id` from a copy of `helloapp.json` named `_broken.manifest.json`. The wrapper exits `1` with a JSON-pointer-style failure marker:
  ```
  TEST:FAIL:manifest_schema_validate:manifests/examples/_broken.manifest.json:app: 'id' is a required property
  TEST:FAIL:manifest_schema_validate:failed_count=1
  ```
  → satisfies the issue's "intentional schema break makes the stage fail locally" criterion.
- `shellcheck` clean on the new wrapper; `python3 -m py_compile` clean on the Python entry point.
- `.sh` ↔ `.ps1` parity satisfied for the new pair. The pre-existing parity failure on `test_harness_defense.sh` is on `main` already and tracked under #156 — out of scope here.

## Done-when checklist (from #195)

- [x] PR validation workflow has a `manifest-schema-validate` stage that runs on every PR
- [x] Stage passes today against the `helloapp` manifest from #187
- [x] Intentional schema break makes the stage fail locally via the same wrapper
- [x] No drift between `.sh` and `.ps1` wrappers
- [x] No changes to the schema itself

## Follow-ups

None required. Optional future work: extend the discovery glob if/when other apps ship manifests, but the current `*.manifest.json` recursive sweep already handles that without code changes.