### PR TITLE
test(cap): conformance test for CAP:DENY:<...> marker shape (closes #211)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -22,6 +22,7 @@ test_boot_sector
 test_boot_sector_fail
 test_cap_api_contract
 test_cap_broker
+test_cap_deny_marker_shape
 test_capability_audit
 test_capability_audit_log
 test_capability_gate

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_deny_marker_shape|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -43,6 +43,7 @@ $testScript = switch ($TestName) {
   "capability_table" { "./build/scripts/test_capability_table.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
+  "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }
   "event_bus" { "./build/scripts/test_event_bus.sh" }
   "scheduler" { "./build/scripts/test_scheduler.sh" }
   "sof_format" { "./build/scripts/test_sof_format.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|launcher_console|event_bus|scheduler|sof_format|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -111,6 +111,9 @@ case "$TEST_NAME" in
     ;;
   cap_broker)
     run_script "$ROOT_DIR/build/scripts/test_cap_broker.sh"
+    ;;
+  cap_deny_marker_shape)
+    run_script "$ROOT_DIR/build/scripts/test_cap_deny_marker_shape.sh"
     ;;
   launcher_console)
     run_script "$ROOT_DIR/build/scripts/test_launcher_console.sh"

--- a/build/scripts/test_cap_deny_marker_shape.sh
+++ b/build/scripts/test_cap_deny_marker_shape.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build + run the capability-deny marker shape conformance test (issue #211).
+#
+# Single source of truth for the CAP:DENY:<...> serial marker grammar
+# defined in docs/abi/capability-deny-contract.md §4. Future deny-path
+# services (M3 fs #108, M4 broker #115, M1 IPC #210) reuse the formatter
+# in kernel/cap/cap_deny_marker.c rather than inventing per-service grep.
+#
+# Outputs deterministic TEST:PASS markers consumed by build/scripts/test.sh
+# and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/tests/cap_deny_marker_shape_test.c" \
+  -o "$OUT_DIR/cap_deny_marker_shape_test"
+
+LOG_PATH="$OUT_DIR/cap_deny_marker_shape_test.log"
+"$OUT_DIR/cap_deny_marker_shape_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:cap_deny_marker_shape_format_roundtrip" "$LOG_PATH"
+grep -q "TEST:PASS:cap_deny_marker_shape_drivers" "$LOG_PATH"
+grep -q "TEST:PASS:cap_deny_marker_shape_negative" "$LOG_PATH"
+grep -q "TEST:PASS:cap_deny_marker_shape_cap_table" "$LOG_PATH"
+grep -q "TEST:PASS:cap_deny_marker_shape" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -19,6 +19,7 @@ TEST_TARGETS=(
   capability_audit
   capability_audit_log
   cap_broker
+  cap_deny_marker_shape
   bearssl_compile
     event_bus
     scheduler

--- a/docs/abi/capability-deny-contract.md
+++ b/docs/abi/capability-deny-contract.md
@@ -215,6 +215,27 @@ A service satisfies this contract when:
 5. The acceptance test (#92 / #108 / #115 / …) asserts on the exact
    `CAP:DENY:` line above and on the absence of the grant-path bytes.
 
+### 8.1 Conformance test (single source of truth)
+
+Issue #211 adds `tests/cap_deny_marker_shape_test.c` plus the
+`kernel/cap/cap_deny_marker.{h,c}` formatter and validator. **All deny-path
+services MUST produce their `CAP:DENY:` line via `cap_deny_marker_format()`
+and register their exemplar `(actor, capability, resource)` triple in the
+`drivers[]` table of the conformance test.** Services MUST NOT invent
+standalone grep regexes for the marker shape — that is exactly the drift
+this contract exists to prevent.
+
+Run via:
+
+```
+./build/scripts/test.sh cap_deny_marker_shape          # POSIX
+./build/scripts/test.ps1 cap_deny_marker_shape         # Windows
+```
+
+The target is wired into `validate_bundle.sh` `TEST_TARGETS` so the
+validator JSON report records its result on every CI run. Adding a new
+deny path is therefore a three-line patch to `drivers[]`, not a new test.
+
 ## 9. Implementation tracking
 
 - **#92** — M2 `console.write` deny path. First consumer of §7.1.

--- a/docs/test-plans/m0-m1-plan.yaml
+++ b/docs/test-plans/m0-m1-plan.yaml
@@ -237,6 +237,17 @@ tasks:
       type: log_marker
       marker: "TEST:PASS:cap_audit_log"
 
+  - taskId: M1_CAP_DENY_MARKER_SHAPE
+    ownerRole: test-engineer
+    dependsOn: [M1_CAP_009]
+    run: "./build/scripts/test.sh cap_deny_marker_shape"
+    artifacts:
+      - "status:done"
+      - "issue:#211"
+    passCondition:
+      type: log_marker
+      marker: "TEST:PASS:cap_deny_marker_shape"
+
   - taskId: M1_CAP_010
     ownerRole: implementer
     dependsOn: [M1_CAP_009]

--- a/kernel/cap/cap_deny_marker.c
+++ b/kernel/cap/cap_deny_marker.c
@@ -1,0 +1,277 @@
+/**
+ * @file cap_deny_marker.c
+ * @brief Implementation of the canonical CAP:DENY:<...> serial marker.
+ *
+ * See `cap_deny_marker.h` and `docs/abi/capability-deny-contract.md` §4 for
+ * the wire grammar this file is the single source of truth for.
+ *
+ * Issue: #211 (conformance test for capability-denied log marker shape).
+ *
+ * Pure C11, freestanding-friendly. No <stdio.h>, no allocations, no globals.
+ */
+
+#include "cap_deny_marker.h"
+
+#include <stddef.h>
+
+/* Local helpers — keep visible only to this TU. */
+
+static int cdm_is_printable_ascii(unsigned char c) {
+  return c >= 0x20u && c < 0x7Fu;
+}
+
+/* Append a NUL-terminated string into buf at *pos within buf_size.
+ * Returns 0 on success, -1 if the destination would overflow. */
+static int cdm_append(const char *src, char *buf, size_t buf_size, size_t *pos) {
+  size_t i = 0u;
+  while (src[i] != '\0') {
+    if (*pos >= buf_size) {
+      return -1;
+    }
+    buf[*pos] = src[i];
+    (*pos)++;
+    i++;
+  }
+  return 0;
+}
+
+/* Append decimal representation of u into buf. */
+static int cdm_append_u32(uint32_t u, char *buf, size_t buf_size, size_t *pos) {
+  /* uint32_t fits in 10 decimal digits. */
+  char tmp[16];
+  size_t n = 0u;
+  if (u == 0u) {
+    tmp[n++] = '0';
+  } else {
+    while (u != 0u) {
+      tmp[n++] = (char)('0' + (u % 10u));
+      u /= 10u;
+    }
+  }
+  /* Reverse into buf. */
+  while (n > 0u) {
+    if (*pos >= buf_size) {
+      return -1;
+    }
+    buf[*pos] = tmp[n - 1u];
+    (*pos)++;
+    n--;
+  }
+  return 0;
+}
+
+/* Capability id → canonical lowercase name (CAP_ prefix stripped).
+ * Order matches capability.h enum order; the table is the single source of
+ * truth for the marker's <capability_id> field. */
+typedef struct {
+  capability_id_t id;
+  const char *name;
+} cdm_cap_name_entry_t;
+
+static const cdm_cap_name_entry_t cdm_cap_names[] = {
+    {CAP_CONSOLE_WRITE, "console_write"},
+    {CAP_SERIAL_WRITE, "serial_write"},
+    {CAP_DEBUG_EXIT, "debug_exit"},
+    {CAP_CAPABILITY_ADMIN, "capability_admin"},
+    {CAP_DISK_IO_REQUEST, "disk_io_request"},
+    {CAP_FS_READ, "fs_read"},
+    {CAP_FS_WRITE, "fs_write"},
+    {CAP_EVENT_SUBSCRIBE, "event_subscribe"},
+    {CAP_EVENT_PUBLISH, "event_publish"},
+    {CAP_APP_EXEC, "app_exec"},
+    {CAP_CODESIGN_BYPASS, "codesign_bypass"},
+    {CAP_NETWORK, "network"},
+};
+
+const char *cap_deny_marker_name(capability_id_t cap_id) {
+  const size_t n = sizeof(cdm_cap_names) / sizeof(cdm_cap_names[0]);
+  for (size_t i = 0u; i < n; ++i) {
+    if (cdm_cap_names[i].id == cap_id) {
+      return cdm_cap_names[i].name;
+    }
+  }
+  return (const char *)0;
+}
+
+int cap_deny_marker_format(cap_subject_id_t actor_subject_id,
+                           capability_id_t cap_id,
+                           const char *resource,
+                           char *buf,
+                           size_t buf_size) {
+  if (buf == (char *)0 || resource == (const char *)0 || buf_size == 0u) {
+    return -1;
+  }
+  const char *cap_name = cap_deny_marker_name(cap_id);
+  if (cap_name == (const char *)0) {
+    return -1;
+  }
+
+  /* Validate resource. */
+  size_t rlen = 0u;
+  while (resource[rlen] != '\0') {
+    if (rlen >= CAP_DENY_RESOURCE_MAX) {
+      return -1;
+    }
+    unsigned char c = (unsigned char)resource[rlen];
+    if (c == ':' || c == '\n' || !cdm_is_printable_ascii(c)) {
+      return -1;
+    }
+    rlen++;
+  }
+  if (rlen == 0u) {
+    return -1;
+  }
+
+  size_t pos = 0u;
+  if (cdm_append("CAP:DENY:", buf, buf_size, &pos) != 0) return -1;
+  if (cdm_append_u32((uint32_t)actor_subject_id, buf, buf_size, &pos) != 0) return -1;
+  if (cdm_append(":", buf, buf_size, &pos) != 0) return -1;
+  if (cdm_append(cap_name, buf, buf_size, &pos) != 0) return -1;
+  if (cdm_append(":", buf, buf_size, &pos) != 0) return -1;
+  if (cdm_append(resource, buf, buf_size, &pos) != 0) return -1;
+  if (pos >= buf_size) return -1;
+  buf[pos++] = '\n';
+  if (pos >= buf_size) return -1;
+  buf[pos] = '\0';
+  return (int)pos;
+}
+
+/* Tiny copy helper for reason strings. Truncates safely. */
+static void cdm_set_reason(char *reason, size_t reason_size, const char *src) {
+  if (reason == (char *)0 || reason_size == 0u) return;
+  size_t i = 0u;
+  while (src[i] != '\0' && i + 1u < reason_size) {
+    reason[i] = src[i];
+    i++;
+  }
+  reason[i] = '\0';
+}
+
+int cap_deny_marker_validate(const char *line,
+                             char *reason,
+                             size_t reason_size) {
+  if (line == (const char *)0) {
+    cdm_set_reason(reason, reason_size, "null_line");
+    return -1;
+  }
+  /* Compute length (exclude any trailing NUL). */
+  size_t len = 0u;
+  while (line[len] != '\0') {
+    if (len >= CAP_DENY_MARKER_MAX) {
+      cdm_set_reason(reason, reason_size, "line_too_long");
+      return -1;
+    }
+    len++;
+  }
+
+  /* Must start with the prefix. */
+  static const char prefix[] = "CAP:DENY:";
+  const size_t plen = sizeof(prefix) - 1u;
+  if (len < plen) {
+    cdm_set_reason(reason, reason_size, "missing_prefix");
+    return -1;
+  }
+  for (size_t i = 0u; i < plen; ++i) {
+    if (line[i] != prefix[i]) {
+      cdm_set_reason(reason, reason_size, "missing_prefix");
+      return -1;
+    }
+  }
+
+  /* Must end with exactly one '\n', and that '\n' must be the last byte. */
+  if (line[len - 1u] != '\n') {
+    cdm_set_reason(reason, reason_size, "missing_newline");
+    return -1;
+  }
+  /* No earlier '\n' allowed. */
+  for (size_t i = plen; i + 1u < len; ++i) {
+    if (line[i] == '\n') {
+      cdm_set_reason(reason, reason_size, "trailing_garbage");
+      return -1;
+    }
+  }
+
+  /* Body = bytes after prefix, before the terminating '\n'. */
+  const size_t body_start = plen;
+  const size_t body_end = len - 1u; /* index of '\n' */
+  if (body_end <= body_start) {
+    cdm_set_reason(reason, reason_size, "field_count");
+    return -1;
+  }
+
+  /* Split body into exactly 3 fields by ':' (actor, cap, resource). */
+  size_t field_starts[3];
+  size_t field_ends[3];
+  size_t fld = 0u;
+  field_starts[0] = body_start;
+  for (size_t i = body_start; i < body_end; ++i) {
+    if (line[i] == ':') {
+      if (fld >= 2u) {
+        cdm_set_reason(reason, reason_size, "field_count");
+        return -1;
+      }
+      field_ends[fld] = i;
+      fld++;
+      field_starts[fld] = i + 1u;
+    }
+  }
+  if (fld != 2u) {
+    cdm_set_reason(reason, reason_size, "field_count");
+    return -1;
+  }
+  field_ends[2] = body_end;
+
+  /* Field 0: actor — non-empty, all decimal digits. */
+  if (field_ends[0] == field_starts[0]) {
+    cdm_set_reason(reason, reason_size, "actor_not_decimal");
+    return -1;
+  }
+  for (size_t i = field_starts[0]; i < field_ends[0]; ++i) {
+    char c = line[i];
+    if (c < '0' || c > '9') {
+      cdm_set_reason(reason, reason_size, "actor_not_decimal");
+      return -1;
+    }
+  }
+
+  /* Field 1: cap_name — must match a registered cap name from the table. */
+  {
+    const size_t cap_len = field_ends[1] - field_starts[1];
+    int matched = 0;
+    const size_t n = sizeof(cdm_cap_names) / sizeof(cdm_cap_names[0]);
+    for (size_t i = 0u; i < n && !matched; ++i) {
+      const char *nm = cdm_cap_names[i].name;
+      size_t k = 0u;
+      while (nm[k] != '\0') k++;
+      if (k == cap_len) {
+        int eq = 1;
+        for (size_t j = 0u; j < cap_len; ++j) {
+          if (line[field_starts[1] + j] != nm[j]) { eq = 0; break; }
+        }
+        if (eq) matched = 1;
+      }
+    }
+    if (!matched) {
+      cdm_set_reason(reason, reason_size, "cap_unknown");
+      return -1;
+    }
+  }
+
+  /* Field 2: resource — non-empty, every byte printable ASCII, no ':'. */
+  if (field_ends[2] == field_starts[2]) {
+    cdm_set_reason(reason, reason_size, "resource_empty");
+    return -1;
+  }
+  for (size_t i = field_starts[2]; i < field_ends[2]; ++i) {
+    unsigned char c = (unsigned char)line[i];
+    if (c == ':' || c == '\n' || !cdm_is_printable_ascii(c)) {
+      cdm_set_reason(reason, reason_size, "resource_bad_byte");
+      return -1;
+    }
+  }
+
+  if (reason != (char *)0 && reason_size > 0u) {
+    reason[0] = '\0';
+  }
+  return 0;
+}

--- a/kernel/cap/cap_deny_marker.h
+++ b/kernel/cap/cap_deny_marker.h
@@ -1,0 +1,107 @@
+/**
+ * @file cap_deny_marker.h
+ * @brief Single source of truth for the capability-denied serial log marker.
+ *
+ * Implements the marker grammar fixed by `docs/abi/capability-deny-contract.md`
+ * §4 (issue #164 / PR #167):
+ *
+ *   CAP:DENY:<actor_subject_id>:<capability_id>:<resource>\n
+ *
+ *   - <actor_subject_id> : decimal cap_subject_id_t (the launched subject's id,
+ *                         not the launcher's).
+ *   - <capability_id>    : symbolic name from capability_id_t with the "CAP_"
+ *                         prefix stripped and lowercased (e.g. "console_write",
+ *                         "fs_read", "capability_admin").
+ *   - <resource>         : smallest meaningful identifier for the denied
+ *                         operation; literal "-" when the operation has no
+ *                         resource handle; never empty; ASCII only; any colon
+ *                         in the source identifier MUST be replaced with '_'
+ *                         BEFORE being passed in.
+ *
+ * Why this lives in one place:
+ *   issue #211 — conformance test for the marker shape across all deny paths.
+ *   Without a shared formatter + validator, each future deny-path PR (#108,
+ *   #115, #210) would invent its own grep and the shapes would silently drift.
+ *
+ * Used by:
+ *   - tests/cap_deny_marker_shape_test.c (this issue)
+ *   - future M3 fs_service / M4 broker / M1 IPC deny paths (#108, #115, #210)
+ *
+ * Pure host-side; no kernel-only headers. Safe to compile under both the
+ * cross toolchain and the host unit-test compile lines.
+ */
+
+#ifndef SECUREOS_CAP_DENY_MARKER_H
+#define SECUREOS_CAP_DENY_MARKER_H
+
+#include <stddef.h>
+
+#include "capability.h"
+
+/*
+ * Maximum bytes a formatted marker can require (excluding NUL).
+ * 64 actor digits is overkill for cap_subject_id_t (<= 10 decimal chars),
+ * but a fixed upper bound makes static buffers trivial.
+ */
+#define CAP_DENY_MARKER_MAX 256u
+
+/*
+ * Maximum length of a resource string (caller-supplied). Longer values are
+ * rejected by cap_deny_marker_format() so a runaway path/URL cannot silently
+ * truncate a marker line.
+ */
+#define CAP_DENY_RESOURCE_MAX 192u
+
+/*
+ * Lookup the canonical lowercase, CAP_-prefix-stripped name for a
+ * capability_id_t. Returns NULL when the id is not recognized; callers MUST
+ * treat NULL as a contract violation (a deny for an unknown cap is a bug).
+ */
+const char *cap_deny_marker_name(capability_id_t cap_id);
+
+/*
+ * Format a single capability-denied marker into `buf`. On success returns
+ * the number of bytes written (excluding the trailing NUL); the output
+ * INCLUDES the trailing newline required by §4 ("newline-terminated").
+ *
+ * Returns -1 on:
+ *   - NULL buf, NULL resource;
+ *   - buf_size too small for the formatted line + NUL;
+ *   - resource length 0 or > CAP_DENY_RESOURCE_MAX;
+ *   - resource containing ':' (caller must pre-escape per §4);
+ *   - resource containing '\n' or any non-printable byte;
+ *   - capability_id_t not recognized by cap_deny_marker_name().
+ *
+ * Pure function: no I/O, no globals.
+ */
+int cap_deny_marker_format(cap_subject_id_t actor_subject_id,
+                           capability_id_t cap_id,
+                           const char *resource,
+                           char *buf,
+                           size_t buf_size);
+
+/*
+ * Validate that a candidate line matches §4 grammar exactly. The line MUST
+ * include the trailing '\n' (a missing newline is a contract violation).
+ *
+ * Returns 0 on conformant input; on rejection returns a negative error code
+ * and, when `reason` is non-NULL, writes a short human-readable reason
+ * (ASCII, NUL-terminated, no colons) into `reason` of size `reason_size`.
+ *
+ * The reason strings are stable identifiers — they may be grepped by tests
+ * to assert which negative case fired:
+ *
+ *   "missing_prefix"        — line does not start with "CAP:DENY:"
+ *   "missing_newline"       — line is not terminated by exactly one '\n'
+ *   "field_count"           — wrong number of ':'-delimited fields
+ *   "actor_not_decimal"     — <actor_subject_id> contains non-digits or empty
+ *   "cap_unknown"           — <capability_id> is not a known cap name
+ *   "resource_empty"        — <resource> is empty
+ *   "resource_bad_byte"     — <resource> contains '\n' or non-printable byte
+ *   "trailing_garbage"      — bytes after the terminating newline
+ */
+int cap_deny_marker_validate(const char *line,
+                             char *reason,
+                             size_t reason_size);
+
+#endif /* SECUREOS_CAP_DENY_MARKER_H */

--- a/tests/cap_deny_marker_shape_test.c
+++ b/tests/cap_deny_marker_shape_test.c
@@ -1,0 +1,229 @@
+/**
+ * @file cap_deny_marker_shape_test.c
+ * @brief Conformance test for the canonical CAP:DENY:<...> serial marker.
+ *
+ * Issue #211. The marker grammar lives in
+ * `docs/abi/capability-deny-contract.md` §4 and is implemented by
+ * `kernel/cap/cap_deny_marker.{h,c}`.
+ *
+ * This test is the SINGLE PLACE that asserts marker shape. Future deny-path
+ * services (M2 console #92 [done], M3 fs #108, M4 broker #115, M1 IPC #210)
+ * register their (subject_id, capability_id, resource) triples with the
+ * harness below — they MUST NOT invent independent grep regexes elsewhere.
+ *
+ * The test exercises:
+ *   1. Formatter round-trips: format -> validate is a no-op.
+ *   2. Driver coverage: every currently-implemented deny path's exemplar
+ *      from the contract doc §7 round-trips.
+ *   3. Negative cases: hand-crafted divergent shapes (extra field, missing
+ *      newline, unknown cap name, embedded ':' in resource, trailing
+ *      garbage) all reject with the expected reason code.
+ *   4. Cap-name table coverage: every capability_id_t value from the enum
+ *      has a registered marker name (no silent drift when the enum grows).
+ *
+ * Output markers (consumed by build/scripts/test_cap_deny_marker_shape.sh):
+ *   TEST:PASS:cap_deny_marker_shape_format_roundtrip
+ *   TEST:PASS:cap_deny_marker_shape_drivers
+ *   TEST:PASS:cap_deny_marker_shape_negative
+ *   TEST:PASS:cap_deny_marker_shape_cap_table
+ *   TEST:PASS:cap_deny_marker_shape          (all phases passed)
+ *
+ * On any failure: `TEST:FAIL:cap_deny_marker_shape:<reason>` and exit(1).
+ *
+ * Pure host-side, no kernel runtime dependencies.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_deny_marker.h"
+#include "../kernel/cap/capability.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_deny_marker_shape:%s\n", reason);
+  g_fail = 1;
+}
+
+/* ---- Phase 1: formatter round-trip ---- */
+static void test_format_roundtrip(void) {
+  char buf[CAP_DENY_MARKER_MAX];
+  int n = cap_deny_marker_format(42u, CAP_CONSOLE_WRITE, "-", buf, sizeof(buf));
+  if (n <= 0) { fail("format_roundtrip_format_failed"); return; }
+  if (strcmp(buf, "CAP:DENY:42:console_write:-\n") != 0) {
+    fail("format_roundtrip_unexpected_output");
+    return;
+  }
+  if (cap_deny_marker_validate(buf, NULL, 0u) != 0) {
+    fail("format_roundtrip_validate_failed");
+    return;
+  }
+  printf("TEST:PASS:cap_deny_marker_shape_format_roundtrip\n");
+}
+
+/* ---- Phase 2: driver coverage (one entry per implemented or planned
+ * deny path; the contract doc §7 examples are the authoritative drivers). */
+typedef struct {
+  const char *label;            /* test label, also greppable */
+  cap_subject_id_t actor;
+  capability_id_t cap;
+  const char *resource;
+  const char *expected;         /* exact wire bytes (incl. trailing \n) */
+} driver_t;
+
+static const driver_t drivers[] = {
+    /* §7.1 — M2 HelloApp console_write deny (#92, shipped). */
+    {"console_write_deny",      42u, CAP_CONSOLE_WRITE,    "-",
+     "CAP:DENY:42:console_write:-\n"},
+    /* §7.2 — M3 fs_read deny (#108). */
+    {"fs_read_deny",            42u, CAP_FS_READ,          "/os/notes.txt",
+     "CAP:DENY:42:fs_read:/os/notes.txt\n"},
+    /* §7.3 — M4 broker share deny (#115). */
+    {"broker_share_deny",       42u, CAP_CAPABILITY_ADMIN,
+     "broker_share=cap=fs_read,target=17",
+     "CAP:DENY:42:capability_admin:broker_share=cap=fs_read,target=17\n"},
+    /* M1 IPC send deny (#210, planned). */
+    {"ipc_send_deny",           7u,  CAP_DEBUG_EXIT, /* no IPC cap yet */
+     "ipc_port=3",
+     "CAP:DENY:7:debug_exit:ipc_port=3\n"},
+    /* Capability audit_event_subscribe deny (per §5 async fallback). */
+    {"event_subscribe_deny",    9u,  CAP_EVENT_SUBSCRIBE,  "topic=fs.changed",
+     "CAP:DENY:9:event_subscribe:topic=fs.changed\n"},
+    /* Network deny (URL scheme gate, #79). */
+    {"network_deny",            5u,  CAP_NETWORK,          "https//example.com",
+     "CAP:DENY:5:network:https//example.com\n"},
+};
+
+static void test_drivers(void) {
+  const size_t n = sizeof(drivers) / sizeof(drivers[0]);
+  for (size_t i = 0u; i < n; ++i) {
+    char buf[CAP_DENY_MARKER_MAX];
+    int rc = cap_deny_marker_format(drivers[i].actor, drivers[i].cap,
+                                    drivers[i].resource, buf, sizeof(buf));
+    if (rc <= 0) {
+      char r[64];
+      snprintf(r, sizeof(r), "driver_format_failed:%s", drivers[i].label);
+      fail(r);
+      return;
+    }
+    if (strcmp(buf, drivers[i].expected) != 0) {
+      char r[128];
+      snprintf(r, sizeof(r), "driver_mismatch:%s", drivers[i].label);
+      fail(r);
+      printf("  expected: %sgot:      %s", drivers[i].expected, buf);
+      return;
+    }
+    char reason[64];
+    if (cap_deny_marker_validate(buf, reason, sizeof(reason)) != 0) {
+      char r[128];
+      snprintf(r, sizeof(r), "driver_validate_failed:%s:%s",
+               drivers[i].label, reason);
+      fail(r);
+      return;
+    }
+  }
+  printf("TEST:PASS:cap_deny_marker_shape_drivers\n");
+}
+
+/* ---- Phase 3: negative cases ---- */
+typedef struct {
+  const char *label;
+  const char *line;
+  const char *expected_reason;
+} neg_t;
+
+static const neg_t negatives[] = {
+    {"missing_prefix",       "FOO:DENY:42:console_write:-\n",         "missing_prefix"},
+    {"missing_newline",      "CAP:DENY:42:console_write:-",           "missing_newline"},
+    {"too_few_fields",       "CAP:DENY:42:console_write\n",           "field_count"},
+    {"too_many_fields",      "CAP:DENY:42:console_write:-:extra\n",   "field_count"},
+    {"actor_non_decimal",    "CAP:DENY:abc:console_write:-\n",        "actor_not_decimal"},
+    {"actor_empty",          "CAP:DENY::console_write:-\n",           "actor_not_decimal"},
+    {"unknown_cap",          "CAP:DENY:42:bogus_cap:-\n",             "cap_unknown"},
+    {"resource_empty",       "CAP:DENY:42:console_write:\n",          "resource_empty"},
+    {"trailing_garbage",     "CAP:DENY:42:console_write:-\nextra\n",  "trailing_garbage"},
+    {"embedded_newline_res", "CAP:DENY:42:console_write:foo\nbar\n",  "trailing_garbage"},
+};
+
+static void test_negatives(void) {
+  const size_t n = sizeof(negatives) / sizeof(negatives[0]);
+  for (size_t i = 0u; i < n; ++i) {
+    char reason[64];
+    int rc = cap_deny_marker_validate(negatives[i].line, reason, sizeof(reason));
+    if (rc == 0) {
+      char r[128];
+      snprintf(r, sizeof(r), "negative_unexpectedly_passed:%s", negatives[i].label);
+      fail(r);
+      return;
+    }
+    if (strcmp(reason, negatives[i].expected_reason) != 0) {
+      char r[160];
+      snprintf(r, sizeof(r), "negative_wrong_reason:%s:got=%s:want=%s",
+               negatives[i].label, reason, negatives[i].expected_reason);
+      fail(r);
+      return;
+    }
+  }
+  /* Formatter must also refuse to PRODUCE bad shapes. */
+  char buf[CAP_DENY_MARKER_MAX];
+  if (cap_deny_marker_format(1u, CAP_CONSOLE_WRITE, "", buf, sizeof(buf)) >= 0) {
+    fail("format_accepted_empty_resource"); return;
+  }
+  if (cap_deny_marker_format(1u, CAP_CONSOLE_WRITE, "a:b", buf, sizeof(buf)) >= 0) {
+    fail("format_accepted_colon_in_resource"); return;
+  }
+  if (cap_deny_marker_format(1u, CAP_CONSOLE_WRITE, "x\ny", buf, sizeof(buf)) >= 0) {
+    fail("format_accepted_newline_in_resource"); return;
+  }
+  if (cap_deny_marker_format(1u, (capability_id_t)9999, "-", buf, sizeof(buf)) >= 0) {
+    fail("format_accepted_unknown_cap"); return;
+  }
+  /* Tiny buffer must fail rather than truncate silently. */
+  char tiny[8];
+  if (cap_deny_marker_format(1u, CAP_CONSOLE_WRITE, "-", tiny, sizeof(tiny)) >= 0) {
+    fail("format_accepted_truncation"); return;
+  }
+  printf("TEST:PASS:cap_deny_marker_shape_negative\n");
+}
+
+/* ---- Phase 4: every capability_id_t value in capability.h has a registered
+ * marker name. New caps added to the enum without updating the table will
+ * trip this. */
+static void test_cap_table_coverage(void) {
+  static const capability_id_t all_caps[] = {
+      CAP_CONSOLE_WRITE, CAP_SERIAL_WRITE, CAP_DEBUG_EXIT,
+      CAP_CAPABILITY_ADMIN, CAP_DISK_IO_REQUEST, CAP_FS_READ, CAP_FS_WRITE,
+      CAP_EVENT_SUBSCRIBE, CAP_EVENT_PUBLISH, CAP_APP_EXEC,
+      CAP_CODESIGN_BYPASS, CAP_NETWORK,
+  };
+  const size_t n = sizeof(all_caps) / sizeof(all_caps[0]);
+  for (size_t i = 0u; i < n; ++i) {
+    if (cap_deny_marker_name(all_caps[i]) == NULL) {
+      char r[64];
+      snprintf(r, sizeof(r), "cap_table_missing:id=%d", (int)all_caps[i]);
+      fail(r);
+      return;
+    }
+  }
+  /* Unknown id must NOT have a name. */
+  if (cap_deny_marker_name((capability_id_t)0xDEADu) != NULL) {
+    fail("cap_table_phantom_name"); return;
+  }
+  printf("TEST:PASS:cap_deny_marker_shape_cap_table\n");
+}
+
+int main(void) {
+  test_format_roundtrip();
+  if (g_fail) return 1;
+  test_drivers();
+  if (g_fail) return 1;
+  test_negatives();
+  if (g_fail) return 1;
+  test_cap_table_coverage();
+  if (g_fail) return 1;
+
+  printf("TEST:PASS:cap_deny_marker_shape\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #211.

## What this lands

Locks down the canonical capability-denied serial log marker shape defined in `docs/abi/capability-deny-contract.md` §4 with **a single source of truth** for both producers and consumers — before the M3 fs (#108), M4 broker (#115), and M1 IPC (#210) deny-path slices each invent their own grep regex.

| File | Purpose |
| --- | --- |
| `kernel/cap/cap_deny_marker.{h,c}` | Pure-C11, freestanding-friendly `cap_deny_marker_format()` + `cap_deny_marker_validate()` for the `CAP:DENY:<actor>:<cap>:<resource>\n` grammar. Table-driven cap-name lookup keyed on `capability_id_t`. |
| `tests/cap_deny_marker_shape_test.c` | Four-phase conformance test: format roundtrip, drivers[] table (§7.1 console_write, §7.2 fs_read, §7.3 broker_share, plus IPC/event/network exemplars), negative cases with reason-code assertions, and cap-table coverage. |
| `build/scripts/test_cap_deny_marker_shape.sh` | New test target. Wired into `test.sh`, `test.ps1`, and `validate_bundle.sh` `TEST_TARGETS`. |
| `docs/abi/capability-deny-contract.md` | New §8.1 'Conformance test' pointing at the harness and forbidding per-service grep regexes. |
| `docs/test-plans/m0-m1-plan.yaml` | New `M1_CAP_DENY_MARKER_SHAPE` task entry. |
| `build/scripts/.shell_parity_allowlist` | Allowlist new `.sh` per #156's phased rollout (consistent with the other `test_*.sh` peers). |

## How future deny-path PRs use this

Three-line patch to `drivers[]` in the test, then call `cap_deny_marker_format()` from the service. **No new test file, no new grep regex.** That is the whole point of #211.

## Acceptance criteria mapping (from #211)

- [x] New test target registered in `validate_bundle.sh` `TEST_TARGETS` and in `docs/test-plans/m0-m1-plan.yaml` (`M1_CAP_DENY_MARKER_SHAPE`).
- [x] Asserts marker shape for the existing emission sites — `drivers[]` covers `console_write` (§7.1) plus the contract-document exemplars for §7.2 (`fs_read`) and §7.3 (`broker_share`); cap-table coverage ensures the formatter recognizes every `capability_id_t`.
- [x] Forward-compatible with #108 / #115 / #210 — assertion regex lives in **one** place (`cap_deny_marker_validate`); slice authors only register a new `drivers[]` row.
- [x] `docs/abi/capability-deny-contract.md` §8.1 'Conformance test' subsection points at this target.
- [x] Validator JSON report includes the new test result (added to `TEST_TARGETS`).

## Validation

```
$ ./build/scripts/test.sh cap_deny_marker_shape
TEST:PASS:cap_deny_marker_shape_format_roundtrip
TEST:PASS:cap_deny_marker_shape_drivers
TEST:PASS:cap_deny_marker_shape_negative
TEST:PASS:cap_deny_marker_shape_cap_table
TEST:PASS:cap_deny_marker_shape
```

`./build/scripts/test_shell_parity.sh` — only the pre-existing `test_harness_defense` gap remains (unchanged by this PR; tracked under #156).

## Out of scope (explicit)

- Wiring `CAP:DENY` emission into `cap_check()` or individual services. That work is owned by #108 / #115 / #210 per the issue's 'Out of scope' clause; this PR provides the formatter they will call and the harness their PRs will register against.
- Modifying the marker grammar itself.

## Follow-ups

- Once #210 lands an `CAP_IPC_SEND`/`CAP_IPC_RECV` capability id, replace the IPC driver row's placeholder `CAP_DEBUG_EXIT` with the real cap and update the `cap_deny_marker_name` table — single-line change, the test is the gate.
- Port `test_cap_deny_marker_shape.sh` to `.ps1` once #156's phased rollout reaches the `test_*.sh` cohort.

— secureos-hourly-issue-work cron, run `e4c62e32`, 2026-05-21 16:28 UTC