### PR TITLE
fix #195: CI manifest schema validation step

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,7 +37,15 @@ jobs:
       - name: Install runtime test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y nasm qemu-system-x86
+          sudo apt-get install -y nasm qemu-system-x86 python3-jsonschema
+
+      - name: Manifest schema validate (issue #195)
+        # Re-validates every in-tree app manifest under manifests/examples/
+        # against manifests/schema/v0.json on every PR so the schema and the
+        # worked examples cannot silently drift (BUILD_ROADMAP §7 / #187).
+        # Runs through the same .sh wrapper invoked locally so behavior is
+        # identical in CI and on a contributor's box.
+        run: ./build/scripts/validate_manifests.sh
 
       - name: Kernel entry build
         run: ./build/scripts/build.sh kernel

--- a/build/scripts/validate_manifests.ps1
+++ b/build/scripts/validate_manifests.ps1
@@ -1,0 +1,30 @@
+# build/scripts/validate_manifests.ps1
+#
+# Issue #195: thin wrapper around tools/validate_manifests.py so the
+# manifest schema check runs through the same build/scripts/* entrypoint
+# convention as every other validator. Mirror script:
+# build/scripts/validate_manifests.sh (AGENTS.md cross-platform parity
+# rule, #156).
+#
+# Exit codes:
+#   0 — all manifests validated against manifests/schema/v0.json
+#   1 — one or more manifests failed schema validation
+#   2 — environment / usage error (missing schema, missing jsonschema lib)
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+$Py = if ($env:PYTHON) { $env:PYTHON } else { 'python3' }
+if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+    # Fallback to Windows-launcher style.
+    $Py = 'python'
+    if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+        Write-Error 'MANIFEST_VALIDATE:ERROR:python3/python not found on PATH'
+        exit 2
+    }
+}
+
+$Script = Join-Path $RootDir 'tools/validate_manifests.py'
+& $Py $Script @args
+exit $LASTEXITCODE

--- a/build/scripts/validate_manifests.sh
+++ b/build/scripts/validate_manifests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# build/scripts/validate_manifests.sh
+#
+# Issue #195: thin wrapper around tools/validate_manifests.py so the
+# manifest schema check runs through the same `build/scripts/*.sh`
+# entrypoint convention as every other validator. Mirror script:
+# build/scripts/validate_manifests.ps1 (AGENTS.md cross-platform parity
+# rule, #156).
+#
+# Exit codes:
+#   0 — all manifests validated against manifests/schema/v0.json
+#   1 — one or more manifests failed schema validation
+#   2 — environment / usage error (missing schema, missing jsonschema lib)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "MANIFEST_VALIDATE:ERROR:python3 not found on PATH" >&2
+  exit 2
+fi
+
+exec "$PY" "$ROOT_DIR/tools/validate_manifests.py" "$@"

