### PR TITLE
fix #232: M1 syscall entry stub (reserve ABI vector, return INVALID_MSG)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -46,6 +46,7 @@ test_helloapp_deny
 test_https
 test_ipc_sync_v0
 test_ipc_port_lifecycle
+test_syscall_entry_stub
 test_kernel_persistence
 test_launcher_console
 test_launcher_fs

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -64,6 +64,7 @@ $testScript = switch ($TestName) {
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
+  "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -239,6 +239,12 @@ case "$TEST_NAME" in
     # generation, stale handles are rejected, and the wrap-around
     # guard keeps IPC_PORT_INVALID unreachable.
     run_script "$ROOT_DIR/build/scripts/test_ipc_port_lifecycle.sh"
+    ;;
+  syscall_entry_stub)
+    # Issue #232: M1 syscall entry stub — reserved ABI vector range,
+    # all vectors return IPC_ERR_INVALID_MSG, deny-marker shape
+    # cross-check, and OS_ABI_VERSION anchor cross-check.
+    run_script "$ROOT_DIR/build/scripts/test_syscall_entry_stub.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/test_syscall_entry_stub.sh
+++ b/build/scripts/test_syscall_entry_stub.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build + run the M1 syscall entry stub conformance test (issue #232).
+#
+# Covers:
+#   - Every vector in [SYSCALL_VECTOR_BASE, SYSCALL_VECTOR_LIMIT) plus
+#     a handful of out-of-range probes returns IPC_ERR_INVALID_MSG.
+#   - kernel_syscall_entry emits the canonical
+#     CAP:DENY:<actor>:syscall:- marker via the shared
+#     cap_deny_marker formatter (single source of truth — issue #211).
+#   - SYSCALL_ENTRY_ABI_ANCHOR cross-checks against OS_ABI_VERSION
+#     from user/include/secureos_abi.h (same anchor pattern as #228).
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$ROOT_DIR/user/include" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/proc/syscall_entry.c" \
+  "$ROOT_DIR/tests/syscall_entry_stub_test.c" \
+  -o "$OUT_DIR/syscall_entry_stub_test"
+
+LOG_PATH="$OUT_DIR/syscall_entry_stub_test.log"
+"$OUT_DIR/syscall_entry_stub_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:syscall_entry_stub_invalid_msg_sweep" "$LOG_PATH"
+grep -q "TEST:PASS:syscall_entry_stub_deny_marker_shape" "$LOG_PATH"
+grep -q "TEST:PASS:syscall_entry_stub_abi_anchor" "$LOG_PATH"
+grep -q "TEST:PASS:syscall_entry_stub$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -23,6 +23,9 @@ implementation history and per-CAP-NNN deltas, see
 | 10 | `CAP_APP_EXEC` | dynamic library load / app launch |
 | 11 | `CAP_CODESIGN_BYPASS` | sealed-build only; never granted in prod |
 | 12 | `CAP_NETWORK` | all `os_net_*` (incl. HTTPS) |
+| 13 | `CAP_IPC_SEND` | `ipc_send` / `ipc_call` send leg (M1 sync IPC) |
+| 14 | `CAP_IPC_RECV` | `ipc_recv` (M1 sync IPC) |
+| 15 | `CAP_SYSCALL` | M1 syscall entry stub (reserved; see [syscalls.md](syscalls.md)). |
 
 Rules (all enforced today):
 

--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -90,6 +90,38 @@ the dispatch shim, not as new capability IDs at this layer.
 | `os_storage_info(out, len)` | (none) | Read-only. |
 | `os_get_args(out, len)` | (none) | Caller's argv. |
 
+## Reserved syscall vector range (M1)
+
+Issue #232 (plan #198) reserves a frozen syscall vector range under
+`OS_ABI_VERSION = 0` so the ABI slot exists before any real M2+ caller
+binds to it. The single source of truth is
+[`kernel/proc/syscall_entry.h`](../../kernel/proc/syscall_entry.h):
+
+- Range: `[SYSCALL_VECTOR_BASE, SYSCALL_VECTOR_BASE + SYSCALL_VECTOR_COUNT)`
+  = `[0x0000, 0x0010)` (16 slots).
+- Contract in M1: `kernel_syscall_entry()` returns `IPC_ERR_INVALID_MSG`
+  for **every** vector — in-range or out-of-range — and emits a
+  canonical `CAP:DENY:<actor>:syscall:-` marker via the shared
+  [`cap_deny_marker`](capability-deny-contract.md) formatter so the
+  deny-marker contract tests apply uniformly the moment a real caller
+  is wired.
+- ABI anchor: `SYSCALL_ENTRY_ABI_ANCHOR = (OS_ABI_VERSION << 16) |
+  SYSCALL_VECTOR_COUNT`. Cross-checked by
+  `tests/syscall_entry_stub_test.c` so the reservation cannot silently
+  drift away from the `OS_ABI_VERSION` anchor (same pattern as #228 for
+  manifest `os_abi_version`).
+- Gating capability: `CAP_SYSCALL = 15` (declared in
+  `kernel/cap/capability.h`, append-only enum slot).
+
+Vectors inside the range are reserved but unbound; renumbering or
+reusing one for a different purpose once a real M2+ caller binds is a
+covered ABI break under [versioning.md](versioning.md). Widening the
+range (raising `SYSCALL_VECTOR_COUNT`) is additive and allowed within
+`OS_ABI_VERSION = 0`.
+
+No GDT/TSS/ring-3 plumbing exists in M1 — see plan #198 ("stubbed but
+unused"). The reservation is purely an ABI-shape anchor.
+
 ## Adding a syscall
 
 1. Declare the prototype in `user/include/secureos_api.h`.
@@ -103,3 +135,4 @@ the dispatch shim, not as new capability IDs at this layer.
 5. Update this table and bump the verification line below.
 
 Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+

--- a/kernel/cap/cap_deny_marker.c
+++ b/kernel/cap/cap_deny_marker.c
@@ -81,6 +81,7 @@ static const cdm_cap_name_entry_t cdm_cap_names[] = {
     {CAP_APP_EXEC, "app_exec"},
     {CAP_CODESIGN_BYPASS, "codesign_bypass"},
     {CAP_NETWORK, "network"},
+    {CAP_SYSCALL, "syscall"},
 };
 
 const char *cap_deny_marker_name(capability_id_t cap_id) {

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -21,6 +21,19 @@ typedef enum {
   CAP_NETWORK = 12,
   CAP_IPC_SEND = 13,
   CAP_IPC_RECV = 14,
+  /*
+   * CAP_SYSCALL: reserved-but-unused in M1 (issue #232).
+   *
+   * Gates the M1 syscall-entry ABI vector (see
+   * `kernel/proc/syscall_entry.{c,h}` and `docs/abi/syscalls.md`).
+   * No call sites exist yet — `kernel_syscall_entry` returns
+   * `IPC_ERR_INVALID_MSG` for every vector in M1. The capability is
+   * declared now so the deny-marker contract
+   * (`docs/abi/capability-deny-contract.md` §4) has a single source of
+   * truth for the marker's <capability_id> field the moment any real
+   * caller is wired in M2+.
+   */
+  CAP_SYSCALL = 15,
 } capability_id_t;
 
 typedef enum {

--- a/kernel/cap/workflow_rule.c
+++ b/kernel/cap/workflow_rule.c
@@ -87,6 +87,9 @@ static int capability_is_known(capability_id_t cap) {
     case CAP_APP_EXEC:
     case CAP_CODESIGN_BYPASS:
     case CAP_NETWORK:
+    case CAP_IPC_SEND:
+    case CAP_IPC_RECV:
+    case CAP_SYSCALL:
       return 1;
   }
   return 0;

--- a/kernel/ipc/ipc_ops.c
+++ b/kernel/ipc/ipc_ops.c
@@ -65,6 +65,7 @@ static const char *ipc_cap_name(capability_id_t cap) {
     case CAP_APP_EXEC: return "app_exec";
     case CAP_CODESIGN_BYPASS: return "codesign_bypass";
     case CAP_NETWORK: return "network";
+    case CAP_SYSCALL: return "syscall";
   }
   return "unknown";
 }

--- a/kernel/ipc/ipc_port.c
+++ b/kernel/ipc/ipc_port.c
@@ -90,6 +90,7 @@ static bool capability_id_known(capability_id_t cap) {
     case CAP_NETWORK:
     case CAP_IPC_SEND:
     case CAP_IPC_RECV:
+    case CAP_SYSCALL:
       return true;
   }
   return false;

--- a/kernel/proc/syscall_entry.c
+++ b/kernel/proc/syscall_entry.c
@@ -1,0 +1,81 @@
+/**
+ * @file syscall_entry.c
+ * @brief M1 stub implementation of `kernel_syscall_entry` (issue #232).
+ *
+ * Behavior (per plan #198, "stubbed but unused"):
+ *
+ *   - Every vector — in-range or out-of-range — returns
+ *     `IPC_ERR_INVALID_MSG`.
+ *   - Every invocation emits a single `CAP:DENY:<actor>:syscall:-`
+ *     line via the canonical formatter in `kernel/cap/cap_deny_marker.c`.
+ *     The formatter is the single source of truth for the marker
+ *     grammar (#211); we deliberately do *not* `printf` the line by
+ *     hand here so a future change to the marker shape only has to
+ *     touch one place.
+ *
+ * No GDT/TSS/ring-3 plumbing in this file — that is M2+ work and
+ * explicitly out of scope per issue #232.
+ *
+ * Used by:
+ *   - tests/syscall_entry_stub_test.c (this issue).
+ *   - The future ring-3 transition will replace the body of this
+ *     function with a real dispatch table while keeping the deny path
+ *     for unknown / unauthorized vectors intact.
+ *
+ * Launched by:
+ *   In M1, only the unit-test harness. The kernel image links the
+ *   object so the symbol is present, but no in-kernel call site
+ *   exists yet.
+ */
+
+#include "syscall_entry.h"
+
+#include "../cap/cap_deny_marker.h"
+
+#include <stdio.h>
+
+/*
+ * Spec-mandated canonical resource string for a deny marker that has
+ * no per-call resource handle, matching the value already used by the
+ * IPC deny path (`kernel/ipc/ipc_ops.c`).
+ */
+#define SYSCALL_DENY_RESOURCE_NONE "-"
+
+static void syscall_emit_deny_marker(cap_subject_id_t caller_subject) {
+  char buf[CAP_DENY_MARKER_MAX];
+  int n = cap_deny_marker_format(caller_subject,
+                                 CAP_SYSCALL,
+                                 SYSCALL_DENY_RESOURCE_NONE,
+                                 buf,
+                                 sizeof(buf));
+  if (n <= 0) {
+    /* Formatter contract violation — fall back to the literal grammar
+     * so the kernel still emits *something* recognizable rather than
+     * silently swallowing a deny. The shape test will fail loudly. */
+    printf("CAP:DENY:%u:syscall:%s\n",
+           (unsigned)caller_subject,
+           SYSCALL_DENY_RESOURCE_NONE);
+    return;
+  }
+  /* cap_deny_marker_format() already appends '\n'; fwrite to stdout so
+   * we do not accidentally inject an extra newline via printf("%s\n"). */
+  (void)fwrite(buf, 1u, (size_t)n, stdout);
+}
+
+ipc_result_t kernel_syscall_entry(cap_subject_id_t caller_subject,
+                                  uint32_t vector,
+                                  uintptr_t arg0,
+                                  uintptr_t arg1,
+                                  uintptr_t arg2) {
+  (void)vector;
+  (void)arg0;
+  (void)arg1;
+  (void)arg2;
+
+  /* M1 contract: every vector is unimplemented. Emit the deny marker
+   * unconditionally so the deny-marker shape contract applies the
+   * moment any caller wires up. */
+  syscall_emit_deny_marker(caller_subject);
+
+  return IPC_ERR_INVALID_MSG;
+}

--- a/kernel/proc/syscall_entry.h
+++ b/kernel/proc/syscall_entry.h
@@ -1,0 +1,103 @@
+/**
+ * @file syscall_entry.h
+ * @brief M1 syscall entry stub — reserves the ABI vector range without
+ *        wiring any actual call sites (issue #232, plan #198).
+ *
+ * Purpose:
+ *   `plans/2026-05-20-m1-process-address-space.md` §"Kernel/user
+ *   separation strategy in M1" calls for a *reserved-but-unused*
+ *   syscall entry vector so the ABI slot is locked under
+ *   `OS_ABI_VERSION = 0` (#150) before any caller is added. This file
+ *   is the single source of truth for that vector range; once any
+ *   real M2+ syscall is wired, its numeric vector MUST be allocated
+ *   from `[SYSCALL_VECTOR_BASE, SYSCALL_VECTOR_BASE + SYSCALL_VECTOR_COUNT)`
+ *   and remain stable across ABI majors.
+ *
+ *   In M1, `kernel_syscall_entry` returns `IPC_ERR_INVALID_MSG` for
+ *   every vector (matching the IPC error vocabulary so the kernel does
+ *   not yet need a second status enum). Any invocation also emits the
+ *   canonical `CAP:DENY:<actor>:syscall:-` marker via the shared
+ *   `cap_deny_marker` formatter so the deny-marker contract tests
+ *   (#211 / #221 shape) apply uniformly once a caller is wired.
+ *
+ * Interactions:
+ *   - kernel/cap/capability.h: declares `CAP_SYSCALL = 15`, the
+ *     capability gating future M2+ callers.
+ *   - kernel/cap/cap_deny_marker.{c,h}: canonical marker formatter
+ *     used by `kernel_syscall_entry` on its deny path.
+ *   - kernel/ipc/ipc_msg.h: `ipc_result_t` / `IPC_ERR_INVALID_MSG`.
+ *   - user/include/secureos_abi.h: anchors `OS_ABI_VERSION = 0` so the
+ *     vector range freeze is observable on both sides of the boundary.
+ *   - docs/abi/syscalls.md: human-readable record of the reserved
+ *     range and the "returns INVALID_MSG in M1" contract.
+ *
+ * Launched by:
+ *   Header-only declarations; not a standalone process. The future
+ *   ring-3 transition (M2+) is the only caller of
+ *   `kernel_syscall_entry` outside the unit-test harness.
+ */
+
+#ifndef SECUREOS_KERNEL_PROC_SYSCALL_ENTRY_H
+#define SECUREOS_KERNEL_PROC_SYSCALL_ENTRY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../cap/capability.h"
+#include "../ipc/ipc_msg.h"
+#include "../../user/include/secureos_abi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Reserved syscall vector range — frozen under OS_ABI_VERSION = 0.
+ *
+ * The range is intentionally small at M1 (16 slots). It can be widened
+ * additively without breaking the freeze; numeric values inside the
+ * range MUST NOT be renumbered or reused for a different purpose once
+ * any real caller binds to one.
+ *
+ * Vectors outside [SYSCALL_VECTOR_BASE, SYSCALL_VECTOR_BASE + SYSCALL_VECTOR_COUNT)
+ * are not part of the SecureOS syscall ABI and `kernel_syscall_entry`
+ * rejects them with `IPC_ERR_INVALID_MSG` just like in-range vectors
+ * do in M1 — the rejection reason is "out of range" rather than
+ * "stubbed". Callers cannot distinguish today; the distinction will
+ * matter in M2+ when in-range vectors start returning real results.
+ */
+#define SYSCALL_VECTOR_BASE   ((uint32_t)0x0000u)
+#define SYSCALL_VECTOR_COUNT  ((uint32_t)16u)
+#define SYSCALL_VECTOR_LIMIT  (SYSCALL_VECTOR_BASE + SYSCALL_VECTOR_COUNT)
+
+/*
+ * Packed (OS_ABI_VERSION << 16) | SYSCALL_VECTOR_COUNT anchor. The unit
+ * test cross-checks this value against `OS_ABI_VERSION` from
+ * `user/include/secureos_abi.h` so the syscall reservation cannot
+ * silently drift away from the ABI freeze.
+ */
+#define SYSCALL_ENTRY_ABI_ANCHOR \
+    (((uint32_t)OS_ABI_VERSION << 16) | SYSCALL_VECTOR_COUNT)
+
+/*
+ * Stub syscall entry. In M1 this function returns `IPC_ERR_INVALID_MSG`
+ * for every vector and emits a canonical `CAP:DENY` marker for
+ * `CAP_SYSCALL`. The argument registers are accepted but ignored.
+ *
+ * `caller_subject` is the subject identity the future ring-3 transition
+ * will stamp; the unit-test harness passes a synthetic subject id so
+ * the deny marker is observable.
+ *
+ * Pure host-side compilable: no <stdio.h> in this header.
+ */
+ipc_result_t kernel_syscall_entry(cap_subject_id_t caller_subject,
+                                  uint32_t vector,
+                                  uintptr_t arg0,
+                                  uintptr_t arg1,
+                                  uintptr_t arg2);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_PROC_SYSCALL_ENTRY_H */

--- a/tests/syscall_entry_stub_test.c
+++ b/tests/syscall_entry_stub_test.c
@@ -1,0 +1,188 @@
+/**
+ * @file syscall_entry_stub_test.c
+ * @brief Conformance test for the M1 syscall entry stub (issue #232).
+ *
+ * Three checks, mirroring the "Done when" list in #232:
+ *
+ *   1. All-vectors sweep: every vector in
+ *      [SYSCALL_VECTOR_BASE, SYSCALL_VECTOR_LIMIT) — plus a handful of
+ *      out-of-range vectors — returns IPC_ERR_INVALID_MSG.
+ *   2. Deny-marker shape: the line emitted by `kernel_syscall_entry`
+ *      passes `cap_deny_marker_validate()` and matches the canonical
+ *      `CAP:DENY:<actor>:syscall:-\n` form.
+ *   3. ABI anchor: `SYSCALL_ENTRY_ABI_ANCHOR` encodes the same
+ *      `OS_ABI_VERSION` that `secureos_abi.h` advertises (same
+ *      cross-check pattern used by #228 for manifest os_abi_version).
+ *
+ * Launched by:
+ *   build/scripts/test_syscall_entry_stub.sh (dispatched via
+ *   build/scripts/test.sh syscall_entry_stub).
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../kernel/cap/cap_deny_marker.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/proc/syscall_entry.h"
+#include "../user/include/secureos_abi.h"
+
+static int g_failures = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:syscall_entry_stub:%s\n", reason);
+  g_failures++;
+}
+
+/* Capture stdout for the duration of `body()` and return the captured
+ * bytes in a static buffer. Returns the number of bytes captured (or
+ * -1 on error). Uses freopen() to redirect the C stdio stream; works
+ * on both glibc and musl. */
+static char g_capture[4096];
+
+static long capture_stdout(void (*body)(void *), void *ctx) {
+  /* Use a tmpfile to avoid filesystem hygiene concerns. */
+  fflush(stdout);
+  FILE *saved = stdout;
+  FILE *tmp = tmpfile();
+  if (!tmp) return -1;
+
+  /* Swap: redirect stdout to tmp by dup'ing the fd. We avoid freopen
+   * because it would close the original stdout fd permanently. */
+  int saved_fd = dup(fileno(saved));
+  if (saved_fd < 0) { fclose(tmp); return -1; }
+  fflush(saved);
+  if (dup2(fileno(tmp), fileno(saved)) < 0) {
+    close(saved_fd); fclose(tmp); return -1;
+  }
+
+  body(ctx);
+
+  fflush(saved);
+  /* Restore original stdout. */
+  dup2(saved_fd, fileno(saved));
+  close(saved_fd);
+
+  /* Read tmp from the start. */
+  fseek(tmp, 0L, SEEK_SET);
+  size_t n = fread(g_capture, 1u, sizeof(g_capture) - 1u, tmp);
+  g_capture[n] = '\0';
+  fclose(tmp);
+  return (long)n;
+}
+
+/* --- check 1: all-vectors sweep ---------------------------------- */
+
+struct sweep_ctx {
+  cap_subject_id_t subject;
+  uint32_t vector;
+  ipc_result_t result;
+};
+
+static void sweep_body(void *p) {
+  struct sweep_ctx *c = (struct sweep_ctx *)p;
+  c->result = kernel_syscall_entry(c->subject, c->vector, 0, 0, 0);
+}
+
+static void check_all_vectors_return_invalid_msg(void) {
+  /* In-range. */
+  for (uint32_t v = SYSCALL_VECTOR_BASE; v < SYSCALL_VECTOR_LIMIT; ++v) {
+    struct sweep_ctx ctx = { .subject = 7u, .vector = v, .result = IPC_OK };
+    long n = capture_stdout(sweep_body, &ctx);
+    if (n < 0) { fail("sweep_capture_failed"); return; }
+    if (ctx.result != IPC_ERR_INVALID_MSG) {
+      fail("in_range_vector_returned_non_invalid_msg");
+      return;
+    }
+  }
+  /* Out-of-range probes — also must reject. */
+  const uint32_t probes[] = { SYSCALL_VECTOR_LIMIT,
+                              SYSCALL_VECTOR_LIMIT + 1u,
+                              0xFFFFFFFFu,
+                              0x10000u };
+  for (size_t i = 0; i < sizeof(probes)/sizeof(probes[0]); ++i) {
+    struct sweep_ctx ctx = { .subject = 7u, .vector = probes[i], .result = IPC_OK };
+    long n = capture_stdout(sweep_body, &ctx);
+    if (n < 0) { fail("sweep_capture_failed"); return; }
+    if (ctx.result != IPC_ERR_INVALID_MSG) {
+      fail("out_of_range_vector_returned_non_invalid_msg");
+      return;
+    }
+  }
+  printf("TEST:PASS:syscall_entry_stub_invalid_msg_sweep\n");
+}
+
+/* --- check 2: deny-marker shape conformance ---------------------- */
+
+static void single_call_body(void *p) {
+  struct sweep_ctx *c = (struct sweep_ctx *)p;
+  c->result = kernel_syscall_entry(c->subject, c->vector, 0, 0, 0);
+}
+
+static void check_deny_marker_shape(void) {
+  struct sweep_ctx ctx = { .subject = 42u, .vector = SYSCALL_VECTOR_BASE, .result = IPC_OK };
+  long n = capture_stdout(single_call_body, &ctx);
+  if (n < 0) { fail("deny_capture_failed"); return; }
+  if (ctx.result != IPC_ERR_INVALID_MSG) {
+    fail("deny_call_did_not_return_invalid_msg");
+    return;
+  }
+  /* Exactly one CAP:DENY line. */
+  const char *expected = "CAP:DENY:42:syscall:-\n";
+  if (strcmp(g_capture, expected) != 0) {
+    printf("TEST:FAIL:syscall_entry_stub:deny_line_mismatch:got=[%s]:expected=[%s]\n",
+           g_capture, expected);
+    g_failures++;
+    return;
+  }
+  /* Cross-validate with the canonical validator (single source of truth
+   * for the marker grammar — same as #211). */
+  char reason[64] = {0};
+  int rc = cap_deny_marker_validate(g_capture, reason, sizeof(reason));
+  if (rc != 0) {
+    printf("TEST:FAIL:syscall_entry_stub:deny_validate_rejected:%s\n", reason);
+    g_failures++;
+    return;
+  }
+  printf("TEST:PASS:syscall_entry_stub_deny_marker_shape\n");
+}
+
+/* --- check 3: ABI anchor cross-check ------------------------------ */
+
+static void check_abi_anchor(void) {
+  /* SYSCALL_ENTRY_ABI_ANCHOR = (OS_ABI_VERSION << 16) | SYSCALL_VECTOR_COUNT. */
+  uint32_t expected = ((uint32_t)OS_ABI_VERSION << 16) | SYSCALL_VECTOR_COUNT;
+  if (SYSCALL_ENTRY_ABI_ANCHOR != expected) {
+    fail("abi_anchor_mismatch");
+    return;
+  }
+  /* And the OS_ABI_VERSION half must round-trip cleanly. */
+  uint32_t recovered = (uint32_t)(SYSCALL_ENTRY_ABI_ANCHOR >> 16);
+  if (recovered != (uint32_t)OS_ABI_VERSION) {
+    fail("abi_anchor_version_recovery");
+    return;
+  }
+  if (SYSCALL_VECTOR_COUNT == 0u) {
+    fail("vector_count_zero");
+    return;
+  }
+  printf("TEST:PASS:syscall_entry_stub_abi_anchor\n");
+}
+
+int main(void) {
+  check_all_vectors_return_invalid_msg();
+  check_deny_marker_shape();
+  check_abi_anchor();
+
+  if (g_failures != 0) {
+    printf("TEST:FAIL:syscall_entry_stub:summary_failures=%d\n", g_failures);
+    return 1;
+  }
+  printf("TEST:PASS:syscall_entry_stub\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #232. Implements the second of three PR-shaped slots from plan #198 (M1 process abstraction / address-space boundary).

## Summary

Lands a reserved-but-unused syscall entry vector range so the ABI slot is locked under `OS_ABI_VERSION=0` (#150) before any caller is wired in M2+.

- `kernel/proc/syscall_entry.{c,h}` (new directory): `kernel_syscall_entry()` returns `IPC_ERR_INVALID_MSG` for every vector (in-range or out-of-range) and emits the canonical `CAP:DENY:<actor>:syscall:-` marker via the shared `cap_deny_marker` formatter (single source of truth, #211).
- `kernel/cap/capability.h`: append-only `CAP_SYSCALL = 15` enum slot. Updated `cap_deny_marker`, `ipc_port`, `ipc_ops`, and `workflow_rule` switches to recognize the new id (no behavior change).
- `tests/syscall_entry_stub_test.c`: three checks
  1. all-vectors-return-INVALID_MSG sweep over the locked range plus out-of-range probes,
  2. deny-marker shape conformance via `cap_deny_marker_validate()`,
  3. `SYSCALL_ENTRY_ABI_ANCHOR` cross-check against `OS_ABI_VERSION` (anchor pattern from #228).
- `build/scripts/test_syscall_entry_stub.sh` + `test.sh` / `test.ps1` dispatch + `.shell_parity_allowlist` entry (#156).
- `docs/abi/syscalls.md`: records the reserved vector range and the "returns `INVALID_MSG` in M1" contract.
- `docs/abi/capabilities.md`: documents `CAP_SYSCALL` (plus previously-undocumented `CAP_IPC_SEND` / `CAP_IPC_RECV`).

## Validation

```
$ bash build/scripts/test.sh syscall_entry_stub
TEST:PASS:syscall_entry_stub_invalid_msg_sweep
TEST:PASS:syscall_entry_stub_deny_marker_shape
TEST:PASS:syscall_entry_stub_abi_anchor
TEST:PASS:syscall_entry_stub
```

Also re-ran neighboring suites to verify no regressions from the enum/capability surface changes:
- `cap_deny_marker_shape` ✅
- `abi_version` ✅
- `ipc_sync_v0` ✅
- `ipc_port_lifecycle` ✅
- `workflow_rule` ✅
- `parity` ✅

## Out of scope (own sibling issues)

- Scheduler-visible PID dispatch / context-switch wiring (third PR-shaped slot under plan #198).
- Concrete `address_space_t` paging fields (M2 paging).
- Any actual ring-3 transition or userland call site.
- Kernel image link list update — the symbol is currently for unit-test consumption; the future ring-3 transition will link it in M2+.

## Follow-ups

- When the third sibling (scheduler-visible PID dispatch) lands, wire `kernel_syscall_entry` into the in-kernel test driver so the deny-marker contract is also exercised end-to-end through the scheduler.
- Add the syscall stub object to the kernel image build list once M2 ring-3 wiring is in flight.