### PR TITLE
fix #227: cross-check manifest os_abi_version against secureos_abi.h anchor

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -39,13 +39,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y nasm qemu-system-x86 python3-jsonschema
 
-      - name: Manifest schema validate (issue #195)
+      - name: Manifest schema validate (issue #195, #227)
         # Re-validates every in-tree app manifest under manifests/examples/
         # against manifests/schema/v0.json on every PR so the schema and the
         # worked examples cannot silently drift (BUILD_ROADMAP §7 / #187).
+        # Also cross-checks each manifest's os_abi_version against the
+        # OS_ABI_VERSION_MAJOR constant in user/include/secureos_abi.h
+        # (issue #227) so a header bump fails CI on stale examples
+        # rather than at runtime in the launcher.
         # Runs through the same .sh wrapper invoked locally so behavior is
         # identical in CI and on a contributor's box.
-        run: ./build/scripts/validate_manifests.sh
+        run: ./build/scripts/validate_manifests.sh --require-abi-major-from-header user/include/secureos_abi.h
 
       - name: Kernel entry build
         run: ./build/scripts/build.sh kernel

--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -52,6 +52,7 @@ test_scheduler
 test_sof_format
 test_sof_verify_at_rest
 test_tls
+test_validate_manifests_abi_major
 test_validator_report
 test_workflow_rule
 

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|ipc_sync_v0|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|ipc_sync_v0|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -213,6 +213,12 @@ case "$TEST_NAME" in
     ;;
   abi_version)
     run_script "$ROOT_DIR/build/scripts/test_abi_version.sh"
+    ;;
+  validate_manifests_abi_major)
+    # Issue #227: cross-check that --require-abi-major{,-from-header}
+    # wiring rejects examples whose os_abi_version drifts from the
+    # secureos_abi.h anchor.
+    run_script "$ROOT_DIR/build/scripts/test_validate_manifests_abi_major.sh"
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"

--- a/build/scripts/test_validate_manifests_abi_major.sh
+++ b/build/scripts/test_validate_manifests_abi_major.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# build/scripts/test_validate_manifests_abi_major.sh
+#
+# Issue #227: regression-test the --require-abi-major / --require-abi-major-from-header
+# wiring added to tools/validate_manifests.py.
+#
+# Three checks:
+#   1. PASS path: invoking the validator with the real header against the
+#      real example manifests must succeed and emit MANIFEST_VALIDATE:PASS
+#      for each manifest plus a SUMMARY:pass line.
+#   2. FAIL path (explicit): forcing --require-abi-major=1 against the
+#      current main-tree examples (which declare os_abi_version=0) must
+#      exit non-zero AND emit a deterministic "does not match required"
+#      marker for at least one manifest. This validates that a future
+#      header bump to 1 without a lockstep manifest bump fails CI.
+#   3. FAIL path (synthetic header): point --require-abi-major-from-header
+#      at a generated header that defines OS_ABI_VERSION_MAJOR 1 and
+#      confirm the same deterministic failure marker appears, validating
+#      the parser path end-to-end.
+#
+# Exit codes:
+#   0  - all three checks passed
+#   1  - one of the checks regressed
+#   78 - harness error (env/tool missing)
+#
+# Markers emitted on this script's own success path:
+#   TEST:PASS:validate_manifests_abi_major
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
+HEADER="$ROOT_DIR/user/include/secureos_abi.h"
+
+if [[ ! -x "$WRAPPER" && ! -r "$WRAPPER" ]]; then
+  echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
+  exit 78
+fi
+if [[ ! -r "$HEADER" ]]; then
+  echo "TEST:FAIL:harness_missing_header:$HEADER" >&2
+  exit 78
+fi
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_python" >&2
+  exit 78
+fi
+if ! "$PY" -c "import jsonschema" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_jsonschema" >&2
+  exit 78
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Check 1: pass with real header -------------------------------------
+OUT="$TMP/check1.out"
+if ! bash "$WRAPPER" --require-abi-major-from-header "$HEADER" >"$OUT" 2>&1; then
+  echo "TEST:FAIL:validate_manifests_abi_major:pass_path_returned_nonzero" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "MANIFEST_VALIDATE:SUMMARY:pass " "$OUT"; then
+  echo "TEST:FAIL:validate_manifests_abi_major:pass_path_missing_summary" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+# --- Check 2: fail with --require-abi-major=1 ---------------------------
+OUT="$TMP/check2.out"
+set +e
+bash "$WRAPPER" --require-abi-major=1 >"$OUT" 2>&1
+RC=$?
+set -e
+if [[ "$RC" -eq 0 ]]; then
+  echo "TEST:FAIL:validate_manifests_abi_major:explicit_fail_path_returned_zero" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "does not match required OS_ABI_VERSION_MAJOR=1" "$OUT"; then
+  echo "TEST:FAIL:validate_manifests_abi_major:explicit_fail_path_missing_marker" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+# --- Check 3: fail via synthetic header (parser path) -------------------
+SYN_HEADER="$TMP/secureos_abi.h"
+cat >"$SYN_HEADER" <<'EOF'
+#ifndef SECUREOS_ABI_H
+#define SECUREOS_ABI_H
+#define OS_ABI_VERSION_MAJOR 1
+#define OS_ABI_VERSION_MINOR 0
+#define OS_ABI_VERSION ((OS_ABI_VERSION_MAJOR << 16) | OS_ABI_VERSION_MINOR)
+#endif
+EOF
+OUT="$TMP/check3.out"
+set +e
+bash "$WRAPPER" --require-abi-major-from-header "$SYN_HEADER" >"$OUT" 2>&1
+RC=$?
+set -e
+if [[ "$RC" -eq 0 ]]; then
+  echo "TEST:FAIL:validate_manifests_abi_major:synthetic_fail_path_returned_zero" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+if ! grep -q "does not match required OS_ABI_VERSION_MAJOR=1" "$OUT"; then
+  echo "TEST:FAIL:validate_manifests_abi_major:synthetic_fail_path_missing_marker" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:validate_manifests_abi_major"

