### PR TITLE
test(ipc): port lifecycle round-trip test (closes #223)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -44,6 +44,7 @@ test_helloapp_allow
 test_helloapp_deny
 test_https
 test_ipc_sync_v0
+test_ipc_port_lifecycle
 test_kernel_persistence
 test_launcher_console
 test_launcher_fs

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -62,6 +62,7 @@ $testScript = switch ($TestName) {
   "bearssl_compile" { "./build/scripts/test_bearssl_compile.sh" }
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
+  "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|ipc_sync_v0|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -222,6 +222,13 @@ case "$TEST_NAME" in
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"
+    ;;
+  ipc_port_lifecycle)
+    # Issue #223: lock in the (generation << 16) | index handle
+    # encoding by asserting create→destroy→create advances the
+    # generation, stale handles are rejected, and the wrap-around
+    # guard keeps IPC_PORT_INVALID unreachable.
+    run_script "$ROOT_DIR/build/scripts/test_ipc_port_lifecycle.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/test_ipc_port_lifecycle.sh
+++ b/build/scripts/test_ipc_port_lifecycle.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build + run the M1 IPC port lifecycle round-trip test (issue #223).
+#
+# Covers:
+#   - create → destroy → create on a reused slot index advances the
+#     handle's generation field (no stale-handle aliasing).
+#   - Every read accessor rejects a stale handle with IPC_ERR_INVALID_PORT,
+#     and double-destroy is also IPC_ERR_INVALID_PORT.
+#   - ipc_port_destroy(IPC_PORT_INVALID) → IPC_ERR_INVALID_PORT (no
+#     underflow / no-op crash).
+#   - 65535 create/destroy cycles on the same slot index never produce
+#     a handle == IPC_PORT_INVALID and never let the slot index drift
+#     into the generation half (wrap-around guard holds).
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/tests/ipc_port_lifecycle_test.c" \
+  -o "$OUT_DIR/ipc_port_lifecycle_test"
+
+LOG_PATH="$OUT_DIR/ipc_port_lifecycle_test.log"
+"$OUT_DIR/ipc_port_lifecycle_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:ipc_port_lifecycle_handle_advances" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_port_lifecycle_stale_rejected" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_port_lifecycle_destroy_invalid" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_port_lifecycle_wrap_around" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_port_lifecycle$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -42,6 +42,7 @@ TEST_TARGETS=(
     kernel_persistence
     validator_report
     ipc_sync_v0
+    ipc_port_lifecycle
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -121,7 +121,18 @@ as caller-opaque in v0 — receivers MUST NOT decode it.
 IPC endpoints are addressed by **opaque port handles**, not by name:
 
 - `ipc_port_t` is a 32-bit handle allocated from a kernel-owned port
-  table (`kernel/ipc/ipc_port.{c,h}` per the M1 plan).
+  table (`kernel/ipc/ipc_port.{c,h}` per the M1 plan). The v0
+  implementation packs the handle as `(generation << 16) | index`,
+  where `index` is the low 16 bits (table slot, `0..IPC_PORT_TABLE_MAX-1`)
+  and `generation` is a 16-bit counter that is bumped every time a slot
+  is destroyed and skipped over `0` on wrap-around, so a freshly
+  destroyed handle is never equal to `IPC_PORT_INVALID` (= `0`) and
+  never aliases the next handle issued for the same slot. The lifecycle
+  contract is locked in by `tests/ipc_port_lifecycle_test.c` (issue
+  #223): create → destroy → create returns a strictly different handle
+  even when the underlying slot is reused, every read accessor rejects
+  the stale handle with `IPC_ERR_INVALID_PORT`, and 65535 create/destroy
+  cycles on the same slot index never produce `IPC_PORT_INVALID`.
 - The exact bit layout (generation counter vs. table index) is owned by
   [`capabilities.md`](./capabilities.md) and shared with other
   capability-handle types so that revocation semantics are uniform.

--- a/tests/ipc_port_lifecycle_test.c
+++ b/tests/ipc_port_lifecycle_test.c
@@ -1,0 +1,174 @@
+/**
+ * @file ipc_port_lifecycle_test.c
+ * @brief Lifecycle round-trip test for the M1 IPC port table (#223).
+ *
+ * Asserts the four invariants spelled out in issue #223:
+ *
+ *   1. create → destroy → create returns a *different* handle (the
+ *      generation counter advanced) even when the underlying slot
+ *      index is reused.
+ *   2. The pre-destroy (stale) handle returns IPC_ERR_INVALID_PORT
+ *      on every read accessor (owner/send_cap/recv_cap) after destroy.
+ *   3. ipc_port_destroy(IPC_PORT_INVALID) → IPC_ERR_INVALID_PORT (no
+ *      underflow / no-op crash).
+ *   4. Generation never returns to 0 (handle is non-zero by
+ *      construction) even after wrap-around: simulate wrap by
+ *      65535 create/destroy cycles on the same slot index.
+ *
+ * This is intentionally a docs/test lock-in for the existing
+ * kernel/ipc/ipc_port.{c,h} surface — no API changes here.
+ *
+ * Launched by:
+ *   build/scripts/test_ipc_port_lifecycle.sh (dispatched via
+ *   build/scripts/test.sh ipc_port_lifecycle).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_port.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:ipc_port_lifecycle:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  ipc_port_table_reset();
+}
+
+static ipc_port_t create_or_die(const char *where) {
+  ipc_port_t p = IPC_PORT_INVALID;
+  ipc_result_t rc = ipc_port_create((cap_subject_id_t)1,
+                                    CAP_IPC_SEND,
+                                    CAP_IPC_RECV,
+                                    &p);
+  if (rc != IPC_OK) {
+    die(where);
+  }
+  if (p == IPC_PORT_INVALID) {
+    die("create_returned_invalid_handle");
+  }
+  return p;
+}
+
+/* Check 1: create → destroy → create yields a different handle, and
+ * the underlying slot index is reused (slot reuse is exercised by the
+ * implementation's first-fit walk; in an otherwise-empty table the
+ * second create will land on the same index, so the only bit that may
+ * legitimately differ is the generation field). */
+static void check_handle_advances_on_reuse(void) {
+  reset_world();
+  ipc_port_t a = create_or_die("first_create");
+  if (ipc_port_destroy(a) != IPC_OK) {
+    die("destroy_a");
+  }
+  ipc_port_t b = create_or_die("second_create");
+  if (a == b) {
+    die("handle_did_not_advance_after_destroy_create");
+  }
+  /* Slot-reuse + generation-advance contract: lower 16 bits are the
+   * table index, upper 16 are the generation. In an empty table the
+   * new create MUST reuse the same slot index, so the only differing
+   * bits MUST be in the generation half. */
+  uint16_t a_idx = (uint16_t)(a & 0xFFFFu);
+  uint16_t b_idx = (uint16_t)(b & 0xFFFFu);
+  uint16_t a_gen = (uint16_t)((a >> 16) & 0xFFFFu);
+  uint16_t b_gen = (uint16_t)((b >> 16) & 0xFFFFu);
+  if (a_idx != b_idx) {
+    die("reused_slot_index_changed");
+  }
+  if (b_gen == a_gen) {
+    die("generation_did_not_advance");
+  }
+  /* Cleanup. */
+  if (ipc_port_destroy(b) != IPC_OK) {
+    die("destroy_b");
+  }
+  printf("TEST:PASS:ipc_port_lifecycle_handle_advances\n");
+}
+
+/* Check 2: every read accessor rejects the stale (pre-destroy)
+ * handle with IPC_ERR_INVALID_PORT. */
+static void check_stale_handle_rejected(void) {
+  reset_world();
+  ipc_port_t stale = create_or_die("stale_create");
+  if (ipc_port_destroy(stale) != IPC_OK) {
+    die("destroy_stale");
+  }
+
+  cap_subject_id_t owner = 0u;
+  if (ipc_port_owner(stale, &owner) != IPC_ERR_INVALID_PORT) {
+    die("stale_owner_not_rejected");
+  }
+  capability_id_t cap = (capability_id_t)0;
+  if (ipc_port_send_cap(stale, &cap) != IPC_ERR_INVALID_PORT) {
+    die("stale_send_cap_not_rejected");
+  }
+  if (ipc_port_recv_cap(stale, &cap) != IPC_ERR_INVALID_PORT) {
+    die("stale_recv_cap_not_rejected");
+  }
+  /* Double-destroy of a stale handle is also a transport fault. */
+  if (ipc_port_destroy(stale) != IPC_ERR_INVALID_PORT) {
+    die("stale_double_destroy_not_rejected");
+  }
+  printf("TEST:PASS:ipc_port_lifecycle_stale_rejected\n");
+}
+
+/* Check 3: destroying the reserved-invalid handle is a no-op-crash
+ * deterministic IPC_ERR_INVALID_PORT. */
+static void check_destroy_invalid_handle(void) {
+  reset_world();
+  if (ipc_port_destroy(IPC_PORT_INVALID) != IPC_ERR_INVALID_PORT) {
+    die("destroy_invalid_did_not_return_invalid_port");
+  }
+  printf("TEST:PASS:ipc_port_lifecycle_destroy_invalid\n");
+}
+
+/* Check 4: wrap-around. Run more create/destroy cycles than the
+ * 16-bit generation field can hold and assert (a) every issued handle
+ * is non-zero and (b) the slot index never changes (no leak/overflow
+ * into the index half), confirming the `if (gen == 0) gen = 1` guard
+ * in ipc_port.c keeps IPC_PORT_INVALID unreachable forever. */
+static void check_generation_wrap_around(void) {
+  reset_world();
+  ipc_port_t first = create_or_die("wrap_first_create");
+  uint16_t fixed_index = (uint16_t)(first & 0xFFFFu);
+  if (ipc_port_destroy(first) != IPC_OK) {
+    die("wrap_first_destroy");
+  }
+
+  /* 65535 cycles + the initial pair guarantees we cross the
+   * generation-counter wrap exactly once. */
+  for (uint32_t i = 0; i < 65535u; ++i) {
+    ipc_port_t p = IPC_PORT_INVALID;
+    ipc_result_t rc = ipc_port_create((cap_subject_id_t)1,
+                                      CAP_IPC_SEND,
+                                      CAP_IPC_RECV,
+                                      &p);
+    if (rc != IPC_OK) {
+      die("wrap_cycle_create_failed");
+    }
+    if (p == IPC_PORT_INVALID) {
+      die("wrap_cycle_handle_was_invalid");
+    }
+    if ((uint16_t)(p & 0xFFFFu) != fixed_index) {
+      die("wrap_cycle_slot_index_drifted");
+    }
+    if (ipc_port_destroy(p) != IPC_OK) {
+      die("wrap_cycle_destroy_failed");
+    }
+  }
+  printf("TEST:PASS:ipc_port_lifecycle_wrap_around\n");
+}
+
+int main(void) {
+  check_handle_advances_on_reuse();
+  check_stale_handle_rejected();
+  check_destroy_invalid_handle();
+  check_generation_wrap_around();
+  printf("TEST:PASS:ipc_port_lifecycle\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #223.

## Summary

Locks in the `(generation << 16) | index` handle encoding implemented in `kernel/ipc/ipc_port.c` with a new host-runnable test, `tests/ipc_port_lifecycle_test.c`. The M1 sync IPC v0 scaffold (#210 / PR #220) exercised the happy round-trip but never the destroy-then-reuse-with-same-slot-index path that the encoding is designed to defend.

## Changes

- `tests/ipc_port_lifecycle_test.c` — four assertions, each emitting a deterministic `TEST:PASS:ipc_port_lifecycle_*` marker, plus an aggregate `TEST:PASS:ipc_port_lifecycle`:
  1. **handle_advances**: `create → destroy → create` on a reused slot index advances the generation half of the handle (no stale-handle aliasing). Slot-index half is asserted unchanged so the generation contract is the *only* thing being checked.
  2. **stale_rejected**: `ipc_port_owner` / `ipc_port_send_cap` / `ipc_port_recv_cap` and a double-destroy all return `IPC_ERR_INVALID_PORT` on the pre-destroy handle.
  3. **destroy_invalid**: `ipc_port_destroy(IPC_PORT_INVALID)` returns `IPC_ERR_INVALID_PORT` (no underflow, no crash).
  4. **wrap_around**: 65 535 create/destroy cycles on the same slot index never produce a handle == `IPC_PORT_INVALID` and never let the slot-index bits drift into the generation half — confirms the `if (gen == 0) gen = 1` wrap guard in `ipc_port.c`.
- `build/scripts/test_ipc_port_lifecycle.sh` — builds `capability.c`, `cap_table.c`, `ipc_port.c` + the test, runs it, and asserts every marker plus the aggregate rollup. Mirrors the shape of `test_ipc_sync_v0.sh`.
- `build/scripts/test.sh` + `build/scripts/test.ps1` — new `ipc_port_lifecycle` dispatch target and usage line on both shells.
- `build/scripts/validate_bundle.sh` — added `ipc_port_lifecycle` to `TEST_TARGETS` so the bundle keeps the new target green.
- `build/scripts/.shell_parity_allowlist` — `test_ipc_port_lifecycle` added next to `test_ipc_sync_v0` (`.sh`-only, tracked under #156).
- `docs/abi/ipc-wire.md` §3 — documents the `(generation << 16) | index` handle encoding actually implemented in `ipc_port.c` and points at this test as the lock-in.

**No changes to `kernel/ipc/ipc_port.{c,h}` API surface** — this is a test + docs lock-in, not a redesign.

## Validation

```
$ bash build/scripts/test.sh ipc_port_lifecycle
TEST:PASS:ipc_port_lifecycle_handle_advances
TEST:PASS:ipc_port_lifecycle_stale_rejected
TEST:PASS:ipc_port_lifecycle_destroy_invalid
TEST:PASS:ipc_port_lifecycle_wrap_around
TEST:PASS:ipc_port_lifecycle

$ bash build/scripts/test.sh parity
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 51 entries)
TEST:PASS:parity:build_scripts_sh_ps1_in_sync

$ bash build/scripts/test.sh ipc_sync_v0   # regression: still green
TEST:PASS:ipc_sync_v0
```

## Done-when (from #223)

- [x] `tests/ipc_port_lifecycle_test.c` lands with the four assertions.
- [x] `build/scripts/test_ipc_port_lifecycle.sh` + `test.sh ipc_port_lifecycle` wired (.ps1 peer deferred per #156, allowlist updated).
- [x] CI runs the new target (added to `validate_bundle.sh` TEST_TARGETS).
- [x] One-paragraph handle-encoding note added to `docs/abi/ipc-wire.md` §3 referencing the actual code.
- [x] No changes to `ipc_port.{c,h}` API surface.

## Follow-ups

- Native `.ps1` peer for `test_ipc_port_lifecycle.sh` — tracked under #156 alongside `test_ipc_sync_v0`.