### PR TITLE
fix #115: M4 broker allow/deny/revoke acceptance test slice (rebased on main)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -20,6 +20,9 @@ test_app_runtime
 test_bearssl_compile
 test_boot_sector
 test_boot_sector_fail
+test_broker_share_allow
+test_broker_share_deny
+test_broker_share_revoke
 test_cap_api_contract
 test_cap_broker
 test_capability_audit

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -114,6 +114,15 @@ case "$TEST_NAME" in
     ;;
   cap_broker)
     run_script "$ROOT_DIR/build/scripts/test_cap_broker.sh"
+    ;;
+  broker_share_allow)
+    run_script "$ROOT_DIR/build/scripts/test_broker_share_allow.sh"
+    ;;
+  broker_share_deny)
+    run_script "$ROOT_DIR/build/scripts/test_broker_share_deny.sh"
+    ;;
+  broker_share_revoke)
+    run_script "$ROOT_DIR/build/scripts/test_broker_share_revoke.sh"
     ;;
   workflow_rule)
     run_script "$ROOT_DIR/build/scripts/test_workflow_rule.sh"

--- a/build/scripts/test_broker_share_allow.sh
+++ b/build/scripts/test_broker_share_allow.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_broker.c" \
+  "$ROOT_DIR/tests/broker_share_allow_test.c" \
+  -o "$OUT_DIR/broker_share_allow_test"
+
+LOG_PATH="$OUT_DIR/broker_share_allow_test.log"
+"$OUT_DIR/broker_share_allow_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:broker_share_allow:owner_holds_cap" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_allow:request_returns_pending_share_id" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_allow:approve_grants_recipient" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_allow:scope_is_resource_bound" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_allow:scope_is_capability_bound" "$LOG_PATH"
+grep -q "TEST:SKIP:broker_share_allow:audit_grant_recorded" "$LOG_PATH"
+grep -q "TEST:DONE:broker_share_allow" "$LOG_PATH"

--- a/build/scripts/test_broker_share_deny.sh
+++ b/build/scripts/test_broker_share_deny.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_broker.c" \
+  "$ROOT_DIR/tests/broker_share_deny_test.c" \
+  -o "$OUT_DIR/broker_share_deny_test"
+
+LOG_PATH="$OUT_DIR/broker_share_deny_test.log"
+"$OUT_DIR/broker_share_deny_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:broker_share_deny:owner_holds_cap" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_deny:request_returns_pending_share_id" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_deny:deny_path" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_deny:no_recipient_grant" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_deny:cannot_be_re_approved" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_deny:bystander_cannot_mutate" "$LOG_PATH"
+grep -q "TEST:SKIP:broker_share_deny:audit_deny_recorded" "$LOG_PATH"
+grep -q "TEST:DONE:broker_share_deny" "$LOG_PATH"

