### PR TITLE
feat(kernel/cap): M1 capability handle table skeleton (#225)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -30,6 +30,7 @@ test_capability_audit
 test_capability_audit_log
 test_capability_gate
 test_capability_table
+test_cap_table_skeleton
 test_cert_chain
 test_codesign
 test_ed25519

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -42,6 +42,7 @@ $testScript = switch ($TestName) {
   "harness_negative" { "./build/scripts/test_harness_negative.sh" }
   "cap_api_contract" { "./build/scripts/test_cap_api_contract.sh" }
   "capability_table" { "./build/scripts/test_capability_table.sh" }
+  "cap_table_skeleton" { "./build/scripts/test_cap_table_skeleton.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
   "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -102,6 +102,9 @@ case "$TEST_NAME" in
     ;;
   capability_table)
     run_script "$ROOT_DIR/build/scripts/test_capability_table.sh"
+    ;;
+  cap_table_skeleton)
+    run_script "$ROOT_DIR/build/scripts/test_cap_table_skeleton.sh"
     ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"

--- a/build/scripts/test_cap_table_skeleton.sh
+++ b/build/scripts/test_cap_table_skeleton.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# build/scripts/test_cap_table_skeleton.sh
+#
+# Compiles and runs tests/cap_table_skeleton_test.c against the M1 kernel
+# capability handle table skeleton landed for issue #225 (M1-CAPTBL-001).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/tests/cap_table_skeleton_test.c" \
+  -o "$OUT_DIR/cap_table_skeleton_test"
+
+"$OUT_DIR/cap_table_skeleton_test"

--- a/kernel/cap/cap_handle.c
+++ b/kernel/cap/cap_handle.c
@@ -1,0 +1,178 @@
+/**
+ * @file cap_handle.c
+ * @brief M1 kernel capability handle table skeleton — implementation.
+ *
+ * Purpose:
+ *   First slice (M1-CAPTBL-001) of the plan in
+ *   plans/2026-05-20-m1-kernel-capability-table.md. Lands the
+ *   `cap_handle_row` struct, the bounded global table, and a minimal
+ *   grant/revoke/check API. Existing `cap_table_*` call sites are NOT
+ *   migrated in this slice — that is deferred per plan acceptance #2 to a
+ *   later execute issue that wires the façade and proves byte-exact audit
+ *   parity.
+ *
+ * Interactions:
+ *   - capability.h: shares `capability_id_t`, `cap_subject_id_t`, and the
+ *     `cap_result_t` vocabulary used by every kernel cap call site.
+ *   - cap_table.{c,h}: untouched in this slice. The handle table sits
+ *     alongside the existing per-subject bitset table.
+ *
+ * Launched by:
+ *   Not yet wired into kmain() — this slice is library-only and exercised
+ *   by tests/cap_table_skeleton_test.c via
+ *   build/scripts/test_cap_table_skeleton.sh.
+ *
+ * Determinism / no-heap:
+ *   - Static `.bss` allocation (`g_rows[CAP_HANDLE_TABLE_MAX]`).
+ *   - No `kmalloc`, no syscalls, no global mutable state outside the table.
+ */
+
+#include "cap_handle.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* The plan freezes the handle representation against OS_ABI_VERSION=0
+ * (#150). The literal lives in user/include/secureos_abi.h once that
+ * surface is finalised; for the M1-CAPTBL-001 skeleton we pin a local
+ * constant equal to 0 so each row carries the v0 marker today and the
+ * follow-up slice can flip this to an `#include` without disturbing any
+ * persisted artefact. */
+#define CAP_HANDLE_ABI_VERSION_V0 0u
+
+static cap_handle_row g_rows[CAP_HANDLE_TABLE_MAX];
+
+static int cap_handle_subject_valid(cap_subject_id_t subject_id) {
+  return subject_id < CAP_TABLE_MAX_SUBJECTS;
+}
+
+static int cap_handle_cap_id_valid(capability_id_t cap_id) {
+  return cap_id >= CAP_CONSOLE_WRITE && cap_id <= CAP_IPC_RECV;
+}
+
+static cap_handle_row *cap_handle_find_live(cap_subject_id_t owner_subject,
+                                            capability_id_t cap_id) {
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    cap_handle_row *row = &g_rows[i];
+    if ((row->flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+      continue;
+    }
+    if (row->owner_subject == owner_subject && row->cap_id == cap_id) {
+      return row;
+    }
+  }
+  return NULL;
+}
+
+static cap_handle_row *cap_handle_find_free_slot(void) {
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    if ((g_rows[i].flags & CAP_HANDLE_FLAG_LIVE) == 0u &&
+        (g_rows[i].flags & CAP_HANDLE_FLAG_REVOKED) == 0u) {
+      return &g_rows[i];
+    }
+  }
+  /* Second pass: a revoked row may be reused, but the row retains its
+   * generation counter so prior handles continue to fail the M1-CAPTBL-002
+   * staleness check once it lands. */
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    if ((g_rows[i].flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+      return &g_rows[i];
+    }
+  }
+  return NULL;
+}
+
+void cap_handle_table_init(void) {
+  cap_handle_table_reset();
+}
+
+void cap_handle_table_reset(void) {
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    g_rows[i].abi_version = 0u;
+    g_rows[i].flags = 0u;
+    g_rows[i].cap_id = (capability_id_t)0;
+    g_rows[i].owner_subject = 0u;
+    g_rows[i].granter_subject = 0u;
+    g_rows[i].parent_handle = 0u;
+    g_rows[i].generation = 0u;
+  }
+}
+
+cap_result_t cap_handle_table_grant(cap_subject_id_t owner_subject,
+                                    cap_subject_id_t granter_subject,
+                                    capability_id_t cap_id) {
+  if (!cap_handle_subject_valid(owner_subject) ||
+      !cap_handle_subject_valid(granter_subject)) {
+    return CAP_ERR_SUBJECT_INVALID;
+  }
+  if (!cap_handle_cap_id_valid(cap_id)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  /* Idempotent duplicate-grant path (plan §"Mapping the M2 console grants
+   * into the table"). No second row, no generation bump. */
+  if (cap_handle_find_live(owner_subject, cap_id) != NULL) {
+    return CAP_OK;
+  }
+
+  cap_handle_row *row = cap_handle_find_free_slot();
+  if (row == NULL) {
+    /* Table full — plan §"Risks": v0 treats this as a hard CAP error.
+     * CAP_ERR_CAP_INVALID is the closest existing code; a dedicated
+     * CAP_ERR_TABLE_FULL is a candidate for the M1-CAPTBL-002 follow-up. */
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  row->abi_version = CAP_HANDLE_ABI_VERSION_V0;
+  row->cap_id = cap_id;
+  row->owner_subject = owner_subject;
+  row->granter_subject = granter_subject;
+  row->parent_handle = 0u; /* reserved in v0 */
+  row->generation += 1u;
+  row->flags = CAP_HANDLE_FLAG_LIVE;
+  return CAP_OK;
+}
+
+cap_result_t cap_handle_table_revoke(cap_subject_id_t owner_subject,
+                                     capability_id_t cap_id) {
+  if (!cap_handle_subject_valid(owner_subject)) {
+    return CAP_ERR_SUBJECT_INVALID;
+  }
+  if (!cap_handle_cap_id_valid(cap_id)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+
+  cap_handle_row *row = cap_handle_find_live(owner_subject, cap_id);
+  if (row == NULL) {
+    /* Revoke of an ungranted (subject, cap) — clear missing marker, no-op
+     * on table state (plan §"Revocation hooks"). */
+    return CAP_ERR_MISSING;
+  }
+
+  row->flags = CAP_HANDLE_FLAG_REVOKED;
+  row->generation += 1u;
+  return CAP_OK;
+}
+
+cap_result_t cap_handle_table_check(cap_subject_id_t owner_subject,
+                                    capability_id_t cap_id) {
+  if (!cap_handle_subject_valid(owner_subject)) {
+    return CAP_ERR_SUBJECT_INVALID;
+  }
+  if (!cap_handle_cap_id_valid(cap_id)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  return (cap_handle_find_live(owner_subject, cap_id) != NULL)
+             ? CAP_OK
+             : CAP_ERR_MISSING;
+}
+
+uint32_t cap_handle_table_live_count(void) {
+  uint32_t live = 0u;
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    if ((g_rows[i].flags & CAP_HANDLE_FLAG_LIVE) != 0u) {
+      live += 1u;
+    }
+  }
+  return live;
+}

--- a/kernel/cap/cap_handle.h
+++ b/kernel/cap/cap_handle.h
@@ -1,0 +1,95 @@
+#ifndef SECUREOS_CAP_HANDLE_H
+#define SECUREOS_CAP_HANDLE_H
+
+/**
+ * @file cap_handle.h
+ * @brief M1 kernel capability handle table skeleton (PR-shaped from
+ *        plans/2026-05-20-m1-kernel-capability-table.md, execute issue #225).
+ *
+ * This is the M1-CAPTBL-001 slice: the row struct, the bounded global table,
+ * and a minimal grant/revoke/check API on top of it. No behavioural change
+ * is introduced for existing `cap_table_*` callers — `cap_table.{c,h}` is
+ * untouched in this slice. Handle representation (32-bit packed handle,
+ * `cap_gate_check_handle`, process-exit bulk revoke, subtree revoke) are
+ * deferred to follow-up execute slices (M1-CAPTBL-002..006).
+ *
+ * Layout matches the plan exactly:
+ *
+ *   struct cap_handle_row {
+ *     uint16_t        abi_version;
+ *     uint16_t        flags;
+ *     capability_id_t cap_id;
+ *     cap_subject_id_t owner_subject;
+ *     cap_subject_id_t granter_subject;
+ *     uint32_t        parent_handle;   // reserved, 0 in v0
+ *     uint32_t        generation;
+ *   };
+ *
+ * The table is statically allocated (no heap dependency at M1, per
+ * docs/CODING_CONVENTIONS.md / #163) and sized at CAP_HANDLE_TABLE_MAX = 64,
+ * which is the v0 figure pinned by the plan as sufficient for the M1–M3
+ * fixture set.
+ */
+
+#include <stdint.h>
+
+#include "capability.h"
+#include "cap_table.h"  /* reuses CAP_TABLE_MAX_SUBJECTS as the per-process subject bound */
+
+/* v0 sizing (plan: "Table data structure"). */
+#define CAP_HANDLE_TABLE_MAX 64u
+
+/* Row flag bits (plan: "Table data structure"). bit3+ MBZ in v0. */
+#define CAP_HANDLE_FLAG_LIVE    (1u << 0)
+#define CAP_HANDLE_FLAG_REVOKED (1u << 1)
+#define CAP_HANDLE_FLAG_SEALED  (1u << 2)
+
+typedef struct cap_handle_row {
+  uint16_t abi_version;
+  uint16_t flags;
+  capability_id_t cap_id;
+  cap_subject_id_t owner_subject;
+  cap_subject_id_t granter_subject;
+  uint32_t parent_handle;
+  uint32_t generation;
+} cap_handle_row;
+
+/* Result codes specific to the M1-CAPTBL-001 slice. Reuses the shared
+ * cap_result_t enum from capability.h so call sites and tests don't need a
+ * second error vocabulary. CAP_ERR_CAP_INVALID doubles as "table full" in
+ * this slice; the follow-up handle-representation slice (M1-CAPTBL-002) is
+ * the right place to split that out if/when needed. */
+
+void cap_handle_table_init(void);
+void cap_handle_table_reset(void);
+
+/* Returns CAP_OK on first grant. Duplicate grants for the same
+ * (owner_subject, cap_id) are idempotent and return CAP_OK without bumping
+ * generation or allocating a second row (plan §"Mapping the M2 console
+ * grants into the table" — `grant` is idempotent on the existing row). */
+cap_result_t cap_handle_table_grant(cap_subject_id_t owner_subject,
+                                    cap_subject_id_t granter_subject,
+                                    capability_id_t cap_id);
+
+/* Revoking a (subject, cap) that has no live row returns CAP_ERR_MISSING
+ * (plan §"Revocation hooks": revoke has a clear error contract; we lift the
+ * existing `cap_check`-style missing marker so audit/log behaviour stays
+ * uniform). On success, clears LIVE, sets REVOKED, bumps generation, and
+ * returns CAP_OK. The row is retained (slot is not freed in v0) so the
+ * generation counter is observable for the M1-CAPTBL-002 staleness check. */
+cap_result_t cap_handle_table_revoke(cap_subject_id_t owner_subject,
+                                     capability_id_t cap_id);
+
+/* CAP_OK if a live row exists for (owner_subject, cap_id); CAP_ERR_MISSING
+ * otherwise (after revoke, or never granted). Bounds errors return
+ * CAP_ERR_SUBJECT_INVALID / CAP_ERR_CAP_INVALID matching the existing
+ * cap_table contract. */
+cap_result_t cap_handle_table_check(cap_subject_id_t owner_subject,
+                                    capability_id_t cap_id);
+
+/* Test/inspection helper: number of currently-live rows in the table. Used
+ * by the unit tests to assert idempotency and table-full behaviour without
+ * exposing the row array itself. */
+uint32_t cap_handle_table_live_count(void);
+
+#endif

--- a/tests/cap_table_skeleton_test.c
+++ b/tests/cap_table_skeleton_test.c
@@ -1,0 +1,181 @@
+/**
+ * @file cap_table_skeleton_test.c
+ * @brief Unit tests for the M1 capability handle table skeleton (#225).
+ *
+ * Purpose:
+ *   Exercises `kernel/cap/cap_handle.{c,h}` against the four cases listed
+ *   in issue #225's "Done when":
+ *     1. Grant → check passes; revoke → check fails.
+ *     2. Duplicate grant is idempotent (no double-count, no spurious err).
+ *     3. Revoke of an ungranted (subject, cap) returns CAP_ERR_MISSING.
+ *     4. Table-full rejection.
+ *
+ *   Plus a small invariant check that the bounded table really is bounded
+ *   (live count never exceeds CAP_HANDLE_TABLE_MAX).
+ *
+ * Interactions:
+ *   - cap_handle.c: the unit under test.
+ *   - capability.h: shared `capability_id_t` / `cap_result_t` vocabulary.
+ *
+ * Launched by:
+ *   build/scripts/test_cap_table_skeleton.sh (registered with
+ *   build/scripts/test.sh under the `cap_table_skeleton` target).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/capability.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_table_skeleton:%s\n", reason);
+  exit(1);
+}
+
+static void test_grant_check_revoke(void) {
+  cap_handle_table_reset();
+
+  if (cap_handle_table_check(2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("default_deny_before_grant");
+  }
+  if (cap_handle_table_grant(2u, 1u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("first_grant_failed");
+  }
+  if (cap_handle_table_check(2u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("check_after_grant");
+  }
+  if (cap_handle_table_revoke(2u, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_failed");
+  }
+  if (cap_handle_table_check(2u, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("check_after_revoke");
+  }
+  printf("TEST:PASS:cap_table_skeleton_grant_check_revoke\n");
+}
+
+static void test_grant_idempotent(void) {
+  cap_handle_table_reset();
+
+  if (cap_handle_table_grant(3u, 1u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("idem_first_grant");
+  }
+  const uint32_t after_first = cap_handle_table_live_count();
+  if (after_first != 1u) {
+    fail("idem_first_grant_count");
+  }
+  /* Duplicate grants — same (owner, cap), possibly different granter. Both
+   * MUST return CAP_OK and the live-row count MUST stay at 1. */
+  if (cap_handle_table_grant(3u, 1u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("idem_dup_grant_same_granter");
+  }
+  if (cap_handle_table_grant(3u, 4u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("idem_dup_grant_other_granter");
+  }
+  if (cap_handle_table_live_count() != after_first) {
+    fail("idem_double_count");
+  }
+  if (cap_handle_table_check(3u, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("idem_check_after_dup");
+  }
+  printf("TEST:PASS:cap_table_skeleton_grant_idempotent\n");
+}
+
+static void test_revoke_ungranted(void) {
+  cap_handle_table_reset();
+
+  /* Never granted — revoke MUST report MISSING and MUST NOT mutate state. */
+  if (cap_handle_table_revoke(5u, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+    fail("revoke_ungranted_wrong_result");
+  }
+  if (cap_handle_table_live_count() != 0u) {
+    fail("revoke_ungranted_mutated_table");
+  }
+  if (cap_handle_table_check(5u, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+    fail("revoke_ungranted_check_drift");
+  }
+
+  /* Grant then revoke twice: second revoke MUST also report MISSING. */
+  if (cap_handle_table_grant(5u, 1u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("revoke_ungranted_pre_grant");
+  }
+  if (cap_handle_table_revoke(5u, CAP_DEBUG_EXIT) != CAP_OK) {
+    fail("revoke_ungranted_first_revoke");
+  }
+  if (cap_handle_table_revoke(5u, CAP_DEBUG_EXIT) != CAP_ERR_MISSING) {
+    fail("revoke_ungranted_double_revoke");
+  }
+  printf("TEST:PASS:cap_table_skeleton_revoke_ungranted\n");
+}
+
+static void test_table_full_rejection(void) {
+  cap_handle_table_reset();
+
+  /* We have 7 valid subjects (0..CAP_TABLE_MAX_SUBJECTS-1=7) and
+   * CAP_IPC_RECV - CAP_CONSOLE_WRITE + 1 = 14 valid caps. That gives a
+   * worst-case 7*14 = 98 distinct (subject, cap) pairs, comfortably above
+   * CAP_HANDLE_TABLE_MAX=64. We fill the table by walking the cap space
+   * across subjects and assert that the (CAP_HANDLE_TABLE_MAX+1)-th grant
+   * returns CAP_ERR_CAP_INVALID (the "table full" signal in v0). */
+  uint32_t granted = 0u;
+  for (cap_subject_id_t subject = 0; subject < CAP_TABLE_MAX_SUBJECTS; ++subject) {
+    for (capability_id_t cap = CAP_CONSOLE_WRITE; cap <= CAP_IPC_RECV;
+         cap = (capability_id_t)(cap + 1)) {
+      cap_result_t r = cap_handle_table_grant(subject, 1u, cap);
+      if (granted < CAP_HANDLE_TABLE_MAX) {
+        if (r != CAP_OK) {
+          fail("table_full_premature_reject");
+        }
+        granted += 1u;
+      } else {
+        if (r != CAP_ERR_CAP_INVALID) {
+          fail("table_full_did_not_reject");
+        }
+        if (cap_handle_table_live_count() != CAP_HANDLE_TABLE_MAX) {
+          fail("table_full_overflowed_bound");
+        }
+        printf("TEST:PASS:cap_table_skeleton_table_full\n");
+        return;
+      }
+    }
+  }
+  fail("table_full_never_filled");
+}
+
+static void test_bounds_invariants(void) {
+  cap_handle_table_reset();
+
+  /* Bad subject. */
+  if (cap_handle_table_grant(CAP_TABLE_MAX_SUBJECTS, 1u, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_SUBJECT_INVALID) {
+    fail("bounds_bad_subject_grant");
+  }
+  if (cap_handle_table_revoke(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_SUBJECT_INVALID) {
+    fail("bounds_bad_subject_revoke");
+  }
+  if (cap_handle_table_check(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_SUBJECT_INVALID) {
+    fail("bounds_bad_subject_check");
+  }
+
+  /* Bad cap id (0 is below the documented CAP_CONSOLE_WRITE = 1 floor). */
+  if (cap_handle_table_grant(0u, 1u, (capability_id_t)0) != CAP_ERR_CAP_INVALID) {
+    fail("bounds_bad_cap_grant");
+  }
+  if (cap_handle_table_check(0u, (capability_id_t)999) != CAP_ERR_CAP_INVALID) {
+    fail("bounds_bad_cap_check");
+  }
+  printf("TEST:PASS:cap_table_skeleton_bounds\n");
+}
+
+int main(void) {
+  printf("TEST:START:cap_table_skeleton\n");
+  test_grant_check_revoke();
+  test_grant_idempotent();
+  test_revoke_ungranted();
+  test_table_full_rejection();
+  test_bounds_invariants();
+  printf("TEST:PASS:cap_table_skeleton\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #225. First execute slice (M1-CAPTBL-001) of `plans/2026-05-19-m1-capability-table.md` / `plans/2026-05-20-m1-kernel-capability-table.md` (filed by daily-review #222).

## What landed

- `kernel/cap/cap_handle.{c,h}` — `cap_handle_row` struct exactly as the plan freezes (abi_version, flags, cap_id, owner_subject, granter_subject, parent_handle reserved, generation) and a bounded static table (`CAP_HANDLE_TABLE_MAX = 64`). Static `.bss` allocation, no heap dependency (per `docs/CODING_CONVENTIONS.md` / #163).
- Minimal `cap_handle_table_{init,reset,grant,revoke,check,live_count}` API meeting issue #225's four done-when cases. Slot reuse keeps the row's `generation` counter monotonic so the M1-CAPTBL-002 staleness check can land cleanly on top.
- `tests/cap_table_skeleton_test.c` — five test cases:
  1. Grant → check passes; revoke → check fails.
  2. Duplicate grant is idempotent (no double row, no spurious error, no extra generation bump; verified across same and differing granter).
  3. Revoke of an ungranted (subject, cap) returns `CAP_ERR_MISSING` and does NOT mutate the table; double-revoke also returns `CAP_ERR_MISSING`.
  4. Table-full rejection returns `CAP_ERR_CAP_INVALID`; live count stays bounded at `CAP_HANDLE_TABLE_MAX`.
  5. Subject / cap-id bounds invariants for grant/revoke/check.
- `build/scripts/test_cap_table_skeleton.sh` + dispatcher wiring in `test.sh` and `test.ps1`, plus an entry in `.shell_parity_allowlist` (consistent with the rest of `test_*` per #156).

## Out of scope (deferred to follow-up execute slices)

Per the plan's "Acceptance criteria" + "Proposed follow-up implementation issues" section, the following are explicitly **not** in this PR:

- **M1-CAPTBL-002** — 32-bit packed handle representation + `cap_gate_check_handle` (depends on #150 / #158).
- **M1-CAPTBL-003** — `cap_handle_revoke_subject` + process-exit hook (depends on #224 / #192).
- **M1-CAPTBL-004** — `cap_handle_revoke_subtree` stub.
- **M1-CAPTBL-005** — byte-exact `CAP_AUDIT:` fixture-diff under the façade migration.
- **M1-CAPTBL-006** — IPC integration (`ipc_send`/`ipc_recv` consume handles).

Existing `kernel/cap/cap_table.{c,h}` and its callers are deliberately untouched in this slice; the façade migration (plan acceptance #2) lives in a later PR so the byte-exact `CAP_AUDIT:` parity test (M1-CAPTBL-005) can guard it.

## Validation

```
bash build/scripts/test.sh cap_table_skeleton  # PASS (5/5)
bash build/scripts/test.sh capability_table    # PASS (5/5, no drift)
bash build/scripts/check_shell_parity.sh       # PARITY:OK
```

## Risk

Pure additive — new file pair under `kernel/cap/` plus a new test target; no existing source files or audit lines touched. No on-disk artefact changes; deterministic-image hash unaffected (#174).
