### PR TITLE
docs(abi): capability registry index + CI-validated cross-checks (fixes #234)

### DIFF
--- a/build/scripts/lint.sh
+++ b/build/scripts/lint.sh
@@ -153,9 +153,43 @@ run_parity() {
     emit_marker "TEST:PASS:lint_parity:fallback_sh_only=${sh_only}"
 }
 
+run_capability_registry() {
+    # Issue #234: cross-check docs/abi/capability-registry.json against
+    # kernel/cap/capability.h + build/scripts/test.sh + plans/.
+    # Rolled out warn-only first (LINT_REGISTRY_FATAL=0) per the
+    # determinism-check pattern from #176; flip to fatal in the
+    # follow-up issue once one green cycle is observed.
+    emit_marker "TEST:START:lint_capability_registry"
+    if [ ! -x build/scripts/validate_capability_registry.sh ]; then
+        emit_marker "TEST:PASS:lint_capability_registry:wrapper_missing_skipped"
+        return
+    fi
+    local out rc
+    out="$(build/scripts/validate_capability_registry.sh 2>&1)" || true
+    rc=$?
+    printf '%s\n' "$out"
+    if [ "$rc" -eq 0 ]; then
+        emit_marker "TEST:PASS:lint_capability_registry"
+        return
+    fi
+    local reason
+    reason="$(printf '%s\n' "$out" | grep -E '^REGISTRY_VALIDATE:FAIL:' | head -n1 | sed 's/^REGISTRY_VALIDATE:FAIL://')"
+    if [ -z "$reason" ]; then
+        reason="validator_exit_${rc}"
+    fi
+    if [ "${LINT_REGISTRY_FATAL:-0}" = "1" ]; then
+        emit_marker "TEST:FAIL:lint_capability_registry:${reason}"
+        fail_count=$((fail_count + 1))
+    else
+        emit_marker "TEST:WARN:lint_capability_registry:${reason}"
+        emit_marker "TEST:PASS:lint_capability_registry:warn_only"
+    fi
+}
+
 run_clang_format
 run_shellcheck
 run_parity
+run_capability_registry
 
 if [ "$miss_count" -gt 0 ]; then
     emit_marker "TEST:FAIL:lint:tools_missing=${miss_count}"

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -65,6 +65,8 @@ $testScript = switch ($TestName) {
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
   "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
+  "validate_capability_registry" { "./build/scripts/validate_capability_registry.sh" }
+  "capability_registry_drift" { "./tests/harness/capability_registry_drift_test.sh" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -245,6 +245,22 @@ case "$TEST_NAME" in
     # all vectors return IPC_ERR_INVALID_MSG, deny-marker shape
     # cross-check, and OS_ABI_VERSION anchor cross-check.
     run_script "$ROOT_DIR/build/scripts/test_syscall_entry_stub.sh"
+    ;;
+  validate_capability_registry)
+    # Issue #234: cross-check that docs/abi/capability-registry.json
+    # stays consistent with the capability_id_t enum in
+    # kernel/cap/capability.h, every referenced test.sh target exists,
+    # every deny_marker conforms to the §4 grammar from
+    # docs/abi/capability-deny-contract.md, and every owning_plan
+    # resolves under plans/.
+    run_script "$ROOT_DIR/build/scripts/validate_capability_registry.sh"
+    ;;
+  capability_registry_drift)
+    # Issue #234: negative-canary self-test — adds a fake CAP_* to a
+    # sandboxed capability.h copy and asserts the registry validator
+    # emits the REGISTRY_VALIDATE:FAIL:enum_not_in_registry marker.
+    # Mirrors the canary discipline from #213 / #177.
+    run_script "$ROOT_DIR/tests/harness/capability_registry_drift_test.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/validate_capability_registry.ps1
+++ b/build/scripts/validate_capability_registry.ps1
@@ -1,0 +1,27 @@
+# build/scripts/validate_capability_registry.ps1
+#
+# Issue #234: PowerShell peer of validate_capability_registry.sh
+# (#156 cross-platform parity rule). Thin wrapper around
+# tools/validate_capability_registry.py.
+#
+# Exit codes are passed through from the Python implementation:
+#   0  registry consistent with kernel/cap/capability.h + test.sh + plans/
+#   1  one or more REGISTRY_VALIDATE:FAIL markers emitted
+#   2  environment / usage error (missing input file, malformed JSON)
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+$Py = if ($env:PYTHON) { $env:PYTHON } else { 'python3' }
+if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+    $Py = 'python'
+    if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+        Write-Error 'REGISTRY_VALIDATE:FAIL:python3_not_found'
+        exit 2
+    }
+}
+
+$Script = Join-Path $RootDir 'tools/validate_capability_registry.py'
+& $Py $Script --root $RootDir @args
+exit $LASTEXITCODE