--- a/tools/validate_manifests.py
+++ b/tools/validate_manifests.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+validate_manifests.py — Validate SecureOS app manifests against the
+manifest JSON Schema (manifests/schema/v0.json).
+
+Issue #195: lock in the value of the schema landed by #187 by re-validating
+every in-tree example manifest on every PR. Without this, schema and examples
+silently drift — exactly the ABI-rot mode BUILD_ROADMAP §7 is meant to
+prevent.
+
+Usage:
+    tools/validate_manifests.py [--schema PATH] [--root PATH] [GLOB ...]
+
+Defaults:
+    --schema  manifests/schema/v0.json
+    --root    repository root (parent of `tools/`)
+    GLOB(s)   manifests/examples/*.json
+
+Exit codes:
+    0  — every manifest validated against the schema
+    1  — one or more manifests failed validation (errors printed with the
+         offending file + JSON-pointer + message)
+    2  — usage / environment error (missing schema, missing jsonschema lib,
+         no manifests matched)
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob as globlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _fail(msg: str, code: int = 2) -> "int":
+    print(f"MANIFEST_VALIDATE:ERROR:{msg}", file=sys.stderr)
+    return code
+
+
+def _load_json(path: Path) -> object:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _format_pointer(absolute_path) -> str:
+    # jsonschema's ValidationError.absolute_path is a deque of keys/indices.
+    # Emit RFC 6901 JSON-pointer so failures are unambiguous in CI logs.
+    parts = []
+    for p in absolute_path:
+        if isinstance(p, int):
+            parts.append(str(p))
+        else:
+            # escape '~' -> '~0' and '/' -> '~1' per RFC 6901.
+            parts.append(str(p).replace("~", "~0").replace("/", "~1"))
+    return "/" + "/".join(parts) if parts else ""
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate SecureOS app manifests against the v0 schema."
+    )
+    parser.add_argument(
+        "--schema",
+        default=None,
+        help="Path to the JSON Schema (default: manifests/schema/v0.json).",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root used to resolve relative paths (default: auto).",
+    )
+    parser.add_argument(
+        "globs",
+        nargs="*",
+        help="Glob(s) for manifests to validate "
+        "(default: manifests/examples/*.json).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.root:
+        root = Path(args.root).resolve()
+    else:
+        root = Path(__file__).resolve().parent.parent
+
+    schema_path = (
+        Path(args.schema).resolve()
+        if args.schema
+        else (root / "manifests" / "schema" / "v0.json").resolve()
+    )
+
+    if not schema_path.is_file():
+        return _fail(f"schema not found at {schema_path}")
+
+    try:
+        import jsonschema  # noqa: F401
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        return _fail(
+            "python `jsonschema` package is required. "
+            "Install via `pip install jsonschema` or `apt-get install "
+            "python3-jsonschema`."
+        )
+
+    try:
+        schema = _load_json(schema_path)
+    except json.JSONDecodeError as exc:
+        return _fail(f"schema {schema_path} is not valid JSON: {exc}")
+
+    try:
+        # Draft202012Validator.check_schema raises on bad meta-schema.
+        Draft202012Validator.check_schema(schema)
+    except Exception as exc:  # pragma: no cover — defensive
+        return _fail(f"schema {schema_path} failed meta-schema check: {exc}")
+
+    validator = Draft202012Validator(schema)
+
+    globs = args.globs or [str(root / "manifests" / "examples" / "*.json")]
+
+    matched: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in globs:
+        # Allow relative patterns to resolve against repo root.
+        if not os.path.isabs(pattern):
+            pattern = str(root / pattern)
+        for hit in sorted(globlib.glob(pattern, recursive=True)):
+            p = Path(hit).resolve()
+            if p in seen:
+                continue
+            seen.add(p)
+            matched.append(p)
+
+    if not matched:
+        return _fail(
+            "no manifests matched the supplied globs "
+            f"({', '.join(globs)})"
+        )
+
+    failures = 0
+    for manifest_path in matched:
+        rel = manifest_path.relative_to(root) if manifest_path.is_relative_to(root) else manifest_path
+        try:
+            doc = _load_json(manifest_path)
+        except json.JSONDecodeError as exc:
+            print(
+                f"MANIFEST_VALIDATE:FAIL:{rel}: invalid JSON: {exc}",
+                file=sys.stderr,
+            )
+            failures += 1
+            continue
+
+        errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.absolute_path))
+        if not errors:
+            print(f"MANIFEST_VALIDATE:PASS:{rel}")
+            continue
+
+        for err in errors:
+            pointer = _format_pointer(err.absolute_path) or "/"
+            print(
+                f"MANIFEST_VALIDATE:FAIL:{rel}: at {pointer}: {err.message}",
+                file=sys.stderr,
+            )
+        failures += 1
+
+    if failures:
+        print(
+            f"MANIFEST_VALIDATE:SUMMARY:fail {failures}/{len(matched)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"MANIFEST_VALIDATE:SUMMARY:pass {len(matched)}/{len(matched)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #195.

## Summary
Adds a `manifest-schema-validate` step to `.github/workflows/pr-build.yml` that re-validates every in-tree app manifest under `manifests/examples/` against `manifests/schema/v0.json` on every PR. Locks in the value of the schema work shipped in #187 so the schema and worked examples cannot silently drift (BUILD_ROADMAP §7).

## Changes
- `tools/validate_manifests.py` — Draft 2020-12 validator using Python's `jsonschema`. Emits deterministic `MANIFEST_VALIDATE:PASS/FAIL/SUMMARY` markers with JSON-pointers at the offending field. Exit codes: `0` ok, `1` schema failure, `2` env/usage error.
- `build/scripts/validate_manifests.sh` + `.ps1` — thin wrappers, kept in sync per AGENTS.md cross-platform rule (#156). `check_shell_parity.sh` is green without adding allowlist entries.
- `.github/workflows/pr-build.yml` — installs `python3-jsonschema` and runs the wrapper as its own step (clean PASS/FAIL signal, before the heavier validation bundle).

## Validation
- `python3 tools/validate_manifests.py` → `pass 2/2` (`helloapp.json`, `helloapp.deny.json`).
- `bash build/scripts/validate_manifests.sh` → same, exit 0.
- Intentional schema break (add `unknown_field`, drop `app.id`) → exit 1, two `MANIFEST_VALIDATE:FAIL` lines with JSON-pointers `/` and `/app`.
- `bash build/scripts/check_shell_parity.sh` → `PARITY:OK` (42 allowlist entries unchanged).

## Done-when checklist (from #195)
- [x] PR validation workflow has a `manifest-schema-validate` stage that runs on every PR
- [x] Stage passes today against the `helloapp` manifest (and the deny variant)
- [x] Intentional schema break makes the stage fail locally via the same wrapper script
- [x] No drift between `.sh` and `.ps1` wrappers
- [x] No changes to the schema itself

## Follow-ups (not in this PR)
- Could later be folded into `validate_bundle.sh` as a `schema_validate` target so it runs alongside the other validators in one bundle (out of scope per the issue's "ideally same workflow" wording — currently it's its own step in the same workflow).