--- a/build/scripts/test_broker_share_revoke.sh
+++ b/build/scripts/test_broker_share_revoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_broker.c" \
+  "$ROOT_DIR/tests/broker_share_revoke_test.c" \
+  -o "$OUT_DIR/broker_share_revoke_test"
+
+LOG_PATH="$OUT_DIR/broker_share_revoke_test.log"
+"$OUT_DIR/broker_share_revoke_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:broker_share_revoke:setup_grants_recipient" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_revoke:owner_revoke_takes_effect" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_revoke:underlying_table_revoked" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_revoke:double_revoke_is_idempotent" "$LOG_PATH"
+grep -q "TEST:PASS:broker_share_revoke:recipient_self_revoke" "$LOG_PATH"
+grep -q "TEST:SKIP:broker_share_revoke:audit_revoke_recorded" "$LOG_PATH"
+grep -q "TEST:DONE:broker_share_revoke" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -21,6 +21,9 @@ TEST_TARGETS=(
   capability_audit_log
   cap_broker
   bearssl_compile
+  broker_share_allow
+  broker_share_deny
+  broker_share_revoke
     event_bus
     scheduler
     sof_format

--- a/tests/broker_share_allow_test.c
+++ b/tests/broker_share_allow_test.c
@@ -1,0 +1,113 @@
+/**
+ * @file broker_share_allow_test.c
+ * @brief M4 capability broker — allow-path acceptance slice (issue #115).
+ *
+ * One of three deterministic acceptance validators carved out of
+ * plans/2026-05-14-m4-broker-acceptance-tests.md for BUILD_ROADMAP §5.4.
+ * Sibling files: broker_share_deny_test.c, broker_share_revoke_test.c.
+ *
+ * Purpose:
+ *   Asserts the broker's allow-path contract from the recipient's point of
+ *   view (the cap_broker_test.c unit covers internal state transitions; this
+ *   slice covers the contract the launcher / consumer side will rely on).
+ *   Emits structured TEST:PASS:<name> / TEST:FAIL:<name>:<reason> markers
+ *   consumable by the validator JSON report (#110).
+ *
+ * Audit assertions (per plan §"audit_grant_recorded") are gated behind #98
+ * (capability audit serial line) and emit TEST:SKIP markers here because the
+ * broker does not yet route through the cap_audit pipeline. This keeps the
+ * slice mergeable while #98's broker wiring is filed as a follow-up.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_broker.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+
+static void marker_fail(const char *name, const char *reason) {
+  printf("TEST:FAIL:%s:%s\n", name, reason);
+  exit(1);
+}
+
+static void marker_pass(const char *name) { printf("TEST:PASS:%s\n", name); }
+
+static void marker_skip(const char *name, const char *reason) {
+  printf("TEST:SKIP:%s:%s\n", name, reason);
+}
+
+int main(void) {
+  printf("TEST:START:broker_share_allow\n");
+
+  cap_table_init();
+  cap_table_reset();
+  cap_broker_reset();
+
+  const cap_subject_id_t owner = 1u;
+  const cap_subject_id_t recip = 2u;
+
+  /* 1: owner_holds_cap — broker precondition. */
+  if (cap_table_grant(owner, CAP_FS_READ) != CAP_OK) {
+    marker_fail("broker_share_allow:owner_holds_cap", "grant_setup_failed");
+  }
+  if (cap_table_check(owner, CAP_FS_READ) != CAP_OK) {
+    marker_fail("broker_share_allow:owner_holds_cap", "check_after_grant_missing");
+  }
+  marker_pass("broker_share_allow:owner_holds_cap");
+
+  /* 2: request_returns_pending_share_id — pre-approval recipient has nothing. */
+  cap_share_id_t sid = CAP_SHARE_ID_INVALID;
+  if (cap_broker_request_share(owner, recip, CAP_FS_READ, "doc-alpha", &sid) !=
+      CAP_BROKER_OK) {
+    marker_fail("broker_share_allow:request_returns_pending_share_id",
+                "request_share_failed");
+  }
+  if (sid == CAP_SHARE_ID_INVALID) {
+    marker_fail("broker_share_allow:request_returns_pending_share_id",
+                "share_id_invalid");
+  }
+  if (cap_broker_state_for_tests(sid) != CAP_SHARE_STATE_REQUESTED) {
+    marker_fail("broker_share_allow:request_returns_pending_share_id",
+                "state_not_requested");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_allow:request_returns_pending_share_id",
+                "recipient_check_should_fail_before_approve");
+  }
+  marker_pass("broker_share_allow:request_returns_pending_share_id");
+
+  /* 3: approve_grants_recipient. */
+  if (cap_broker_approve(owner, sid) != CAP_BROKER_OK) {
+    marker_fail("broker_share_allow:approve_grants_recipient", "approve_failed");
+  }
+  if (cap_broker_state_for_tests(sid) != CAP_SHARE_STATE_APPROVED) {
+    marker_fail("broker_share_allow:approve_grants_recipient", "state_not_approved");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_OK) {
+    marker_fail("broker_share_allow:approve_grants_recipient",
+                "recipient_check_after_approve_failed");
+  }
+  marker_pass("broker_share_allow:approve_grants_recipient");
+
+  /* 4: scope_is_resource_bound — different resource name must miss. */
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-beta") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_allow:scope_is_resource_bound",
+                "other_resource_should_not_be_granted");
+  }
+  marker_pass("broker_share_allow:scope_is_resource_bound");
+
+  /* 5: scope_is_capability_bound — different cap must miss. */
+  if (cap_broker_recipient_check(recip, CAP_FS_WRITE, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_allow:scope_is_capability_bound",
+                "other_capability_should_not_be_granted");
+  }
+  marker_pass("broker_share_allow:scope_is_capability_bound");
+
+  /* 6: audit_grant_recorded — gated on #98 broker→audit wiring. */
+  marker_skip("broker_share_allow:audit_grant_recorded",
+              "broker_audit_unwired_pending_issue_98");
+
+  printf("TEST:DONE:broker_share_allow\n");
+  return 0;
+}