--- a/tools/validate_manifests.py
+++ b/tools/validate_manifests.py
@@ -44,6 +44,32 @@ def _load_json(path: Path) -> object:
         return json.load(fh)
 
 
+# Matches:  #define OS_ABI_VERSION_MAJOR 0
+# Tolerant of extra whitespace and trailing comments; rejects token-paste,
+# function-like macros, or non-integer right-hand sides so a future
+# refactor of the header does not silently start returning the wrong value.
+_ABI_MAJOR_RE = __import__("re").compile(
+    r"^\s*#\s*define\s+OS_ABI_VERSION_MAJOR\s+(\d+)\s*(?:/[/*].*)?$"
+)
+
+
+def _parse_abi_major_from_header(header_path: Path) -> "int | None":
+    """Parse `#define OS_ABI_VERSION_MAJOR <int>` out of secureos_abi.h.
+
+    Returns None if the header is missing, unreadable, or does not contain
+    a parseable definition. Callers convert that into a usage error.
+    """
+    try:
+        text = header_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        m = _ABI_MAJOR_RE.match(line)
+        if m:
+            return int(m.group(1))
+    return None
+
+
 def _format_pointer(absolute_path) -> str:
     # jsonschema's ValidationError.absolute_path is a deque of keys/indices.
     # Emit RFC 6901 JSON-pointer so failures are unambiguous in CI logs.
@@ -77,12 +103,39 @@ def main(argv: list[str]) -> int:
         help="Glob(s) for manifests to validate "
         "(default: manifests/examples/*.json).",
     )
+    parser.add_argument(
+        "--require-abi-major",
+        type=int,
+        default=None,
+        help="Require each manifest's os_abi_version to equal this integer "
+        "(issue #227). Use --require-abi-major-from-header to derive it "
+        "automatically from secureos_abi.h.",
+    )
+    parser.add_argument(
+        "--require-abi-major-from-header",
+        default=None,
+        help="Path to secureos_abi.h; parses OS_ABI_VERSION_MAJOR out of it "
+        "and uses that as --require-abi-major. Relative paths resolve "
+        "against --root. Overrides --require-abi-major if both are given.",
+    )
     args = parser.parse_args(argv)
 
     if args.root:
         root = Path(args.root).resolve()
     else:
         root = Path(__file__).resolve().parent.parent
+
+    require_abi_major: int | None = args.require_abi_major
+    if args.require_abi_major_from_header:
+        header_path = Path(args.require_abi_major_from_header)
+        if not header_path.is_absolute():
+            header_path = (root / header_path).resolve()
+        parsed = _parse_abi_major_from_header(header_path)
+        if parsed is None:
+            return _fail(
+                f"could not parse OS_ABI_VERSION_MAJOR from header {header_path}"
+            )
+        require_abi_major = parsed
 
     schema_path = (
         Path(args.schema).resolve()
@@ -151,17 +204,33 @@ def main(argv: list[str]) -> int:
             continue
 
         errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.absolute_path))
-        if not errors:
-            print(f"MANIFEST_VALIDATE:PASS:{rel}")
-            continue
-
+        manifest_failed = bool(errors)
         for err in errors:
             pointer = _format_pointer(err.absolute_path) or "/"
             print(
                 f"MANIFEST_VALIDATE:FAIL:{rel}: at {pointer}: {err.message}",
                 file=sys.stderr,
             )