--- a/build/scripts/validate_capability_registry.sh
+++ b/build/scripts/validate_capability_registry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# build/scripts/validate_capability_registry.sh
+#
+# Thin wrapper around tools/validate_capability_registry.py so the
+# capability-registry validator runs through the same build/scripts/*.sh
+# entrypoint as every other validator (issue #234). Mirror script:
+# build/scripts/validate_capability_registry.ps1 (#156 parity rule).
+#
+# Exit codes are passed through from the Python implementation:
+#   0  registry consistent with kernel/cap/capability.h + test.sh + plans/
+#   1  one or more REGISTRY_VALIDATE:FAIL markers emitted
+#   2  environment / usage error (missing input file, malformed JSON)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "REGISTRY_VALIDATE:FAIL:python3_not_found" >&2
+  exit 2
+fi
+
+exec "$PY" "$ROOT_DIR/tools/validate_capability_registry.py" --root "$ROOT_DIR" "$@"

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -23,6 +23,11 @@ changes are deliberate and reviewable rather than emergent.
   implementation tracked by the M1 sync-IPC plan (#180 / #185).
 - [versioning.md](versioning.md) — `OS_ABI_VERSION` policy, compat-shim
   window, and the process for adding / removing ABI surface.
+- [capability-registry.md](capability-registry.md) — machine-readable index
+  ([capability-registry.json](capability-registry.json)) of every `CAP_*`:
+  numeric id, subject kinds, `CAP:DENY:` marker shape, allow/deny test
+  targets, and owning plan. Validated in CI by
+  `build/scripts/validate_capability_registry.sh` (issue #234).
 
 ## Provenance
 

--- a/docs/abi/capability-registry.json
+++ b/docs/abi/capability-registry.json
@@ -1,0 +1,157 @@
+{
+  "$schema_version": 0,
+  "description": "Single machine-readable index of every CAP_* defined in kernel/cap/capability.h. For each capability, records the subject kinds that may hold it, the canonical CAP:DENY: marker shape (per docs/abi/capability-deny-contract.md §4), the build/scripts/test.sh targets that exercise the allow and deny paths, the owning plan (when one exists), and the OS_ABI_VERSION at which the capability id was frozen. Validated by build/scripts/validate_capability_registry.sh (issue #234).",
+  "frozen_marker_grammar": "^CAP:DENY:[0-9]+:[a-z][a-z0-9_]*:[\\x20-\\x39\\x3B-\\x7E]+$",
+  "capabilities": [
+    {
+      "cap_id": "CAP_CONSOLE_WRITE",
+      "numeric_id": 1,
+      "subject_kinds": ["app", "launcher"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:console_write:-",
+      "allow_test_target": "helloapp_allow",
+      "deny_test_target": "helloapp_deny",
+      "owning_plan": "plans/2026-04-13-console-write-capability-slice.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_SERIAL_WRITE",
+      "numeric_id": 2,
+      "subject_kinds": ["kernel", "launcher"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:serial_write:-",
+      "allow_test_target": "capability_gate",
+      "deny_test_target": "capability_gate",
+      "owning_plan": "plans/2026-04-11-console-launcher-capability-slice.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_DEBUG_EXIT",
+      "numeric_id": 3,
+      "subject_kinds": ["test_only"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:debug_exit:-",
+      "allow_test_target": "capability_gate",
+      "deny_test_target": "capability_gate",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_CAPABILITY_ADMIN",
+      "numeric_id": 4,
+      "subject_kinds": ["bootstrap_root"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:capability_admin:-",
+      "allow_test_target": "cap_api_contract",
+      "deny_test_target": "cap_api_contract",
+      "owning_plan": "plans/2026-04-21-capability-broker-share-workflow.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_DISK_IO_REQUEST",
+      "numeric_id": 5,
+      "subject_kinds": ["kernel", "fs_service"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:disk_io_request:-",
+      "allow_test_target": "capability_gate",
+      "deny_test_target": "capability_gate",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_FS_READ",
+      "numeric_id": 6,
+      "subject_kinds": ["app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:fs_read:<path>",
+      "allow_test_target": "fs_service_persist_allow",
+      "deny_test_target": "fs_service_persist_deny",
+      "owning_plan": "plans/2026-04-16-filesystem-service-faux-fs.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_FS_WRITE",
+      "numeric_id": 7,
+      "subject_kinds": ["app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:fs_write:<path>",
+      "allow_test_target": "fs_service_persist_allow",
+      "deny_test_target": "fs_service_persist_deny",
+      "owning_plan": "plans/2026-04-16-filesystem-service-faux-fs.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_EVENT_SUBSCRIBE",
+      "numeric_id": 8,
+      "subject_kinds": ["app", "service"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:event_subscribe:<topic>",
+      "allow_test_target": "event_bus",
+      "deny_test_target": "event_bus",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_EVENT_PUBLISH",
+      "numeric_id": 9,
+      "subject_kinds": ["app", "service"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:event_publish:<topic>",
+      "allow_test_target": "event_bus",
+      "deny_test_target": "event_bus",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_APP_EXEC",
+      "numeric_id": 10,
+      "subject_kinds": ["launcher"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:app_exec:<app_name>",
+      "allow_test_target": "app_runtime",
+      "deny_test_target": "app_runtime",
+      "owning_plan": "plans/2026-04-14-console-service-launcher-helloapp.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_CODESIGN_BYPASS",
+      "numeric_id": 11,
+      "subject_kinds": ["sealed_build_only"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:codesign_bypass:-",
+      "allow_test_target": "codesign",
+      "deny_test_target": "codesign",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_NETWORK",
+      "numeric_id": 12,
+      "subject_kinds": ["app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:network:<scheme_host>",
+      "allow_test_target": "netlib_url_scheme",
+      "deny_test_target": "netlib_url_scheme",
+      "owning_plan": "plans/2026-04-09-zero-trust-network-abi-hardening.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_IPC_SEND",
+      "numeric_id": 13,
+      "subject_kinds": ["app", "service"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:ipc_send:-",
+      "allow_test_target": "ipc_sync_v0",
+      "deny_test_target": "ipc_sync_v0",
+      "owning_plan": "plans/2026-05-19-m1-sync-ipc-primitive.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_IPC_RECV",
+      "numeric_id": 14,
+      "subject_kinds": ["app", "service"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:ipc_recv:-",
+      "allow_test_target": "ipc_sync_v0",
+      "deny_test_target": "ipc_sync_v0",
+      "owning_plan": "plans/2026-05-19-m1-sync-ipc-primitive.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_SYSCALL",
+      "numeric_id": 15,
+      "subject_kinds": ["app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:syscall:-",
+      "allow_test_target": null,
+      "deny_test_target": "syscall_entry_stub",
+      "owning_plan": "plans/2026-05-20-m1-kernel-capability-table.md",
+      "frozen_since_abi": "0.0"
+    }
+  ]
+}

--- a/docs/abi/capability-registry.md
+++ b/docs/abi/capability-registry.md
@@ -1,0 +1,128 @@
+# Capability Registry
+
+Status: DRAFT (issue #234 — single machine-readable index of every `CAP_*`)
+Owners: capability subsystem (`kernel/cap/`), validators (`build/scripts/`).
+
+## Why this exists
+
+The capability set is now scattered across several authoritative locations:
+
+- the C enum in `kernel/cap/capability.h`,
+- the human-readable ABI table in [`capabilities.md`](capabilities.md),
+- the deny-marker grammar in [`capability-deny-contract.md`](capability-deny-contract.md),
+- the deny-marker name table in `kernel/cap/cap_deny_marker.c`,
+- per-cap allow/deny test scripts under `build/scripts/test_*.sh`,
+- the capability-matrix harness fixture in `tests/matrix/capability_matrix.json`,
+- the plans under `plans/` that introduced each capability.
+
+This registry is a single index that an agent (or curious human) can
+consult to answer *for any given `CAP_*`*: which subject kinds may hold it,
+what its `CAP:DENY:` marker looks like, which `build/scripts/test.sh`
+targets exercise its allow/deny paths, which plan owns it, and the
+`OS_ABI_VERSION` at which its numeric id was frozen.
+
+Per BUILD_ROADMAP.md §4 (Agentic Build/Test System) and §7 (ABI and
+Interface Freeze Plan), the registry MUST be machine-checkable: when a new
+`CAP_*` lands in `kernel/cap/capability.h`, the validator described below
+fails CI unless the same id is registered here in the same change.
+
+## Files
+
+- [`capability-registry.json`](capability-registry.json) — machine-readable
+  source of truth. Schema is intentionally inline (no separate JSON Schema
+  file yet); structure is enforced by the validator.
+- This file — human-readable mirror, plus the validator contract.
+
+## Rows
+
+Each row in `capability-registry.json` has the following fields. All are
+required unless explicitly marked optional:
+
+| Field               | Type           | Meaning |
+| ------------------- | -------------- | ------- |
+| `cap_id`            | string         | Symbolic name, exactly as declared in `kernel/cap/capability.h` (`CAP_*`). |
+| `numeric_id`        | integer        | The frozen numeric value of the enum. Append-only — never renumbered. Cross-checked against [`capabilities.md`](capabilities.md). |
+| `subject_kinds`     | array<string>  | Human-readable list of which subject kinds may legally hold this capability today (e.g. `app`, `launcher`, `bootstrap_root`, `sealed_build_only`). Informational; not enforced by the kernel. |
+| `deny_marker`       | string         | The canonical `CAP:DENY:<actor>:<lowercase_name>:<resource>` shape for this capability. Must conform to the grammar in [`capability-deny-contract.md`](capability-deny-contract.md) §4. Placeholders `<actor_subject_id>` and `<resource>` (or a service-specific stand-in like `<path>`, `<topic>`, `<scheme_host>`, `<app_name>`) are allowed in the registry text — at runtime the formatter in `kernel/cap/cap_deny_marker.c` substitutes the real values. |
+| `allow_test_target` | string \| null | `build/scripts/test.sh` target name that exercises a representative grant path. `null` when no per-cap allow target exists today (e.g. `CAP_SYSCALL` — the M1 stub denies everything by design). |
+| `deny_test_target`  | string \| null | `build/scripts/test.sh` target name that exercises a representative explicit-deny path. `null` only when justified inline; aim is to have one for every capability. |
+| `owning_plan`       | string \| null | Path (relative to repo root) to the plan under `plans/` that introduced or governs this capability. `null` when no single plan owns it (typically the very-early caps that predate the plan-per-slice convention). |
+| `frozen_since_abi`  | string         | The `OS_ABI_VERSION` (formatted `"<major>.<minor>"`, see [`versioning.md`](versioning.md)) at which this `cap_id`'s numeric value was frozen. All current rows are `"0.0"` because every cap predates the first freeze. |
+
+## Validator
+
+`build/scripts/validate_capability_registry.sh` (and its PowerShell peer
+`validate_capability_registry.ps1`, per the #156 parity rule) enforces:
+
+1. Every `CAP_*` identifier declared in `kernel/cap/capability.h`'s
+   `capability_id_t` enum appears **exactly once** in
+   `capability-registry.json`.
+2. Every `capability-registry.json` row's `cap_id` is declared in
+   `kernel/cap/capability.h`'s `capability_id_t` enum (no orphans).
+3. Every `capability-registry.json` row's `numeric_id` matches the value
+   declared in `kernel/cap/capability.h`.
+4. Every non-null `allow_test_target` / `deny_test_target` is a target
+   recognized by `build/scripts/test.sh` (matched against the `case`
+   dispatch labels in `test.sh`).
+5. Every `deny_marker` parses against the marker prefix and field grammar
+   from [`capability-deny-contract.md`](capability-deny-contract.md) §4
+   (i.e. starts with `CAP:DENY:`, has the right number of colon-delimited
+   fields, and the capability-name segment is lowercase and matches the
+   `cap_id` with the `CAP_` prefix stripped).
+6. Every non-null `owning_plan` resolves to a file under `plans/`.
+
+Exit codes:
+
+- `0` — every check passed.
+- `1` — at least one check failed (one `REGISTRY_VALIDATE:FAIL:<reason>`
+  marker per failure on stderr).
+- `2` — environment error (missing `capability.h`, missing
+  `capability-registry.json`, malformed JSON).
+
+The validator emits stable, grep-able markers so the lint stage can
+classify failures:
+
+```
+REGISTRY_VALIDATE:START
+REGISTRY_VALIDATE:PASS:<check>
+REGISTRY_VALIDATE:FAIL:<check>:<reason>
+REGISTRY_VALIDATE:DONE
+```
+
+## CI wiring
+
+The validator is invoked from `build/scripts/lint.sh` as the
+`registry` check, behind the `LINT_REGISTRY_FATAL` environment variable
+(default `0` — warn-only) so the first run on `main` cannot accidentally
+red-gate unrelated PRs. Per the determinism-check rollout pattern from
+issue #176, the flip to `1` (blocking) is tracked as a separate follow-up
+issue filed at the same time this registry lands. Until that flip the
+lint stage prints `TEST:PASS:lint_capability_registry:warn_only` even on
+failure (with a `TEST:WARN:` line carrying the specific failure reason).
+
+## Negative canary
+
+`tests/integration/_canary_must_fail/capability_registry_drift.sh` adds a
+fake `CAP_*` symbol to a sandboxed copy of `capability.h` and asserts the
+validator emits `REGISTRY_VALIDATE:FAIL:enum_not_in_registry`. This
+mirrors the canary discipline introduced in #213 — it proves that the
+validator actually catches the regression it claims to catch, not that it
+silently no-ops.
+
+## How to add a new capability
+
+1. Append a new entry to the `capability_id_t` enum in
+   `kernel/cap/capability.h` (next free numeric id; never renumber).
+2. Add a row in `kernel/cap/cap_deny_marker.c`'s `cdm_cap_names[]` so the
+   shared formatter can render the new capability's deny marker.
+3. Add a row in `docs/abi/capability-registry.json` with all required
+   fields.
+4. Update [`capabilities.md`](capabilities.md) so the human-readable ABI
+   table stays in sync.
+5. Run `build/scripts/validate_capability_registry.sh` locally — it must
+   exit 0 before the change is mergeable.
+
+## Provenance
+
+Last verified against commit: (regenerated on each touch — see provenance
+note in [`README.md`](README.md))

--- a/tests/harness/capability_registry_drift_test.sh
+++ b/tests/harness/capability_registry_drift_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/integration/_canary_must_fail/capability_registry_drift.sh
+#
+# Negative canary for the capability-registry validator (issue #234).
+#
+# Why this exists:
+#   The validator in build/scripts/validate_capability_registry.sh claims
+#   that adding a brand-new CAP_* to kernel/cap/capability.h without
+#   adding a matching row to docs/abi/capability-registry.json is a hard
+#   failure. This canary proves that claim is real — not a silent no-op
+#   from a stale dispatcher arm or a typo in the regex. It mirrors the
+#   discipline introduced in #213 (validator harness self-test) and #177
+#   (canary_must_fail).
+#
+# Mechanics:
+#   1. Stage a sandbox copy of capability.h with a fake CAP_REGISTRY_DRIFT_PROBE
+#      entry appended to the capability_id_t enum.
+#   2. Run the validator against that sandbox header (keeping the real
+#      registry + test.sh as-is, so the only delta is the extra enum entry).
+#   3. Assert the validator exits non-zero AND emitted the
+#      REGISTRY_VALIDATE:FAIL:enum_not_in_registry:CAP_REGISTRY_DRIFT_PROBE
+#      marker. Anything else (including a clean exit 0) is itself a
+#      regression — the validator went blind.
+#
+# Contract:
+#   On success this script emits TEST:PASS:capability_registry_drift_canary
+#   and exits 0. On failure it emits TEST:FAIL:capability_registry_drift_canary:<reason>
+#   and exits 1.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '$TMP_DIR'" EXIT
+
+printf 'TEST:START:capability_registry_drift_canary\n'
+
+REAL_HEADER="$ROOT_DIR/kernel/cap/capability.h"
+SANDBOX_HEADER="$TMP_DIR/capability.h"
+
+if [ ! -f "$REAL_HEADER" ]; then
+    printf 'TEST:FAIL:capability_registry_drift_canary:real_header_missing\n'
+    exit 1
+fi
+
+# Append a fake CAP_* into the capability_id_t enum by injecting it right
+# before the closing brace of that specific enum. We do not mutate any
+# other enum (CAP_AUDIT_*, CAP_ACCESS_*) — the validator only looks at
+# capability_id_t, so the injection has to land inside that block.
+if ! REAL_HEADER="$REAL_HEADER" python3 -c '
+import os, re, sys, pathlib
+src = pathlib.Path(os.environ["REAL_HEADER"]).read_text(encoding="utf-8")
+def inject(match):
+    body = match.group("body").rstrip()
+    if not body.endswith(","):
+        body += ","
+    body += "\n  CAP_REGISTRY_DRIFT_PROBE = 999,\n"
+    return "typedef enum {" + body + "} capability_id_t;"
+out = re.sub(
+    r"typedef\s+enum\s*\{(?P<body>.*?)\}\s*capability_id_t\s*;",
+    inject, src, count=1, flags=re.DOTALL,
+)
+if out == src:
+    sys.stderr.write("could not locate capability_id_t enum in sandbox\n")
+    sys.exit(2)
+sys.stdout.write(out)
+' > "$SANDBOX_HEADER"; then
+    printf 'TEST:FAIL:capability_registry_drift_canary:sandbox_injection_failed\n'
+    exit 1
+fi
+
+# Run the Python validator directly with --header override so we don't
+# have to clone the rest of the tree.
+LOG_PATH="$TMP_DIR/validator.log"
+set +e
+python3 "$ROOT_DIR/tools/validate_capability_registry.py" \
+    --root "$ROOT_DIR" \
+    --header "$SANDBOX_HEADER" \
+    > "$LOG_PATH" 2>&1
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+    printf 'TEST:FAIL:capability_registry_drift_canary:validator_returned_zero_on_drift\n'
+    cat "$LOG_PATH"
+    exit 1
+fi
+
+if ! grep -q "REGISTRY_VALIDATE:FAIL:enum_not_in_registry:CAP_REGISTRY_DRIFT_PROBE" "$LOG_PATH"; then
+    printf 'TEST:FAIL:capability_registry_drift_canary:expected_marker_missing\n'
+    cat "$LOG_PATH"
+    exit 1
+fi
+
+printf 'TEST:PASS:capability_registry_drift_canary\n'
+exit 0

--- a/tools/validate_capability_registry.py
+++ b/tools/validate_capability_registry.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# tools/validate_capability_registry.py
+#
+# Validate docs/abi/capability-registry.json against the canonical sources:
+#   - kernel/cap/capability.h        (capability_id_t enum)
+#   - build/scripts/test.sh          (test target names)
+#   - docs/abi/capability-deny-contract.md §4 (deny-marker grammar)
+#   - plans/                         (owning_plan file existence)
+#
+# Issue: #234. Companion shell + PowerShell wrappers:
+#   build/scripts/validate_capability_registry.sh
+#   build/scripts/validate_capability_registry.ps1
+#
+# Emits stable REGISTRY_VALIDATE:* markers to stdout so the lint stage
+# can classify failures without parsing English text.
+#
+# Exit codes:
+#   0  every check passed
+#   1  one or more checks failed
+#   2  environment error (missing input file, malformed JSON, etc.)
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+ENUM_RE = re.compile(r"^\s*(CAP_[A-Z][A-Z0-9_]*)\s*=\s*(\d+)\s*,")
+TEST_CASE_RE = re.compile(r"^\s*([a-z_][a-z0-9_]*)\)\s*$")
+MARKER_PREFIX = "CAP:DENY:"
+CAP_NAME_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def parse_enum(header_path: Path) -> dict[str, int]:
+    """Parse capability_id_t entries from capability.h.
+
+    Returns dict: cap_id -> numeric_id. Only entries inside the
+    capability_id_t enum (CAP_* names) are returned.
+    """
+    text = header_path.read_text(encoding="utf-8")
+    # Pull just the capability_id_t enum body to avoid grabbing
+    # CAP_AUDIT_* / CAP_ACCESS_* constants from other enums.
+    m = re.search(
+        r"typedef\s+enum\s*\{(?P<body>.*?)\}\s*capability_id_t\s*;",
+        text,
+        re.DOTALL,
+    )
+    if not m:
+        emit("REGISTRY_VALIDATE:FAIL:enum_not_found:capability_id_t")
+        sys.exit(2)
+    body = m.group("body")
+    out: dict[str, int] = {}
+    for line in body.splitlines():
+        em = ENUM_RE.match(line)
+        if em:
+            out[em.group(1)] = int(em.group(2))
+    if not out:
+        emit("REGISTRY_VALIDATE:FAIL:enum_empty:capability_id_t")
+        sys.exit(2)
+    return out
+
+
+def parse_test_targets(test_sh_path: Path) -> set[str]:
+    """Pull the case-arm labels from build/scripts/test.sh."""
+    targets: set[str] = set()
+    in_case = False
+    text = test_sh_path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('case "$TEST_NAME"'):
+            in_case = True
+            continue
+        if not in_case:
+            continue
+        if stripped == "esac":
+            break
+        # Match `<name>)` arms but skip the catch-all `*)` and `usage)`.
+        m = TEST_CASE_RE.match(line)
+        if m:
+            name = m.group(1)
+            if name == "usage":
+                continue
+            targets.add(name)
+    return targets
+
+
+def parse_registry(registry_path: Path) -> list[dict]:
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        emit(f"REGISTRY_VALIDATE:FAIL:registry_malformed:{exc.msg}")
+        sys.exit(2)
+    caps = data.get("capabilities")
+    if not isinstance(caps, list):
+        emit("REGISTRY_VALIDATE:FAIL:registry_malformed:capabilities_missing")
+        sys.exit(2)
+    return caps
+
+
+def validate_deny_marker(cap_id: str, marker: str) -> str | None:
+    """Return None on success, else a short failure reason."""
+    if not marker.startswith(MARKER_PREFIX):
+        return "missing_prefix"
+    rest = marker[len(MARKER_PREFIX):]
+    # Expected shape: <actor>:<cap_name>:<resource>
+    parts = rest.split(":", 2)
+    if len(parts) != 3:
+        return "field_count"
+    actor, cap_name, resource = parts
+    if not actor:
+        return "actor_empty"
+    if not CAP_NAME_FIELD_RE.match(cap_name):
+        return "cap_name_shape"
+    expected = cap_id[len("CAP_"):].lower()
+    if cap_name != expected:
+        return f"cap_name_mismatch:{cap_name}!={expected}"
+    if not resource:
+        return "resource_empty"
+    if "\n" in resource:
+        return "resource_newline"
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate the capability registry.")
+    ap.add_argument("--root", default=None,
+                    help="Repo root (defaults to git toplevel of this script).")
+    ap.add_argument("--registry", default=None,
+                    help="Override path to capability-registry.json.")
+    ap.add_argument("--header", default=None,
+                    help="Override path to kernel/cap/capability.h.")
+    ap.add_argument("--test-sh", default=None,
+                    help="Override path to build/scripts/test.sh.")
+    args = ap.parse_args()
+
+    here = Path(__file__).resolve().parent
+    root = Path(args.root).resolve() if args.root else here.parent
+    registry_path = Path(args.registry) if args.registry else root / "docs" / "abi" / "capability-registry.json"
+    header_path = Path(args.header) if args.header else root / "kernel" / "cap" / "capability.h"
+    test_sh_path = Path(args.test_sh) if args.test_sh else root / "build" / "scripts" / "test.sh"
+    plans_dir = root / "plans"
+
+    emit("REGISTRY_VALIDATE:START")
+
+    for label, p in (("header", header_path), ("registry", registry_path), ("test_sh", test_sh_path)):
+        if not p.is_file():
+            emit(f"REGISTRY_VALIDATE:FAIL:missing_input:{label}:{p}")
+            return 2
+
+    enum_map = parse_enum(header_path)
+    targets = parse_test_targets(test_sh_path)
+    rows = parse_registry(registry_path)
+
+    failures = 0
+
+    # 1+2+3: bijection between enum and registry, plus numeric_id match.
+    seen_in_registry: dict[str, int] = {}
+    for row in rows:
+        cap_id = row.get("cap_id")
+        if not isinstance(cap_id, str):
+            emit("REGISTRY_VALIDATE:FAIL:row_missing_cap_id")
+            failures += 1
+            continue
+        if cap_id in seen_in_registry:
+            emit(f"REGISTRY_VALIDATE:FAIL:duplicate_registry_entry:{cap_id}")
+            failures += 1
+            continue
+        seen_in_registry[cap_id] = row.get("numeric_id", -1)
+        if cap_id not in enum_map:
+            emit(f"REGISTRY_VALIDATE:FAIL:registry_not_in_enum:{cap_id}")
+            failures += 1
+            continue
+        if row.get("numeric_id") != enum_map[cap_id]:
+            emit(
+                "REGISTRY_VALIDATE:FAIL:numeric_id_mismatch:"
+                f"{cap_id}:registry={row.get('numeric_id')}:enum={enum_map[cap_id]}"
+            )
+            failures += 1
+
+    for cap_id in enum_map:
+        if cap_id not in seen_in_registry:
+            emit(f"REGISTRY_VALIDATE:FAIL:enum_not_in_registry:{cap_id}")
+            failures += 1
+
+    if failures == 0:
+        emit("REGISTRY_VALIDATE:PASS:enum_registry_bijection")
+
+    # 4: every non-null *_test_target appears in test.sh.
+    target_failures = 0
+    for row in rows:
+        cap_id = row.get("cap_id", "<unknown>")
+        for field in ("allow_test_target", "deny_test_target"):
+            t = row.get(field)
+            if t is None:
+                continue
+            if not isinstance(t, str):
+                emit(f"REGISTRY_VALIDATE:FAIL:test_target_not_string:{cap_id}:{field}")
+                target_failures += 1
+                continue
+            if t not in targets:
+                emit(f"REGISTRY_VALIDATE:FAIL:test_target_unknown:{cap_id}:{field}:{t}")
+                target_failures += 1
+    failures += target_failures
+    if target_failures == 0:
+        emit("REGISTRY_VALIDATE:PASS:test_targets_resolved")
+
+    # 5: deny_marker grammar.
+    marker_failures = 0
+    for row in rows:
+        cap_id = row.get("cap_id", "<unknown>")
+        marker = row.get("deny_marker")
+        if not isinstance(marker, str):
+            emit(f"REGISTRY_VALIDATE:FAIL:deny_marker_not_string:{cap_id}")
+            marker_failures += 1
+            continue
+        # Resource may be a placeholder like "<path>" — substitute for grammar
+        # check so the §4 shape is what we validate, not the placeholder text.
+        normalized = re.sub(r"<actor_subject_id>", "0", marker)
+        normalized = re.sub(r"<[a-z_]+>", "x", normalized)
+        # Ensure no remaining angle brackets sneak through.
+        if "<" in normalized or ">" in normalized:
+            emit(f"REGISTRY_VALIDATE:FAIL:deny_marker_placeholder_residue:{cap_id}:{marker}")
+            marker_failures += 1
+            continue
+        reason = validate_deny_marker(cap_id, normalized)
+        if reason is not None:
+            emit(f"REGISTRY_VALIDATE:FAIL:deny_marker_shape:{cap_id}:{reason}")
+            marker_failures += 1
+    failures += marker_failures
+    if marker_failures == 0:
+        emit("REGISTRY_VALIDATE:PASS:deny_marker_shape")
+
+    # 6: owning_plan existence.
+    plan_failures = 0
+    for row in rows:
+        cap_id = row.get("cap_id", "<unknown>")
+        plan = row.get("owning_plan")
+        if plan is None:
+            continue
+        if not isinstance(plan, str):
+            emit(f"REGISTRY_VALIDATE:FAIL:owning_plan_not_string:{cap_id}")
+            plan_failures += 1
+            continue
+        # Plans are recorded as repo-relative paths.
+        plan_path = root / plan
+        if not plan_path.is_file():
+            emit(f"REGISTRY_VALIDATE:FAIL:owning_plan_missing:{cap_id}:{plan}")
+            plan_failures += 1
+    failures += plan_failures
+    if plan_failures == 0:
+        emit("REGISTRY_VALIDATE:PASS:owning_plan_resolves")
+
+    # Sanity: ensure plans_dir exists at all (informational).
+    if not plans_dir.is_dir():
+        emit("REGISTRY_VALIDATE:FAIL:plans_dir_missing")
+        failures += 1
+
+    emit("REGISTRY_VALIDATE:DONE")
+    return 1 if failures > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Lands the machine-readable capability registry asked for in #234: a single index that, for every `CAP_*` in `kernel/cap/capability.h`, records the numeric id, subject kinds, `CAP:DENY:` marker shape, allow/deny `test.sh` targets, and owning plan — plus a validator that cross-checks all of that against the existing sources of truth (`capability.h`, `build/scripts/test.sh`, `docs/abi/capability-deny-contract.md` §4, `plans/`).

## Changes

- **Registry**
  - `docs/abi/capability-registry.json` — machine-readable rows for all 15 `CAP_*` ids.
  - `docs/abi/capability-registry.md` — human-readable mirror + schema doc.
  - `docs/abi/README.md` — index updated to point at the new file.
- **Validator**
  - `tools/validate_capability_registry.py` — enforces enum↔registry bijection, numeric-id match, test-target resolution, deny-marker grammar (per `capability-deny-contract.md` §4), and `owning_plan` existence under `plans/`.
  - `build/scripts/validate_capability_registry.{sh,ps1}` — standard wrapper + PowerShell peer (#156 parity).
  - Stable `REGISTRY_VALIDATE:{START,PASS,FAIL,DONE}` markers so the lint stage can classify failures.
- **Test wiring**
  - `build/scripts/test.{sh,ps1}` gain `validate_capability_registry` and `capability_registry_drift` targets.
- **Negative canary** (per #213 / #177 discipline)
  - `tests/harness/capability_registry_drift_test.sh` injects a fake `CAP_*` into a sandboxed `capability.h` copy and asserts the validator emits `REGISTRY_VALIDATE:FAIL:enum_not_in_registry:CAP_REGISTRY_DRIFT_PROBE`. Proves the validator actually catches drift instead of silently no-op'ing.
- **CI wiring**
  - `build/scripts/lint.sh` runs the registry check after the existing parity/shellcheck/clang-format stages.
  - Rolled out **warn-only** first (`LINT_REGISTRY_FATAL=0` default), per the determinism-check rollout pattern from #176. Failures emit a `TEST:WARN:lint_capability_registry:<reason>` line and a `TEST:PASS:lint_capability_registry:warn_only`. Flip-to-blocking is the explicit follow-up below.

## Validation performed

Locally on this branch:

- `build/scripts/validate_capability_registry.sh` → all four checks PASS (15/15 caps, all targets resolved, all deny markers conform, all plans resolve).
- `build/scripts/test.sh validate_capability_registry` → PASS.
- `build/scripts/test.sh capability_registry_drift` → PASS (canary correctly fires `REGISTRY_VALIDATE:FAIL:enum_not_in_registry`).
- `build/scripts/lint.sh` → PASS (new `lint_capability_registry` check plus existing shellcheck + parity + clang-format informational).
- `build/scripts/check_shell_parity.sh` → PASS (no new parity drift; the new `.sh` has its `.ps1` peer, the new harness lives under `tests/` so it's outside the parity scope).

## Follow-ups

- **Flip-to-blocking issue (todo):** set `LINT_REGISTRY_FATAL=1` in `.github/workflows/lint.yml` after one green cycle on `main` (matches the #176 pattern). Will file as a separate small issue right after this merges so the warn-only window is auditable.
- M1 CAP-table work (#233) and M1-CAPTBL-006 will register their new entries in the same `capability-registry.json` rather than re-inventing per-cap docs.

Fixes #234.