### PR TITLE
fix #210: M1 sync IPC primitive v0 (kernel/ipc/ scaffold) — rebased on main

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -43,6 +43,7 @@ test_harness_negative
 test_helloapp_allow
 test_helloapp_deny
 test_https
+test_ipc_sync_v0
 test_kernel_persistence
 test_launcher_console
 test_launcher_fs

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -61,6 +61,7 @@ $testScript = switch ($TestName) {
   "https" { "./build/scripts/test_https.sh" }
   "bearssl_compile" { "./build/scripts/test_bearssl_compile.sh" }
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
+  "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|ipc_sync_v0|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -213,6 +213,9 @@ case "$TEST_NAME" in
     ;;
   abi_version)
     run_script "$ROOT_DIR/build/scripts/test_abi_version.sh"
+    ;;
+  ipc_sync_v0)
+    run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/test_ipc_sync_v0.sh
+++ b/build/scripts/test_ipc_sync_v0.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build + run the M1 synchronous IPC primitive v0 tests (issue #210).
+#
+# Covers:
+#   - allow path (two modules exchange one envelope)
+#   - deny path (CAP:DENY:<subject>:ipc_send:- marker present + cap audit
+#     ring records the deny event)
+#   - ipc_call round-trip
+#   - envelope ABI invariants (size, field offsets via static_assert,
+#     abi_version / flags / payload_len rejection)
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/ipc_sync_v0_test.c" \
+  -o "$OUT_DIR/ipc_sync_v0_test"
+
+LOG_PATH="$OUT_DIR/ipc_sync_v0_test.log"
+"$OUT_DIR/ipc_sync_v0_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:ipc_sync_v0_abi_envelope" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_sync_v0_allow_send_recv" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_sync_v0_deny_marker" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_sync_v0_call_round_trip" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_sync_v0" "$LOG_PATH"
+# Capability-deny contract marker (docs/abi/capability-deny-contract.md §4):
+# CAP:DENY:<subject>:ipc_send:- emitted by ipc_ops.c on the deny path.
+grep -Eq "^CAP:DENY:[0-9]+:ipc_send:-$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -41,6 +41,7 @@ TEST_TARGETS=(
     kernel_filedemo
     kernel_persistence
     validator_report
+    ipc_sync_v0
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/docs/test-plans/m0-m1-plan.yaml
+++ b/docs/test-plans/m0-m1-plan.yaml
@@ -457,3 +457,13 @@ tasks:
     passCondition:
       type: exit_code
       expected: 0
+
+  - taskId: M1_IPC_SYNC_V0
+    ownerRole: implementer
+    run: "./build/scripts/test.sh ipc_sync_v0"
+    artifacts:
+      - "status:pending"
+      - "issue:#210"
+    passCondition:
+      type: exit_code
+      expected: 0

--- a/kernel/cap/cap_table.c
+++ b/kernel/cap/cap_table.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define CAP_ID_MIN CAP_CONSOLE_WRITE
-#define CAP_ID_MAX CAP_NETWORK
+#define CAP_ID_MAX CAP_IPC_RECV
 
 #define CAPABILITY_COUNT ((uint32_t)(CAP_ID_MAX - CAP_ID_MIN + 1u))
 #define CAP_WORD_BITS 8u

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -19,6 +19,8 @@ typedef enum {
   CAP_APP_EXEC = 10,
   CAP_CODESIGN_BYPASS = 11,
   CAP_NETWORK = 12,
+  CAP_IPC_SEND = 13,
+  CAP_IPC_RECV = 14,
 } capability_id_t;
 
 typedef enum {

--- a/kernel/core/kmain.c
+++ b/kernel/core/kmain.c
@@ -77,6 +77,8 @@ void kmain(void) {
   (void)cap_table_grant(KERNEL_BOOTSTRAP_SUBJECT, CAP_EVENT_PUBLISH);
   (void)cap_table_grant(KERNEL_BOOTSTRAP_SUBJECT, CAP_APP_EXEC);
   (void)cap_table_grant(KERNEL_BOOTSTRAP_SUBJECT, CAP_NETWORK);
+  (void)cap_table_grant(KERNEL_BOOTSTRAP_SUBJECT, CAP_IPC_SEND);
+  (void)cap_table_grant(KERNEL_BOOTSTRAP_SUBJECT, CAP_IPC_RECV);
 
   (void)cap_table_grant(FILEDEMO_SUBJECT, CAP_CONSOLE_WRITE);
   (void)cap_table_grant(FILEDEMO_SUBJECT, CAP_DISK_IO_REQUEST);

--- a/kernel/ipc/ipc_msg.h
+++ b/kernel/ipc/ipc_msg.h
@@ -1,0 +1,144 @@
+/**
+ * @file ipc_msg.h
+ * @brief SecureOS synchronous IPC v0 wire envelope and error model.
+ *
+ * Purpose:
+ *   Single source of truth for the on-wire IPC envelope (`ipc_msg_v0`)
+ *   and the frozen `ipc_result_t` error vocabulary defined by
+ *   `docs/abi/ipc-wire.md` for `OS_ABI_VERSION = 0`. This is the M1
+ *   synchronous IPC primitive v0 ABI surface (issue #210, plan
+ *   `plans/2026-05-19-m1-sync-ipc-primitive.md`).
+ *
+ *   The struct layout is fixed by the spec:
+ *     - 16-byte header (abi_version, flags, sender_subject, tag,
+ *       payload_len) followed by a fixed 64-byte payload region.
+ *     - Total envelope size: 80 bytes. All multi-byte fields are
+ *       naturally aligned and little-endian on supported targets.
+ *     - `flags` is reserved (must be zero in v0).
+ *     - `sender_subject` is kernel-stamped on send; receivers MUST
+ *       reject envelopes whose sender_subject == 0 with
+ *       IPC_ERR_INVALID_MSG.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_port.{c,h}: port table; envelopes are staged in a
+ *     single-waiter slot per port for the v0 in-kernel rendezvous.
+ *   - kernel/ipc/ipc_ops.c: implements ipc_send / ipc_recv / ipc_call
+ *     and is the only writer of `sender_subject` on outbound frames.
+ *   - kernel/cap/capability.h: `cap_subject_id_t` is the type stamped
+ *     into `sender_subject`; CAP_IPC_SEND / CAP_IPC_RECV gate the ops.
+ *   - user/include/secureos_abi.h: provides `OS_ABI_VERSION` that every
+ *     envelope carries and that receivers cross-check.
+ *
+ * Launched by:
+ *   Header-only; not a standalone process. Compiled into the kernel
+ *   image and into the host-side IPC test binary
+ *   (`tests/ipc_sync_v0_test.c`).
+ *
+ * Issue: #210. Plan: plans/2026-05-19-m1-sync-ipc-primitive.md.
+ */
+
+#ifndef SECUREOS_KERNEL_IPC_MSG_H
+#define SECUREOS_KERNEL_IPC_MSG_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../user/include/secureos_abi.h"
+#include "../cap/capability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Fixed-size payload region of the v0 IPC envelope. Spec-frozen at 64
+ * bytes by docs/abi/ipc-wire.md §2; changing this requires a bump of
+ * OS_ABI_VERSION (non-additive change).
+ */
+#define IPC_MSG_PAYLOAD_MAX 64u
+
+/*
+ * Total envelope size in v0. Used by tests and static_asserts to ensure
+ * no implicit padding has been introduced by the compiler/target.
+ */
+#define IPC_MSG_V0_SIZE 80u
+
+/*
+ * Reserved-as-MBZ flag mask. Any non-zero bit here on receive means the
+ * envelope is malformed (IPC_ERR_INVALID_MSG).
+ */
+#define IPC_MSG_FLAGS_RESERVED_MBZ 0xFFFFu
+
+/*
+ * The v0 IPC message envelope. Exactly the wire layout from
+ * docs/abi/ipc-wire.md §2 — do not reorder, resize, or pad.
+ *
+ *   offset  size  field
+ *   ------  ----  -----
+ *        0     2  abi_version
+ *        2     2  flags             (MBZ in v0)
+ *        4     4  sender_subject    (kernel-stamped on send)
+ *        8     4  tag               (caller-defined; opaque to IPC)
+ *       12     4  payload_len       (0..IPC_MSG_PAYLOAD_MAX)
+ *       16    64  payload[]
+ *   ------  ----
+ *       80
+ */
+typedef struct ipc_msg_v0 {
+  uint16_t abi_version;
+  uint16_t flags;
+  uint32_t sender_subject;
+  uint32_t tag;
+  uint32_t payload_len;
+  uint8_t payload[IPC_MSG_PAYLOAD_MAX];
+} ipc_msg_v0;
+
+/*
+ * Frozen-for-v0 IPC error vocabulary. Adding new entries is *not*
+ * additive (see ipc-wire.md §6); a bump of OS_ABI_VERSION is required.
+ *
+ * Class taxonomy (ipc-wire.md §5.1):
+ *   - capability decision: IPC_ERR_CAP_DENIED only.
+ *   - malformed message:   IPC_ERR_INVALID_MSG.
+ *   - transport fault:     IPC_ERR_INVALID_PORT, IPC_ERR_PEER_GONE.
+ *   - reserved future:     IPC_ERR_WOULD_BLOCK (MUST NOT be returned by
+ *                          v0 implementations; consumers MAY test for
+ *                          forward compat).
+ */
+typedef enum {
+  IPC_OK = 0,
+  IPC_ERR_INVALID_PORT = 1,
+  IPC_ERR_INVALID_MSG = 2,
+  IPC_ERR_CAP_DENIED = 3,
+  IPC_ERR_WOULD_BLOCK = 4,
+  IPC_ERR_PEER_GONE = 5,
+} ipc_result_t;
+
+/*
+ * Compile-time guard: catch host targets that would silently insert
+ * padding into the envelope. The static_assert below is conditional
+ * because freestanding kernel builds may pre-date C11 in some shims;
+ * the host-side test build always exercises C11.
+ */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(ipc_msg_v0) == IPC_MSG_V0_SIZE,
+               "ipc_msg_v0 must be exactly IPC_MSG_V0_SIZE bytes (no padding) — see docs/abi/ipc-wire.md §2.2");
+_Static_assert(offsetof(ipc_msg_v0, abi_version) == 0,
+               "ipc_msg_v0.abi_version must be at offset 0");
+_Static_assert(offsetof(ipc_msg_v0, flags) == 2,
+               "ipc_msg_v0.flags must be at offset 2");
+_Static_assert(offsetof(ipc_msg_v0, sender_subject) == 4,
+               "ipc_msg_v0.sender_subject must be at offset 4");
+_Static_assert(offsetof(ipc_msg_v0, tag) == 8,
+               "ipc_msg_v0.tag must be at offset 8");
+_Static_assert(offsetof(ipc_msg_v0, payload_len) == 12,
+               "ipc_msg_v0.payload_len must be at offset 12");
+_Static_assert(offsetof(ipc_msg_v0, payload) == 16,
+               "ipc_msg_v0.payload must be at offset 16");
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_IPC_MSG_H */

--- a/kernel/ipc/ipc_ops.c
+++ b/kernel/ipc/ipc_ops.c
@@ -1,0 +1,225 @@
+/**
+ * @file ipc_ops.c
+ * @brief Synchronous IPC primitive ops (send/recv/call) for v0 (#210).
+ *
+ * Purpose:
+ *   Implements the three synchronous IPC operations defined in
+ *   `docs/abi/ipc-wire.md` §4 on top of the port table in
+ *   `kernel/ipc/ipc_port.{c,h}`:
+ *     - ipc_send  : capability-checked stage into a port's slot.
+ *     - ipc_recv  : capability-checked + ownership-checked consume from
+ *                   a port's slot.
+ *     - ipc_call  : send + recv round-trip over a caller-owned reply
+ *                   port whose handle is carried in `req->tag`.
+ *
+ *   The deny path threads through cap_check() (so the existing audit
+ *   ring records every check unchanged) and emits the canonical
+ *   `CAP:DENY:<subject>:<cap>:-` marker required by
+ *   `docs/abi/capability-deny-contract.md` before returning
+ *   IPC_ERR_CAP_DENIED.
+ *
+ *   In v0 every op is in-kernel-only between two test modules; there is
+ *   no scheduler suspension, so the "blocks until rendezvous" wording
+ *   in the spec is satisfied by the ordering invariants of the test
+ *   harness rather than a true wait queue. The wire layout and error
+ *   model are the binding ABI contract; the in-kernel mechanism behind
+ *   them is intentionally minimal and replaceable.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_port.{c,h}: port table, single-waiter slot.
+ *   - kernel/ipc/ipc_msg.h:      envelope + ipc_result_t vocabulary.
+ *   - kernel/cap/capability.{c,h}: cap_check() drives the audit ring.
+ *
+ * Launched by:
+ *   Not a standalone process. Compiled into the kernel image and into
+ *   the host-side ipc_sync_v0 test binary.
+ *
+ * Issue: #210.
+ */
+
+#include "ipc_msg.h"
+#include "ipc_port.h"
+#include "../cap/capability.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Spec-mandated canonical name for the CAP:DENY marker resource field
+ * when the operation has no resource handle of its own
+ * (capability-deny-contract.md §4). */
+#define IPC_DENY_RESOURCE_NONE "-"
+
+static const char *ipc_cap_name(capability_id_t cap) {
+  switch (cap) {
+    case CAP_IPC_SEND: return "ipc_send";
+    case CAP_IPC_RECV: return "ipc_recv";
+    case CAP_CONSOLE_WRITE: return "console_write";
+    case CAP_SERIAL_WRITE: return "serial_write";
+    case CAP_DEBUG_EXIT: return "debug_exit";
+    case CAP_CAPABILITY_ADMIN: return "capability_admin";
+    case CAP_DISK_IO_REQUEST: return "disk_io_request";
+    case CAP_FS_READ: return "fs_read";
+    case CAP_FS_WRITE: return "fs_write";
+    case CAP_EVENT_SUBSCRIBE: return "event_subscribe";
+    case CAP_EVENT_PUBLISH: return "event_publish";
+    case CAP_APP_EXEC: return "app_exec";
+    case CAP_CODESIGN_BYPASS: return "codesign_bypass";
+    case CAP_NETWORK: return "network";
+  }
+  return "unknown";
+}
+
+static void ipc_emit_deny_marker(cap_subject_id_t subject, capability_id_t cap) {
+  /* Canonical: CAP:DENY:<actor_subject_id>:<cap_id_name>:<resource>
+   * IPC has no per-call resource handle in v0, so the resource is '-'. */
+  printf("CAP:DENY:%u:%s:%s\n", (unsigned)subject, ipc_cap_name(cap), IPC_DENY_RESOURCE_NONE);
+}
+
+/* Capability-gate helpers. These intentionally mirror the shape of
+ * cap_gate.c so audit-side behavior is identical to other gated paths. */
+static ipc_result_t cap_ipc_send_gate(cap_subject_id_t subject, capability_id_t required) {
+  cap_result_t r = cap_check(subject, required);
+  if (r != CAP_OK) {
+    ipc_emit_deny_marker(subject, required);
+    return IPC_ERR_CAP_DENIED;
+  }
+  return IPC_OK;
+}
+
+static ipc_result_t cap_ipc_recv_gate(cap_subject_id_t subject, capability_id_t required) {
+  cap_result_t r = cap_check(subject, required);
+  if (r != CAP_OK) {
+    ipc_emit_deny_marker(subject, required);
+    return IPC_ERR_CAP_DENIED;
+  }
+  return IPC_OK;
+}
+
+static ipc_result_t validate_outbound_envelope(const ipc_msg_v0 *msg) {
+  if (msg == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (msg->abi_version != (uint16_t)OS_ABI_VERSION) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (msg->flags != 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (msg->payload_len > IPC_MSG_PAYLOAD_MAX) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  return IPC_OK;
+}
+
+ipc_result_t ipc_send(cap_subject_id_t sender, ipc_port_t target, const ipc_msg_v0 *msg) {
+  ipc_result_t v = validate_outbound_envelope(msg);
+  if (v != IPC_OK) {
+    return v;
+  }
+
+  capability_id_t required_send = CAP_IPC_SEND;
+  ipc_result_t pr = ipc_port_send_cap(target, &required_send);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+
+  ipc_result_t gate = cap_ipc_send_gate(sender, required_send);
+  if (gate != IPC_OK) {
+    return gate;
+  }
+
+  /* Stamp authenticated sender id; spec §2.4 forbids trusting the
+   * caller-supplied value. A delivered envelope with sender_subject == 0
+   * is treated as IPC_ERR_INVALID_MSG by the receiver. */
+  if (sender == 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  ipc_msg_v0 outbound;
+  memcpy(&outbound, msg, sizeof(outbound));
+  outbound.sender_subject = sender;
+
+  return ipc_port_stage(target, &outbound);
+}
+
+ipc_result_t ipc_recv(cap_subject_id_t receiver, ipc_port_t self_port, ipc_msg_v0 *out_msg) {
+  if (out_msg == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  cap_subject_id_t owner = 0u;
+  ipc_result_t pr = ipc_port_owner(self_port, &owner);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+  if (owner != receiver) {
+    /* Spec §3: only the owning subject may receive on a port. Treat
+     * as a capability decision so policy-leakage tests can rely on
+     * the single deny code. */
+    ipc_emit_deny_marker(receiver, CAP_IPC_RECV);
+    return IPC_ERR_CAP_DENIED;
+  }
+
+  capability_id_t required_recv = CAP_IPC_RECV;
+  pr = ipc_port_recv_cap(self_port, &required_recv);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+
+  ipc_result_t gate = cap_ipc_recv_gate(receiver, required_recv);
+  if (gate != IPC_OK) {
+    return gate;
+  }
+
+  ipc_result_t cr = ipc_port_consume(self_port, out_msg);
+  if (cr != IPC_OK) {
+    return cr;
+  }
+
+  /* §2.4: a delivered envelope with sender_subject == 0 is malformed. */
+  if (out_msg->sender_subject == 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->abi_version != (uint16_t)OS_ABI_VERSION) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->flags != 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->payload_len > IPC_MSG_PAYLOAD_MAX) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  return IPC_OK;
+}
+
+ipc_result_t ipc_call(cap_subject_id_t caller,
+                      ipc_port_t target,
+                      const ipc_msg_v0 *req,
+                      ipc_port_t reply_port,
+                      ipc_msg_v0 *out_reply) {
+  if (req == NULL || out_reply == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  /* Caller must own the reply port (§4: "owns the reply port"). The
+   * reply-port handle is reserved for embedding in `req->tag` (§2.3);
+   * v0 leaves the encoding caller-opaque, so we accept it as an
+   * explicit argument here and the test asserts it is also carried in
+   * req->tag for forward-compat. */
+  cap_subject_id_t reply_owner = 0u;
+  ipc_result_t pr = ipc_port_owner(reply_port, &reply_owner);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+  if (reply_owner != caller) {
+    ipc_emit_deny_marker(caller, CAP_IPC_RECV);
+    return IPC_ERR_CAP_DENIED;
+  }
+
+  ipc_result_t sr = ipc_send(caller, target, req);
+  if (sr != IPC_OK) {
+    return sr;
+  }
+
+  return ipc_recv(caller, reply_port, out_reply);
+}

--- a/kernel/ipc/ipc_ops.h
+++ b/kernel/ipc/ipc_ops.h
@@ -1,0 +1,84 @@
+/**
+ * @file ipc_ops.h
+ * @brief Public entry points for the M1 synchronous IPC primitive (v0).
+ *
+ * Purpose:
+ *   Declares the three synchronous IPC ops (`ipc_send`, `ipc_recv`,
+ *   `ipc_call`) implemented in `ipc_ops.c`. These are the v0 surface
+ *   the rest of the kernel (and the host-side scaffolding test) call
+ *   into. Wire layout and error vocabulary live in `ipc_msg.h`; port
+ *   table lifecycle lives in `ipc_port.h`.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_msg.h: envelope and `ipc_result_t`.
+ *   - kernel/ipc/ipc_port.h: handle resolution + single-waiter slot.
+ *   - kernel/cap/capability.h: `cap_subject_id_t` plus the
+ *     CAP_IPC_SEND / CAP_IPC_RECV capabilities consulted by the gate.
+ *
+ * Launched by:
+ *   Not a standalone process. Header-only declarations.
+ *
+ * Issue: #210.
+ */
+
+#ifndef SECUREOS_KERNEL_IPC_OPS_H
+#define SECUREOS_KERNEL_IPC_OPS_H
+
+#include "ipc_msg.h"
+#include "ipc_port.h"
+#include "../cap/capability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Synchronous send: stage `*msg` into `target`'s single-waiter slot
+ * after checking that `sender` holds the port's send_cap. On success
+ * the staged envelope's `sender_subject` field is the kernel-stamped
+ * value of `sender`, not the caller-supplied one (spec §2.4).
+ *
+ * Returns:
+ *   IPC_OK              — envelope staged.
+ *   IPC_ERR_INVALID_PORT — handle stale or unknown.
+ *   IPC_ERR_INVALID_MSG  — envelope rejected by validation
+ *                          (abi_version mismatch, flags != 0,
+ *                          payload_len > IPC_MSG_PAYLOAD_MAX,
+ *                          sender == 0).
+ *   IPC_ERR_CAP_DENIED   — sender lacks the port's send_cap; a
+ *                          CAP:DENY marker has been emitted.
+ *   IPC_ERR_PEER_GONE    — slot already occupied (v0 has no wait
+ *                          queue; see ipc-wire.md §1).
+ */
+ipc_result_t ipc_send(cap_subject_id_t sender,
+                      ipc_port_t target,
+                      const ipc_msg_v0 *msg);
+
+/*
+ * Synchronous receive: consume the staged envelope on `self_port` into
+ * `*out_msg` after asserting that `receiver` owns the port and holds
+ * the port's recv_cap. Returns IPC_ERR_CAP_DENIED (with a CAP:DENY
+ * marker) if either check fails.
+ */
+ipc_result_t ipc_recv(cap_subject_id_t receiver,
+                      ipc_port_t self_port,
+                      ipc_msg_v0 *out_msg);
+
+/*
+ * Synchronous request/reply: send `*req` to `target` then receive on a
+ * caller-owned `reply_port`. The reply-port handle is carried by the
+ * caller in `req->tag` for forward-compat with the §2.3 reply-port
+ * encoding; in v0 the handle is also passed explicitly to make the
+ * ownership check unambiguous.
+ */
+ipc_result_t ipc_call(cap_subject_id_t caller,
+                      ipc_port_t target,
+                      const ipc_msg_v0 *req,
+                      ipc_port_t reply_port,
+                      ipc_msg_v0 *out_reply);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_IPC_OPS_H */

--- a/kernel/ipc/ipc_port.c
+++ b/kernel/ipc/ipc_port.c
@@ -1,0 +1,255 @@
+/**
+ * @file ipc_port.c
+ * @brief Port table implementation for the M1 synchronous IPC v0 scaffold.
+ *
+ * Purpose:
+ *   Maintains a small fixed-size array of port slots indexed by a 16-bit
+ *   table index, with a 16-bit generation counter packed into the high
+ *   half of `ipc_port_t` to detect use-after-destroy. Each slot holds
+ *   the owning subject, the send/recv capability ids, and a single
+ *   "in flight" envelope used to emulate the synchronous rendezvous
+ *   described by docs/abi/ipc-wire.md §4 (issue #210).
+ *
+ *   This file deliberately contains no synchronization primitives: the
+ *   v0 scaffold is single-threaded and lives between two in-kernel test
+ *   modules. A scheduler-aware blocking implementation is a follow-up
+ *   (see plans/2026-05-19-m1-sync-ipc-primitive.md non-goals).
+ *
+ * Interactions:
+ *   - ipc_port.h: public interface implemented here.
+ *   - ipc_ops.c: the only caller of ipc_port_stage/consume in normal use.
+ *
+ * Launched by:
+ *   Not a standalone process. Compiled into the kernel image and into
+ *   the host-side ipc_sync_v0 test binary.
+ *
+ * Issue: #210.
+ */
+
+#include "ipc_port.h"
+
+#include <string.h>
+
+typedef struct {
+  bool live;
+  bool slot_occupied;
+  uint16_t generation;
+  cap_subject_id_t owner;
+  capability_id_t send_cap;
+  capability_id_t recv_cap;
+  ipc_msg_v0 staged;
+} ipc_port_slot_t;
+
+static ipc_port_slot_t g_ports[IPC_PORT_TABLE_MAX];
+static bool g_table_initialized = false;
+
+#define IPC_PORT_INDEX_MASK 0xFFFFu
+#define IPC_PORT_GEN_SHIFT 16u
+
+static ipc_port_t encode_handle(uint16_t index, uint16_t generation) {
+  /* Index 0 with generation 0 collides with IPC_PORT_INVALID, so we
+   * always start generations at 1 and bump on each (re)use. */
+  return ((ipc_port_t)generation << IPC_PORT_GEN_SHIFT) | (ipc_port_t)index;
+}
+
+static bool decode_handle(ipc_port_t handle, uint16_t *out_index, uint16_t *out_gen) {
+  if (handle == IPC_PORT_INVALID) {
+    return false;
+  }
+  *out_index = (uint16_t)(handle & IPC_PORT_INDEX_MASK);
+  *out_gen = (uint16_t)((handle >> IPC_PORT_GEN_SHIFT) & 0xFFFFu);
+  return *out_index < IPC_PORT_TABLE_MAX;
+}
+
+static ipc_port_slot_t *resolve(ipc_port_t handle) {
+  uint16_t index = 0u;
+  uint16_t gen = 0u;
+  if (!decode_handle(handle, &index, &gen)) {
+    return NULL;
+  }
+  ipc_port_slot_t *slot = &g_ports[index];
+  if (!slot->live || slot->generation != gen) {
+    return NULL;
+  }
+  return slot;
+}
+
+static bool capability_id_known(capability_id_t cap) {
+  switch (cap) {
+    case CAP_CONSOLE_WRITE:
+    case CAP_SERIAL_WRITE:
+    case CAP_DEBUG_EXIT:
+    case CAP_CAPABILITY_ADMIN:
+    case CAP_DISK_IO_REQUEST:
+    case CAP_FS_READ:
+    case CAP_FS_WRITE:
+    case CAP_EVENT_SUBSCRIBE:
+    case CAP_EVENT_PUBLISH:
+    case CAP_APP_EXEC:
+    case CAP_CODESIGN_BYPASS:
+    case CAP_NETWORK:
+    case CAP_IPC_SEND:
+    case CAP_IPC_RECV:
+      return true;
+  }
+  return false;
+}
+
+void ipc_port_table_init(void) {
+  if (!g_table_initialized) {
+    memset(g_ports, 0, sizeof(g_ports));
+    /* Start generations at 1 so encode_handle never produces 0 for
+     * index 0 (which would alias IPC_PORT_INVALID). */
+    for (size_t i = 0; i < IPC_PORT_TABLE_MAX; ++i) {
+      g_ports[i].generation = 1u;
+    }
+    g_table_initialized = true;
+    return;
+  }
+  ipc_port_table_reset();
+}
+
+void ipc_port_table_reset(void) {
+  for (size_t i = 0; i < IPC_PORT_TABLE_MAX; ++i) {
+    if (g_ports[i].live || g_ports[i].slot_occupied) {
+      g_ports[i].generation = (uint16_t)(g_ports[i].generation + 1u);
+      if (g_ports[i].generation == 0u) {
+        g_ports[i].generation = 1u;
+      }
+    } else if (g_ports[i].generation == 0u) {
+      g_ports[i].generation = 1u;
+    }
+    g_ports[i].live = false;
+    g_ports[i].slot_occupied = false;
+    g_ports[i].owner = 0u;
+    g_ports[i].send_cap = (capability_id_t)0;
+    g_ports[i].recv_cap = (capability_id_t)0;
+    memset(&g_ports[i].staged, 0, sizeof(g_ports[i].staged));
+  }
+  g_table_initialized = true;
+}
+
+ipc_result_t ipc_port_create(cap_subject_id_t owner,
+                             capability_id_t send_cap,
+                             capability_id_t recv_cap,
+                             ipc_port_t *out_port) {
+  if (!g_table_initialized) {
+    ipc_port_table_init();
+  }
+  if (out_port == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (!capability_id_known(send_cap) || !capability_id_known(recv_cap)) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  *out_port = IPC_PORT_INVALID;
+
+  for (uint16_t i = 0; i < IPC_PORT_TABLE_MAX; ++i) {
+    if (!g_ports[i].live) {
+      g_ports[i].live = true;
+      g_ports[i].slot_occupied = false;
+      g_ports[i].owner = owner;
+      g_ports[i].send_cap = send_cap;
+      g_ports[i].recv_cap = recv_cap;
+      memset(&g_ports[i].staged, 0, sizeof(g_ports[i].staged));
+      *out_port = encode_handle(i, g_ports[i].generation);
+      return IPC_OK;
+    }
+  }
+  return IPC_ERR_INVALID_PORT;
+}
+
+ipc_result_t ipc_port_destroy(ipc_port_t port) {
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  slot->live = false;
+  slot->slot_occupied = false;
+  slot->generation = (uint16_t)(slot->generation + 1u);
+  if (slot->generation == 0u) {
+    slot->generation = 1u;
+  }
+  memset(&slot->staged, 0, sizeof(slot->staged));
+  return IPC_OK;
+}
+
+ipc_result_t ipc_port_owner(ipc_port_t port, cap_subject_id_t *out_owner) {
+  if (out_owner == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  *out_owner = slot->owner;
+  return IPC_OK;
+}
+
+ipc_result_t ipc_port_send_cap(ipc_port_t port, capability_id_t *out_cap) {
+  if (out_cap == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  *out_cap = slot->send_cap;
+  return IPC_OK;
+}
+
+ipc_result_t ipc_port_recv_cap(ipc_port_t port, capability_id_t *out_cap) {
+  if (out_cap == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  *out_cap = slot->recv_cap;
+  return IPC_OK;
+}
+
+ipc_result_t ipc_port_stage(ipc_port_t port, const ipc_msg_v0 *msg) {
+  if (msg == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  if (slot->slot_occupied) {
+    /* Single-waiter slot: a second staged envelope without an
+     * intervening consume is a transport fault in v0. The strict
+     * blocking variant is a follow-up (ipc-wire.md §4). */
+    return IPC_ERR_PEER_GONE;
+  }
+  memcpy(&slot->staged, msg, sizeof(*msg));
+  slot->slot_occupied = true;
+  return IPC_OK;
+}
+
+ipc_result_t ipc_port_consume(ipc_port_t port, ipc_msg_v0 *out_msg) {
+  if (out_msg == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return IPC_ERR_INVALID_PORT;
+  }
+  if (!slot->slot_occupied) {
+    return IPC_ERR_PEER_GONE;
+  }
+  memcpy(out_msg, &slot->staged, sizeof(*out_msg));
+  slot->slot_occupied = false;
+  memset(&slot->staged, 0, sizeof(slot->staged));
+  return IPC_OK;
+}
+
+bool ipc_port_has_pending_for_tests(ipc_port_t port) {
+  ipc_port_slot_t *slot = resolve(port);
+  if (slot == NULL) {
+    return false;
+  }
+  return slot->slot_occupied;
+}

--- a/kernel/ipc/ipc_port.h
+++ b/kernel/ipc/ipc_port.h
@@ -1,0 +1,119 @@
+/**
+ * @file ipc_port.h
+ * @brief IPC port table for the M1 synchronous IPC primitive (v0).
+ *
+ * Purpose:
+ *   Owns the kernel-side port table that backs `ipc_port_t` handles
+ *   referenced by `kernel/ipc/ipc_ops.c`. Each port records:
+ *     - the owning subject (the only subject that may receive on it),
+ *     - the `send_cap` and `recv_cap` capability ids that gate
+ *       interaction with the port (defaults: CAP_IPC_SEND / CAP_IPC_RECV),
+ *     - a single in-flight envelope slot (the "single-waiter slot" from
+ *       the issue scope) used to emulate synchronous rendezvous in the
+ *       v0 in-kernel-only model.
+ *
+ *   Handles are 32-bit opaque integers `(generation << 16) | index`.
+ *   The generation counter is bumped on destroy so stale handles fail
+ *   with IPC_ERR_INVALID_PORT rather than aliasing a recycled slot.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_ops.c: drives the staging/consume cycle and is the
+ *     only writer of the staged envelope's `sender_subject` field.
+ *   - kernel/cap/capability.h: the port's send_cap/recv_cap fields are
+ *     `capability_id_t` values.
+ *
+ * Launched by:
+ *   Not a standalone process. `ipc_port_table_reset()` is called by
+ *   tests at start-of-run and (when the kernel boots) from kmain at
+ *   subsystem init time.
+ *
+ * Issue: #210. Plan: plans/2026-05-19-m1-sync-ipc-primitive.md.
+ */
+
+#ifndef SECUREOS_KERNEL_IPC_PORT_H
+#define SECUREOS_KERNEL_IPC_PORT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../cap/capability.h"
+#include "ipc_msg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Maximum simultaneously live ports in the v0 in-kernel scaffold. Sized
+ * deliberately small — anything that needs more is out of scope for the
+ * session-sized M1 slice.
+ */
+#define IPC_PORT_TABLE_MAX 16u
+
+/*
+ * Reserved invalid handle. ipc_port_create() never returns this value
+ * on success. Tests use it to assert default-zero handles are rejected.
+ */
+#define IPC_PORT_INVALID 0u
+
+typedef uint32_t ipc_port_t;
+
+/*
+ * Initialize / reset the port table to a known-empty state. Both forms
+ * are idempotent. Calling reset invalidates every previously issued
+ * handle (their generations are bumped by the reset).
+ */
+void ipc_port_table_init(void);
+void ipc_port_table_reset(void);
+
+/*
+ * Create a port owned by `owner` requiring `send_cap` for ipc_send and
+ * `recv_cap` for ipc_recv. Returns IPC_OK and writes the new handle to
+ * `*out_port` on success; returns IPC_ERR_INVALID_PORT on table full or
+ * IPC_ERR_INVALID_MSG if any input is invalid.
+ */
+ipc_result_t ipc_port_create(cap_subject_id_t owner,
+                             capability_id_t send_cap,
+                             capability_id_t recv_cap,
+                             ipc_port_t *out_port);
+
+/*
+ * Destroy a port. Any envelope staged in its single-waiter slot is
+ * dropped. Subsequent operations on the same handle return
+ * IPC_ERR_INVALID_PORT (generation mismatch).
+ */
+ipc_result_t ipc_port_destroy(ipc_port_t port);
+
+/*
+ * Read-only accessors used by ipc_ops.c to consult the port's owner /
+ * capability requirements without exposing the underlying slot
+ * representation. Each returns IPC_ERR_INVALID_PORT for a stale handle.
+ */
+ipc_result_t ipc_port_owner(ipc_port_t port, cap_subject_id_t *out_owner);
+ipc_result_t ipc_port_send_cap(ipc_port_t port, capability_id_t *out_cap);
+ipc_result_t ipc_port_recv_cap(ipc_port_t port, capability_id_t *out_cap);
+
+/*
+ * Single-waiter slot operations. v0 emulates the "blocking rendezvous"
+ * spec by ordering: a sender stages an envelope into an empty slot and
+ * a receiver later drains it. The v0 in-kernel scaffold returns
+ * IPC_ERR_PEER_GONE when the slot is in the wrong state for the op
+ * (occupied on stage, empty on consume) — a strict scheduler-driven
+ * blocking implementation is deferred (see ipc-wire.md §1 non-goals).
+ */
+ipc_result_t ipc_port_stage(ipc_port_t port, const ipc_msg_v0 *msg);
+ipc_result_t ipc_port_consume(ipc_port_t port, ipc_msg_v0 *out_msg);
+
+/*
+ * Test-only helper: does `port` currently have a staged envelope?
+ * Used by ipc_sync_v0_test.c to assert rendezvous progress without
+ * peeking at slot internals.
+ */
+bool ipc_port_has_pending_for_tests(ipc_port_t port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_IPC_PORT_H */

--- a/plans/2026-05-19-m1-sync-ipc-primitive.md
+++ b/plans/2026-05-19-m1-sync-ipc-primitive.md
@@ -1,6 +1,6 @@
 # 2026-05-19 M1 Synchronous IPC Primitive (Plan)
 
-**Status:** Plan-only (per #180). Implementation deferred to follow-up execute issues enumerated below.
+**Status:** Implemented in PR for #210 (v0 scaffold: `kernel/ipc/` with `ipc_port.{c,h}`, `ipc_msg.h`, `ipc_ops.{c,h}`, capability gates `CAP_IPC_SEND` / `CAP_IPC_RECV`, deterministic test target `ipc_sync_v0`). Plan-level non-goals remain deferred to follow-up issues.
 **Tracks:** BUILD_ROADMAP §5.1 (M1 minimal kernel isolation + IPC skeleton).
 **Owner:** kernel
 **Last reviewed:** 2026-05-19

--- a/tests/ipc_sync_v0_test.c
+++ b/tests/ipc_sync_v0_test.c
@@ -1,0 +1,334 @@
+/**
+ * @file ipc_sync_v0_test.c
+ * @brief Acceptance test for the M1 synchronous IPC primitive v0 (#210).
+ *
+ * Covers the done-when bullets from issue #210 / plan
+ * `plans/2026-05-19-m1-sync-ipc-primitive.md`:
+ *
+ *   1. Allow path: two in-kernel test modules holding CAP_IPC_SEND /
+ *      CAP_IPC_RECV exchange one envelope. Asserts the receiver sees
+ *      the kernel-stamped sender_subject and the original payload.
+ *      Emits TEST:PASS:ipc_sync_v0_allow_send_recv.
+ *
+ *   2. Deny path: caller missing CAP_IPC_SEND gets IPC_ERR_CAP_DENIED
+ *      and the canonical `CAP:DENY:<subject>:<cap>:-` marker per
+ *      docs/abi/capability-deny-contract.md is emitted before return.
+ *      Emits TEST:PASS:ipc_sync_v0_deny_marker.
+ *
+ *   3. ipc_call round-trip over a caller-owned reply port. Emits
+ *      TEST:PASS:ipc_sync_v0_call_round_trip.
+ *
+ *   4. ABI surface: envelope size and field offsets match the spec
+ *      (static_asserts in ipc_msg.h are the primary guard; this test
+ *      also confirms at run time and asserts IPC_MSG_PAYLOAD_MAX == 64
+ *      and OS_ABI_VERSION acceptance). Emits
+ *      TEST:PASS:ipc_sync_v0_abi_envelope.
+ *
+ *   5. Aggregate marker TEST:PASS:ipc_sync_v0 is the rollup the harness
+ *      asserts, matching the per-target naming convention.
+ *
+ * Launched by:
+ *   build/scripts/test_ipc_sync_v0.sh (dispatched via test.sh and
+ *   validate_bundle.sh).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:ipc_sync_v0:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  cap_reset_for_tests();
+  cap_table_reset();
+  ipc_port_table_reset();
+  cap_audit_reset_for_tests();
+}
+
+static void make_msg(ipc_msg_v0 *m, uint32_t tag, const char *payload) {
+  memset(m, 0, sizeof(*m));
+  m->abi_version = (uint16_t)OS_ABI_VERSION;
+  m->flags = 0u;
+  m->sender_subject = 0u; /* kernel-stamped on send (§2.4) */
+  m->tag = tag;
+  size_t len = strlen(payload);
+  if (len > IPC_MSG_PAYLOAD_MAX) {
+    len = IPC_MSG_PAYLOAD_MAX;
+  }
+  memcpy(m->payload, payload, len);
+  m->payload_len = (uint32_t)len;
+}
+
+static void test_abi_envelope(void) {
+  if (sizeof(ipc_msg_v0) != IPC_MSG_V0_SIZE) {
+    die("envelope_size_mismatch");
+  }
+  if (IPC_MSG_PAYLOAD_MAX != 64u) {
+    die("payload_max_must_be_64");
+  }
+  /* Probe a value that's not OS_ABI_VERSION to confirm receiver
+   * rejection on abi_version mismatch (spec §2.1). */
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(7u, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK) {
+    die("port_create_abi");
+  }
+  cap_table_reset();
+  if (cap_table_grant(7u, CAP_IPC_SEND) != CAP_OK) {
+    die("grant_send_abi");
+  }
+  ipc_msg_v0 bad;
+  make_msg(&bad, 0u, "x");
+  bad.abi_version = (uint16_t)(OS_ABI_VERSION + 0x1u);
+  if (ipc_send(7u, port, &bad) != IPC_ERR_INVALID_MSG) {
+    die("abi_version_not_rejected");
+  }
+  bad.abi_version = (uint16_t)OS_ABI_VERSION;
+  bad.flags = 0x1u;
+  if (ipc_send(7u, port, &bad) != IPC_ERR_INVALID_MSG) {
+    die("flags_mbz_not_enforced");
+  }
+  bad.flags = 0u;
+  bad.payload_len = IPC_MSG_PAYLOAD_MAX + 1u;
+  if (ipc_send(7u, port, &bad) != IPC_ERR_INVALID_MSG) {
+    die("oversize_payload_not_rejected");
+  }
+  printf("TEST:PASS:ipc_sync_v0_abi_envelope\n");
+}
+
+static void test_allow_send_recv(void) {
+  const cap_subject_id_t sender = 2u;
+  const cap_subject_id_t receiver = 3u;
+
+  reset_world();
+  if (cap_table_grant(sender, CAP_IPC_SEND) != CAP_OK) {
+    die("grant_send");
+  }
+  if (cap_table_grant(receiver, CAP_IPC_RECV) != CAP_OK) {
+    die("grant_recv");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK || port == IPC_PORT_INVALID) {
+    die("port_create");
+  }
+
+  ipc_msg_v0 out;
+  make_msg(&out, 0xCAFEu, "hello-ipc-v0");
+  /* Caller fills sender_subject with a deliberately wrong value; the
+   * IPC layer must overwrite it with the authenticated subject. */
+  out.sender_subject = 0xDEADBEEFu;
+  if (ipc_send(sender, port, &out) != IPC_OK) {
+    die("send_allow_failed");
+  }
+  if (!ipc_port_has_pending_for_tests(port)) {
+    die("envelope_not_staged");
+  }
+
+  ipc_msg_v0 in;
+  memset(&in, 0xAA, sizeof(in));
+  if (ipc_recv(receiver, port, &in) != IPC_OK) {
+    die("recv_allow_failed");
+  }
+  if (in.abi_version != (uint16_t)OS_ABI_VERSION) {
+    die("abi_version_lost");
+  }
+  if (in.sender_subject != sender) {
+    die("sender_not_kernel_stamped");
+  }
+  if (in.tag != 0xCAFEu) {
+    die("tag_corrupted");
+  }
+  if (in.payload_len != strlen("hello-ipc-v0")) {
+    die("payload_len_corrupted");
+  }
+  if (memcmp(in.payload, "hello-ipc-v0", in.payload_len) != 0) {
+    die("payload_corrupted");
+  }
+  printf("TEST:PASS:ipc_sync_v0_allow_send_recv\n");
+}
+
+static void test_deny_marker(void) {
+  const cap_subject_id_t sender = 4u;
+  const cap_subject_id_t receiver = 5u;
+
+  reset_world();
+  /* Deliberately do NOT grant CAP_IPC_SEND to `sender`. */
+  if (cap_table_grant(receiver, CAP_IPC_RECV) != CAP_OK) {
+    die("grant_recv_deny_setup");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK) {
+    die("port_create_deny");
+  }
+
+  ipc_msg_v0 m;
+  make_msg(&m, 0u, "denied");
+
+  /* ipc_send must emit a canonical CAP:DENY marker on stdout *before*
+   * returning IPC_ERR_CAP_DENIED. The test script greps the captured
+   * log for the exact marker (CAP:DENY:4:ipc_send:-); here we only
+   * assert the return code and the audit-ring side effect. */
+  ipc_result_t r = ipc_send(sender, port, &m);
+  if (r != IPC_ERR_CAP_DENIED) {
+    die("deny_wrong_result");
+  }
+
+  /* Audit ring must have recorded the deny event. */
+  size_t count = cap_audit_count_for_tests();
+  cap_audit_event_t ev;
+  int found = 0;
+  for (size_t i = 0; i < count; ++i) {
+    if (cap_audit_get_for_tests(i, &ev) != CAP_OK) {
+      continue;
+    }
+    if (ev.operation == CAP_AUDIT_OP_CHECK
+        && ev.actor_subject_id == sender
+        && ev.capability_id == CAP_IPC_SEND
+        && ev.result == CAP_ERR_MISSING) {
+      found = 1;
+      break;
+    }
+  }
+  if (!found) {
+    die("deny_audit_missing");
+  }
+  printf("TEST:PASS:ipc_sync_v0_deny_marker\n");
+}
+
+static void test_call_round_trip(void) {
+  const cap_subject_id_t client = 2u;
+  const cap_subject_id_t server = 3u;
+
+  reset_world();
+  if (cap_table_grant(client, CAP_IPC_SEND) != CAP_OK) {
+    die("grant_client_send");
+  }
+  if (cap_table_grant(client, CAP_IPC_RECV) != CAP_OK) {
+    die("grant_client_recv");
+  }
+  if (cap_table_grant(server, CAP_IPC_SEND) != CAP_OK) {
+    die("grant_server_send");
+  }
+  if (cap_table_grant(server, CAP_IPC_RECV) != CAP_OK) {
+    die("grant_server_recv");
+  }
+
+  ipc_port_t service_port = IPC_PORT_INVALID;
+  ipc_port_t reply_port = IPC_PORT_INVALID;
+  if (ipc_port_create(server, CAP_IPC_SEND, CAP_IPC_RECV, &service_port) != IPC_OK) {
+    die("service_port_create");
+  }
+  if (ipc_port_create(client, CAP_IPC_SEND, CAP_IPC_RECV, &reply_port) != IPC_OK) {
+    die("reply_port_create");
+  }
+
+  /* Client builds the request. The reply-port handle is also written
+   * into `tag` for forward compatibility with the §2.3 reply-port
+   * encoding; v0 carries it as an explicit argument too. */
+  ipc_msg_v0 req;
+  make_msg(&req, reply_port, "PING");
+
+  /* We can't return from ipc_call cleanly here because ipc_send
+   * blocks-by-policy on a full slot, but the v0 in-kernel scaffold
+   * stages-and-returns. So we drive the round-trip explicitly: client
+   * sends request, server consumes + sends reply, client recvs. This
+   * is what ipc_call sequences internally — we additionally check
+   * each leg by hand. */
+  if (ipc_send(client, service_port, &req) != IPC_OK) {
+    die("call_send_req");
+  }
+  ipc_msg_v0 server_in;
+  if (ipc_recv(server, service_port, &server_in) != IPC_OK) {
+    die("call_server_recv");
+  }
+  if (server_in.sender_subject != client) {
+    die("call_sender_mismatch");
+  }
+  if (server_in.tag != reply_port) {
+    die("call_tag_lost_reply_handle");
+  }
+
+  ipc_msg_v0 reply;
+  make_msg(&reply, server_in.tag, "PONG");
+  if (ipc_send(server, reply_port, &reply) != IPC_OK) {
+    die("call_send_reply");
+  }
+  ipc_msg_v0 client_in;
+  if (ipc_recv(client, reply_port, &client_in) != IPC_OK) {
+    die("call_client_recv");
+  }
+  if (client_in.sender_subject != server) {
+    die("call_reply_sender");
+  }
+  if (client_in.payload_len != 4u || memcmp(client_in.payload, "PONG", 4) != 0) {
+    die("call_reply_payload");
+  }
+
+  /* Now exercise the ipc_call wrapper end-to-end with a fresh pair.
+   * Client sends, server picks it up out-of-band, replies, and client
+   * recvs through the wrapper. We split into two send/recv windows so
+   * the single-waiter slot model is honored. */
+  reset_world();
+  (void)cap_table_grant(client, CAP_IPC_SEND);
+  (void)cap_table_grant(client, CAP_IPC_RECV);
+  (void)cap_table_grant(server, CAP_IPC_SEND);
+  (void)cap_table_grant(server, CAP_IPC_RECV);
+  if (ipc_port_create(server, CAP_IPC_SEND, CAP_IPC_RECV, &service_port) != IPC_OK) {
+    die("wrap_service_port");
+  }
+  if (ipc_port_create(client, CAP_IPC_SEND, CAP_IPC_RECV, &reply_port) != IPC_OK) {
+    die("wrap_reply_port");
+  }
+  /* Pre-stage server's reply *before* the client calls so the round
+   * trip completes without a scheduler. The client first send-stages
+   * a request that the server will never explicitly drain in this
+   * harness (it's a v0-only simplification); after the send the
+   * client's recv will pick up our pre-staged reply. We then drain
+   * the request from the service port to clean up. */
+  ipc_msg_v0 pre_reply;
+  make_msg(&pre_reply, reply_port, "PONG2");
+  if (ipc_send(server, reply_port, &pre_reply) != IPC_OK) {
+    die("prestage_reply");
+  }
+
+  ipc_msg_v0 wrap_req;
+  make_msg(&wrap_req, reply_port, "PING2");
+  ipc_msg_v0 wrap_reply;
+  if (ipc_call(client, service_port, &wrap_req, reply_port, &wrap_reply) != IPC_OK) {
+    die("ipc_call_failed");
+  }
+  if (wrap_reply.payload_len != 5u || memcmp(wrap_reply.payload, "PONG2", 5) != 0) {
+    die("ipc_call_payload");
+  }
+  if (wrap_reply.sender_subject != server) {
+    die("ipc_call_sender");
+  }
+
+  /* Drain the staged request from the service port to leave a clean
+   * table for any later tests. */
+  ipc_msg_v0 drain;
+  (void)ipc_recv(server, service_port, &drain);
+
+  printf("TEST:PASS:ipc_sync_v0_call_round_trip\n");
+}
+
+int main(void) {
+  printf("TEST:START:ipc_sync_v0\n");
+  ipc_port_table_init();
+  test_abi_envelope();
+  test_allow_send_recv();
+  test_deny_marker();
+  test_call_round_trip();
+  printf("TEST:PASS:ipc_sync_v0\n");
+  return 0;
+}


### PR DESCRIPTION
Rebased re-issue of #216 onto current `main` (`5b83acf`). #216 was CONFLICTING/DIRTY against `main` because the test.sh / test.ps1 usage banner and `.shell_parity_allowlist` grew via #171, #157, #186, #204 since the original branch.

Closes #210. Supersedes #216 — please close #216 when this lands.

## What changed vs #216

- Resolved usage-banner conflicts in `build/scripts/test.sh` and `build/scripts/test.ps1` by merging `ipc_sync_v0` into the post-#204 banner that includes the new `sof_verify_at_rest`, `harness_negative`, `fs_service_persist_*`, and `canary_must_fail` targets.
- Added `test_ipc_sync_v0` to `build/scripts/.shell_parity_allowlist` (per #156 — no .ps1 peer yet; on the same backlog as the other `test_*` validators).
- No code changes vs #216's tip.

## Local validation against post-rebase `main`

```
$ bash build/scripts/test_ipc_sync_v0.sh
TEST:START:ipc_sync_v0
TEST:PASS:ipc_sync_v0_abi_envelope
TEST:PASS:ipc_sync_v0_allow_send_recv
CAP:DENY:4:ipc_send:-
TEST:PASS:ipc_sync_v0_deny_marker
TEST:PASS:ipc_sync_v0_call_round_trip
TEST:PASS:ipc_sync_v0

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 44 entries)

$ bash build/scripts/test.sh parity
TEST:PASS:parity:build_scripts_sh_ps1_in_sync

$ bash build/scripts/lint.sh
TEST:PASS:lint_clang_format:diff_informational
TEST:PASS:lint_shellcheck:53_files_clean
TEST:PASS:lint_parity:check_shell_parity
TEST:PASS:lint
```

The Lint workflow failure on #216 was specifically `TEST:FAIL:lint_parity:check_shell_parity` after the `.shell_parity_allowlist` baseline grew under #156; the rebase + allowlist entry fixes it.

## See also
- Original PR: #216 (close on merge of this)
- Spec: `docs/abi/ipc-wire.md`
- Plan: `plans/2026-05-19-m1-sync-ipc-primitive.md`
- Deny-marker contract: `docs/abi/capability-deny-contract.md`

— cron:secureos-hourly-issue-work, 2026-05-22 01:08 UTC