-        failures += 1
+
+        if require_abi_major is not None:
+            # Cross-check os_abi_version against the kernel anchor.
+            # Missing / non-int values are already caught by the schema;
+            # only emit the ABI mismatch when the field is present and an
+            # int so we do not double-report a schema failure.
+            abi_val = doc.get("os_abi_version") if isinstance(doc, dict) else None
+            if isinstance(abi_val, int) and abi_val != require_abi_major:
+                print(
+                    f"MANIFEST_VALIDATE:FAIL:{rel}: at /os_abi_version: "
+                    f"value {abi_val} does not match required "
+                    f"OS_ABI_VERSION_MAJOR={require_abi_major} (issue #227)",
+                    file=sys.stderr,
+                )
+                manifest_failed = True
+
+        if manifest_failed:
+            failures += 1
+        else:
+            print(f"MANIFEST_VALIDATE:PASS:{rel}")
 
     if failures:
         print(


### PR DESCRIPTION
Closes #227.

## Summary

Wires example manifests to the kernel's `OS_ABI_VERSION_MAJOR` anchor so a header bump fails CI on stale manifests rather than silently drifting (follow-up to #153 / #195, per BUILD_ROADMAP §7).

## Changes

- **`tools/validate_manifests.py`**
  - New `--require-abi-major=N` flag: cross-checks every manifest's `os_abi_version` against `N`.
  - New `--require-abi-major-from-header PATH` flag: parses `#define OS_ABI_VERSION_MAJOR <int>` out of `user/include/secureos_abi.h` and uses that as the required value. Header-derived value wins if both flags are passed.
  - Header parser tolerates whitespace and trailing comments; rejects function-like / non-integer definitions so a future header refactor cannot silently start returning the wrong value.
  - Mismatches emit a deterministic `MANIFEST_VALIDATE:FAIL:<rel>: at /os_abi_version: value <V> does not match required OS_ABI_VERSION_MAJOR=<N> (issue #227)` marker. Schema failures and ABI mismatches don't double-report.

- **`.github/workflows/pr-build.yml`**
  - Manifest validate step now runs `./build/scripts/validate_manifests.sh --require-abi-major-from-header user/include/secureos_abi.h` so the kernel anchor is the single source of truth in CI as well as locally.

- **`build/scripts/test_validate_manifests_abi_major.sh` (new)**
  - Regression test with three checks:
    1. Pass path: real header + real examples → exit 0 with `MANIFEST_VALIDATE:SUMMARY:pass`.
    2. Explicit fail path: `--require-abi-major=1` against current main → non-zero exit + the deterministic mismatch marker (proves bumping the header without bumping examples will fail CI).
    3. Synthetic header parser path: generated header with `OS_ABI_VERSION_MAJOR 1` → same deterministic failure marker, exercising the parser end-to-end.
  - Emits `TEST:PASS:validate_manifests_abi_major` on success.

- **`build/scripts/test.sh`**
  - New `validate_manifests_abi_major` dispatch target + usage line.

## Validation

```
$ bash build/scripts/test.sh validate_manifests_abi_major
TEST:PASS:validate_manifests_abi_major

$ bash build/scripts/test.sh abi_version
TEST:START:abi_version
TEST:PASS:abi_version:os_abi_version=0x00000000

$ python3 tools/validate_manifests.py --require-abi-major-from-header user/include/secureos_abi.h
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.deny.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.json
MANIFEST_VALIDATE:SUMMARY:pass 2/2

$ python3 tools/validate_manifests.py --require-abi-major=1   # simulate header bump
MANIFEST_VALIDATE:FAIL:manifests/examples/helloapp.deny.json: at /os_abi_version: value 0 does not match required OS_ABI_VERSION_MAJOR=1 (issue #227)
MANIFEST_VALIDATE:FAIL:manifests/examples/helloapp.json: at /os_abi_version: value 0 does not match required OS_ABI_VERSION_MAJOR=1 (issue #227)
MANIFEST_VALIDATE:SUMMARY:fail 2/2  # exit 1
```

## Scope notes / follow-ups

- **No bump of `OS_ABI_VERSION`** in this PR — wiring only, per the issue's "Done when" checklist.
- **Schema left permissive** (`minimum: 0`) on purpose; strictness lives in the validator flag so the schema doesn't need regeneration on every ABI bump. The issue explicitly calls this out as the simpler option.
- **`.ps1` wrapper parity (#156):** the existing `build/scripts/validate_manifests.ps1` already forwards `@args` unchanged, so the new flags work via the PowerShell wrapper without edits. Worth confirming in the PS test dispatcher in a follow-up if desired.
- **Remaining hard-coded `0` survey:** `tests/abi_version_test.c` already uses `OS_ABI_VERSION_MAJOR` from the header (verified). No other in-tree consumer was found hard-coding an ABI `0`; the main remaining literals are in the JSON examples themselves, which are now covered by this CI gate.