### PR TITLE
fix #226: gate disk-image build on manifest validity + negative regression test

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -48,6 +48,7 @@ test_ipc_port_lifecycle
 test_kernel_persistence
 test_launcher_console
 test_launcher_fs
+test_manifest_required_fields
 test_netlib_url_scheme
 test_scheduler
 test_sof_format

--- a/build/scripts/build_disk_image.sh
+++ b/build/scripts/build_disk_image.sh
@@ -23,6 +23,39 @@ stop_secureos_instances() {
 
 stop_secureos_instances
 
+# Issue #226: gate the disk-image build on manifest validity, not just
+# schema validity (follow-up to #219). Validate every manifest the
+# build pipeline would otherwise stage onto secureos-disk.img — the
+# curated examples under manifests/examples/ AND any per-app manifest
+# dropped under user/apps/**/*.manifest.json. Run this on the host
+# (outside the toolchain container) because the container image does
+# not ship python3-jsonschema; the validator wrapper itself will
+# self-diagnose with MANIFEST_VALIDATE:ERROR if the dependency is
+# missing.
+#
+# If jsonschema is unavailable on this host we fall back to a warning
+# rather than failing the build, so contributors without the lib can
+# still rebuild the disk locally; CI installs jsonschema in the
+# build-and-validate job (see .github/workflows/pr-build.yml) and
+# always exercises the strict path.
+run_manifest_gate() {
+	local py="${PYTHON:-python3}"
+	if ! command -v "$py" >/dev/null 2>&1; then
+		echo "build_disk_image: python3 not found, skipping manifest gate (issue #226)" >&2
+		return 0
+	fi
+	if ! "$py" -c "import jsonschema" >/dev/null 2>&1; then
+		echo "build_disk_image: python3-jsonschema not installed, skipping manifest gate (issue #226)" >&2
+		return 0
+	fi
+	"$ROOT_DIR/build/scripts/validate_manifests.sh" \
+		--require-abi-major-from-header user/include/secureos_abi.h \
+		'manifests/examples/*.json' \
+		'user/apps/**/*.manifest.json'
+}
+
+run_manifest_gate
+
 build_disk_image_inner() {
 	local script_path
 	local cmd_name

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -219,6 +219,13 @@ case "$TEST_NAME" in
     # wiring rejects examples whose os_abi_version drifts from the
     # secureos_abi.h anchor.
     run_script "$ROOT_DIR/build/scripts/test_validate_manifests_abi_major.sh"
+    ;;
+  manifest_required_fields)
+    # Issue #226: negative regression — confirm the validator
+    # wrapper rejects a manifest missing a required field (e.g.
+    # os_abi_version) with a deterministic MANIFEST_VALIDATE:*
+    # marker so the disk-image build gate cannot silently pass.
+    run_script "$ROOT_DIR/build/scripts/test_manifest_required_fields.sh"
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"

--- a/build/scripts/test_manifest_required_fields.sh
+++ b/build/scripts/test_manifest_required_fields.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# build/scripts/test_manifest_required_fields.sh
+#
+# Issue #226: negative regression test for the build-pipeline manifest
+# gate. Synthesizes a tampered manifest in a tempdir (dropping the
+# required `os_abi_version` field), runs the validator wrapper against
+# it, and asserts:
+#
+#   1. The validator exits non-zero.
+#   2. Stderr contains a deterministic `MANIFEST_VALIDATE:ERROR` or
+#      `MANIFEST_VALIDATE:FAIL` marker so CI log scrapers can detect
+#      it without false positives.
+#
+# Exit codes:
+#   0  - regression caught (validator correctly rejected the tampered
+#        manifest)
+#   1  - regression LEAKED (validator accepted the tampered manifest
+#        or emitted no deterministic marker)
+#   78 - harness error (env/tool missing)
+#
+# Markers emitted on this script's own success path:
+#   TEST:PASS:manifest_required_fields
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
+
+if [[ ! -r "$WRAPPER" ]]; then
+  echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
+  exit 78
+fi
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_python" >&2
+  exit 78
+fi
+if ! "$PY" -c "import jsonschema" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_jsonschema" >&2
+  exit 78
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Synthesize a manifest that is JSON-valid but schema-invalid:
+# `os_abi_version` is required by manifests/schema/v0.json and we
+# intentionally omit it.
+TAMPERED="$TMP/tampered.json"
+cat >"$TAMPERED" <<'EOF'
+{
+  "manifest_version": 0,
+  "app": {
+    "id": "tampered",
+    "version": "0.0.1",
+    "subject_id": 2,
+    "binary": "apps/tampered.bin"
+  },
+  "capabilities": {
+    "request": []
+  }
+}
+EOF
+
+OUT="$TMP/out.log"
+set +e
+bash "$WRAPPER" "$TAMPERED" >"$OUT" 2>&1
+RC=$?
+set -e
+
+if [[ "$RC" -eq 0 ]]; then
+  echo "TEST:FAIL:manifest_required_fields:validator_returned_zero_on_tampered" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$OUT"; then
+  echo "TEST:FAIL:manifest_required_fields:missing_deterministic_marker" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+# Specifically: the omission of `os_abi_version` must surface in the
+# error message. Be permissive about exact wording (jsonschema text
+# may vary across versions) but require the field name.
+if ! grep -q "os_abi_version" "$OUT"; then
+  echo "TEST:FAIL:manifest_required_fields:os_abi_version_not_mentioned" >&2
+  sed 's/^/  | /' "$OUT" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:manifest_required_fields"


### PR DESCRIPTION
Closes #226.

Follow-up to #219 (which validates curated examples on PRs) so the build pipeline itself fails fast on any malformed manifest it would stage onto `secureos-disk.img`, not just the curated examples.

## Changes

- **`build/scripts/build_disk_image.sh`** — before any populator step, run `validate_manifests.sh` against `manifests/examples/*.json` **and** `user/apps/**/*.manifest.json` with the `--require-abi-major-from-header user/include/secureos_abi.h` anchor (#227). The gate runs on the host (outside the toolchain container) because the pinned image does not yet ship `python3-jsonschema`; if the lib is missing locally the gate degrades to a printed warning so contributors without it can still rebuild, while CI's `build-and-validate` job always exercises the strict path. The future `user/apps/**/*.manifest.json` glob is forward-looking — it matches zero files today (apps under `user/apps/` do not yet ship manifests), but once #82's launcher slice lands, every new manifest gets gated automatically with no further wiring.
- **`build/scripts/test_manifest_required_fields.sh`** *(new)* — negative regression. Synthesizes a JSON-valid but schema-invalid manifest in a tempdir (drops the required `os_abi_version` field), runs the validator wrapper, asserts: non-zero exit, a deterministic `MANIFEST_VALIDATE:ERROR`/`FAIL` marker on stderr, and that the missing field name appears in the message. Registered as the `manifest_required_fields` target in `build/scripts/test.sh`.
- **`build/scripts/.shell_parity_allowlist`** — add `test_manifest_required_fields` to the documented `.sh`-only debt list (#156); the `.ps1` peer will land with the rest of the `test_*` parity sweep already tracked in `plans/2026-05-16-shell-script-parity.md`.

No schema changes (this is gating, not schema evolution), per the issue's done-when list.

## Done-when mapping

- [x] Disk-image build step fails fast on any malformed manifest under the app-staging glob (not just curated examples) — `run_manifest_gate` in `build_disk_image.sh`.
- [x] `test.sh manifest_required_fields` runs the negative regression and passes — verified locally: `TEST:PASS:manifest_required_fields`.
- [x] `.sh` + `.ps1` parity (#156 allowlist updated) — `check_shell_parity.sh` reports `PARITY:OK`.
- [x] No schema changes.

## Validation performed

```
$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 52 entries)

$ bash build/scripts/test.sh manifest_required_fields
TEST:PASS:manifest_required_fields

$ bash build/scripts/test.sh validate_manifests_abi_major
TEST:PASS:validate_manifests_abi_major

$ bash build/scripts/validate_manifests.sh --require-abi-major-from-header user/include/secureos_abi.h 'manifests/examples/*.json' 'user/apps/**/*.manifest.json'
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.deny.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.json
MANIFEST_VALIDATE:SUMMARY:pass 2/2
```

I did **not** run a full disk-image build locally (it requires the toolchain Docker image); CI's `build-iso-vm-smoke` job will exercise the gate end-to-end via `./build/scripts/build.sh disk`.

## Follow-ups

- A `.ps1` peer for `test_manifest_required_fields.sh` will land with the rest of the `test_*` parity sweep in `plans/2026-05-16-shell-script-parity.md`.
- Once the pinned toolchain image bumps to ship `python3-jsonschema`, the soft-warning fallback in `run_manifest_gate` can be tightened to a hard error.

_— secureos-hourly-issue-work cron, run e4c62e32, 2026-05-22 12:30 UTC_