--- a/tests/broker_share_deny_test.c
+++ b/tests/broker_share_deny_test.c
@@ -1,0 +1,120 @@
+/**
+ * @file broker_share_deny_test.c
+ * @brief M4 capability broker — deny-path acceptance slice (issue #115).
+ *
+ * Asserts the deny-path contract: a denied share leaks nothing to the
+ * recipient or any bystander, and the share is terminal (cannot be
+ * re-approved). Sibling of broker_share_allow_test.c /
+ * broker_share_revoke_test.c per plans/2026-05-14-m4-broker-acceptance-tests.md.
+ *
+ * Audit deny-event assertions are gated on #98 (broker→audit wiring) and
+ * emitted as TEST:SKIP until that follow-up lands.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_broker.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+
+static void marker_fail(const char *name, const char *reason) {
+  printf("TEST:FAIL:%s:%s\n", name, reason);
+  exit(1);
+}
+
+static void marker_pass(const char *name) { printf("TEST:PASS:%s\n", name); }
+
+static void marker_skip(const char *name, const char *reason) {
+  printf("TEST:SKIP:%s:%s\n", name, reason);
+}
+
+int main(void) {
+  printf("TEST:START:broker_share_deny\n");
+
+  cap_table_init();
+  cap_table_reset();
+  cap_broker_reset();
+
+  const cap_subject_id_t owner = 1u;
+  const cap_subject_id_t recip = 2u;
+  const cap_subject_id_t bystander = 3u;
+
+  /* 1: owner_holds_cap. */
+  if (cap_table_grant(owner, CAP_FS_READ) != CAP_OK) {
+    marker_fail("broker_share_deny:owner_holds_cap", "grant_setup_failed");
+  }
+  marker_pass("broker_share_deny:owner_holds_cap");
+
+  /* 2: request_returns_pending_share_id. */
+  cap_share_id_t sid = CAP_SHARE_ID_INVALID;
+  if (cap_broker_request_share(owner, recip, CAP_FS_READ, "doc-alpha", &sid) !=
+      CAP_BROKER_OK) {
+    marker_fail("broker_share_deny:request_returns_pending_share_id",
+                "request_share_failed");
+  }
+  if (sid == CAP_SHARE_ID_INVALID) {
+    marker_fail("broker_share_deny:request_returns_pending_share_id",
+                "share_id_invalid");
+  }
+  marker_pass("broker_share_deny:request_returns_pending_share_id");
+
+  /* 3: deny_path — owner deny is a successful workflow outcome. */
+  if (cap_broker_deny(owner, sid) != CAP_BROKER_OK) {
+    marker_fail("broker_share_deny:deny_path", "owner_deny_failed");
+  }
+  if (cap_broker_state_for_tests(sid) != CAP_SHARE_STATE_DENIED) {
+    marker_fail("broker_share_deny:deny_path", "state_not_denied");
+  }
+  marker_pass("broker_share_deny:deny_path");
+
+  /* 4: no_recipient_grant — neither broker nor underlying table leaks. */
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_deny:no_recipient_grant",
+                "broker_check_should_miss_after_deny");
+  }
+  if (cap_table_check(recip, CAP_FS_READ) != CAP_ERR_MISSING) {
+    marker_fail("broker_share_deny:no_recipient_grant",
+                "underlying_table_should_be_clean");
+  }
+  marker_pass("broker_share_deny:no_recipient_grant");
+
+  /* 5: cannot_be_re_approved — denied is terminal. */
+  if (cap_broker_approve(owner, sid) != CAP_BROKER_ERR_BAD_STATE) {
+    marker_fail("broker_share_deny:cannot_be_re_approved",
+                "denied_share_should_not_be_reapprovable");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_deny:cannot_be_re_approved",
+                "recipient_should_still_miss");
+  }
+  marker_pass("broker_share_deny:cannot_be_re_approved");
+
+  /* 6: bystander_cannot_mutate — set up a fresh share to test approver auth. */
+  cap_share_id_t sid2 = CAP_SHARE_ID_INVALID;
+  if (cap_broker_request_share(owner, recip, CAP_FS_READ, "doc-alpha", &sid2) !=
+      CAP_BROKER_OK) {
+    marker_fail("broker_share_deny:bystander_cannot_mutate",
+                "second_request_setup_failed");
+  }
+  if (cap_broker_approve(bystander, sid2) != CAP_BROKER_ERR_NOT_AUTHORIZED) {
+    marker_fail("broker_share_deny:bystander_cannot_mutate",
+                "bystander_approve_should_be_rejected");
+  }
+  if (cap_broker_deny(bystander, sid2) != CAP_BROKER_ERR_NOT_AUTHORIZED) {
+    marker_fail("broker_share_deny:bystander_cannot_mutate",
+                "bystander_deny_should_be_rejected");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_deny:bystander_cannot_mutate",
+                "recipient_should_still_miss_after_bystander_attempts");
+  }
+  marker_pass("broker_share_deny:bystander_cannot_mutate");
+
+  /* 7: audit_deny_recorded — gated on #98. */
+  marker_skip("broker_share_deny:audit_deny_recorded",
+              "broker_audit_unwired_pending_issue_98");
+
+  printf("TEST:DONE:broker_share_deny\n");
+  return 0;
+}

--- a/tests/broker_share_revoke_test.c
+++ b/tests/broker_share_revoke_test.c
@@ -1,0 +1,133 @@
+/**
+ * @file broker_share_revoke_test.c
+ * @brief M4 capability broker — revoke-path acceptance slice (issue #115).
+ *
+ * Asserts the revoke contract: owner-initiated revoke and recipient
+ * self-revoke both take effect immediately, removing recipient access at
+ * both the broker and the underlying cap_table layer, and the second revoke
+ * lands in a stable terminal state.  Sibling of broker_share_allow_test.c /
+ * broker_share_deny_test.c per plans/2026-05-14-m4-broker-acceptance-tests.md.
+ *
+ * Audit revoke-event assertions are gated on #98 (broker→audit wiring) and
+ * emitted as TEST:SKIP until that follow-up lands.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_broker.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+
+static void marker_fail(const char *name, const char *reason) {
+  printf("TEST:FAIL:%s:%s\n", name, reason);
+  exit(1);
+}
+
+static void marker_pass(const char *name) { printf("TEST:PASS:%s\n", name); }
+
+static void marker_skip(const char *name, const char *reason) {
+  printf("TEST:SKIP:%s:%s\n", name, reason);
+}
+
+static cap_share_id_t setup_approved_share(cap_subject_id_t owner,
+                                           cap_subject_id_t recip,
+                                           const char *name_for_failures) {
+  if (cap_table_grant(owner, CAP_FS_READ) != CAP_OK) {
+    marker_fail(name_for_failures, "owner_grant_setup_failed");
+  }
+  cap_share_id_t sid = CAP_SHARE_ID_INVALID;
+  if (cap_broker_request_share(owner, recip, CAP_FS_READ, "doc-alpha", &sid) !=
+      CAP_BROKER_OK) {
+    marker_fail(name_for_failures, "request_share_failed");
+  }
+  if (cap_broker_approve(owner, sid) != CAP_BROKER_OK) {
+    marker_fail(name_for_failures, "approve_failed");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_OK) {
+    marker_fail(name_for_failures, "post_approve_check_failed");
+  }
+  return sid;
+}
+
+int main(void) {
+  printf("TEST:START:broker_share_revoke\n");
+
+  cap_table_init();
+  cap_table_reset();
+  cap_broker_reset();
+
+  const cap_subject_id_t owner = 1u;
+  const cap_subject_id_t recip = 2u;
+  const cap_subject_id_t bystander = 3u;
+
+  /* 1: setup_grants_recipient. */
+  cap_share_id_t sid =
+      setup_approved_share(owner, recip, "broker_share_revoke:setup_grants_recipient");
+  marker_pass("broker_share_revoke:setup_grants_recipient");
+
+  /* 2: owner_revoke_takes_effect — recipient cannot read after revoke. */
+  if (cap_broker_revoke(bystander, sid) != CAP_BROKER_ERR_NOT_AUTHORIZED) {
+    marker_fail("broker_share_revoke:owner_revoke_takes_effect",
+                "bystander_revoke_should_be_rejected");
+  }
+  if (cap_broker_revoke(owner, sid) != CAP_BROKER_OK) {
+    marker_fail("broker_share_revoke:owner_revoke_takes_effect", "owner_revoke_failed");
+  }
+  if (cap_broker_state_for_tests(sid) != CAP_SHARE_STATE_REVOKED) {
+    marker_fail("broker_share_revoke:owner_revoke_takes_effect", "state_not_revoked");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_revoke:owner_revoke_takes_effect",
+                "recipient_should_miss_after_revoke");
+  }
+  marker_pass("broker_share_revoke:owner_revoke_takes_effect");
+
+  /* 3: underlying_table_revoked — defense in depth, no stale grant. */
+  if (cap_table_check(recip, CAP_FS_READ) != CAP_ERR_MISSING) {
+    marker_fail("broker_share_revoke:underlying_table_revoked",
+                "underlying_table_still_grants_recipient");
+  }
+  marker_pass("broker_share_revoke:underlying_table_revoked");
+
+  /* 4: double_revoke_is_idempotent — terminal state, recipient still misses. */
+  cap_broker_result_t second = cap_broker_revoke(owner, sid);
+  if (second != CAP_BROKER_OK && second != CAP_BROKER_ERR_BAD_STATE) {
+    marker_fail("broker_share_revoke:double_revoke_is_idempotent",
+                "second_revoke_unexpected_result");
+  }
+  if (cap_broker_state_for_tests(sid) != CAP_SHARE_STATE_REVOKED) {
+    marker_fail("broker_share_revoke:double_revoke_is_idempotent",
+                "state_changed_after_second_revoke");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_revoke:double_revoke_is_idempotent",
+                "recipient_regained_access_after_second_revoke");
+  }
+  marker_pass("broker_share_revoke:double_revoke_is_idempotent");
+
+  /* 5: recipient_self_revoke — fresh share, recipient revokes; bystander
+   *    still has no access. */
+  cap_share_id_t sid2 =
+      setup_approved_share(owner, recip, "broker_share_revoke:recipient_self_revoke");
+  if (cap_broker_revoke(recip, sid2) != CAP_BROKER_OK) {
+    marker_fail("broker_share_revoke:recipient_self_revoke",
+                "recipient_self_revoke_failed");
+  }
+  if (cap_broker_recipient_check(recip, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_revoke:recipient_self_revoke",
+                "recipient_still_has_access_after_self_revoke");
+  }
+  if (cap_broker_recipient_check(bystander, CAP_FS_READ, "doc-alpha") != CAP_ERR_MISSING) {
+    marker_fail("broker_share_revoke:recipient_self_revoke",
+                "bystander_should_not_be_granted");
+  }
+  marker_pass("broker_share_revoke:recipient_self_revoke");
+
+  /* 6: audit_revoke_recorded — gated on #98. */
+  marker_skip("broker_share_revoke:audit_revoke_recorded",
+              "broker_audit_unwired_pending_issue_98");
+
+  printf("TEST:DONE:broker_share_revoke\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #115. Rebased re-issue of #199 (which is DIRTY against current `main` per #205 triage).

## What this PR is

Mechanical rebase of #199 onto current `main` (`7f98e58`). Same diff content — no behavioral changes from the original PR.

## Conflict resolution

Two trivial conflicts, both with the defensive-harness work merged via #171 (closes #91) plus the bearssl/harness target additions that landed in the recent wave:

- `build/scripts/test.sh` — usage line + the three new `broker_share_*` dispatch arms now use `run_script` (the defensive launcher introduced by #171), matching every other arm. No semantic change.
- `build/scripts/validate_bundle.sh` — `TEST_TARGETS` list reconciles the new `bearssl_compile` entry from `main` with the three `broker_share_*` entries from this slice.

No test sources, no acceptance-test C code, and no .sh test scripts were touched during the rebase.

## Validation re-run after rebase

```
$ bash build/scripts/test.sh broker_share_allow   → 5 PASS + 1 SKIP, DONE
$ bash build/scripts/test.sh broker_share_deny    → 6 PASS + 1 SKIP, DONE
$ bash build/scripts/test.sh broker_share_revoke  → 5 PASS + 1 SKIP, DONE
```

All audit assertions remain gated as `TEST:SKIP:<name>:broker_audit_unwired_pending_issue_98` per the original PR's design — broker→audit wiring is not on `main` yet (#98 covers cap_table audit, not broker state transitions). Skips will flip to passes when broker→audit wiring lands.

## Follow-ups

Recommend closing #199 once this lands (or after maintainer eyeballs the rebase). Original PR description follows.

---

Implements the three deterministic acceptance validators that BUILD_ROADMAP §5.4 carves out for M4, following plans/2026-05-14-m4-broker-acceptance-tests.md and mirroring the sibling pattern of #92 (M2) / #108 (M3). Builds on top of the broker API already on \`main\` from PR #99.

- \`tests/broker_share_allow_test.c\` — pre-approval miss, approve-grants-recipient, resource-scope, capability-scope.
- \`tests/broker_share_deny_test.c\` — deny-as-successful-outcome, no recipient or underlying-table leak, denied-is-terminal, bystander cannot mutate.
- \`tests/broker_share_revoke_test.c\` — owner revoke, underlying cap_table cleared, double-revoke stable, recipient self-revoke.
- \`build/scripts/test_broker_share_{allow,deny,revoke}.sh\` — same \`-std=c11 -Wall -Wextra -Werror\` posture as \`test_cap_broker.sh\`.
- \`build/scripts/test.sh\` — three new dispatch arms + usage line (now via defensive \`run_script\`).
- \`build/scripts/validate_bundle.sh\` — \`TEST_TARGETS\` extended with the three new names.

— cron:secureos-hourly-issue-work, run e4c62e32, 2026-05-21 21:00 UTC