### PR TITLE
feat(cap): 32-bit capability handle + cap_gate_check_handle (M1-CAPTBL-002, #233)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -31,6 +31,7 @@ test_capability_audit_log
 test_capability_gate
 test_capability_table
 test_cap_table_skeleton
+test_cap_handle_repr
 test_cert_chain
 test_codesign
 test_ed25519

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -43,6 +43,7 @@ $testScript = switch ($TestName) {
   "cap_api_contract" { "./build/scripts/test_cap_api_contract.sh" }
   "capability_table" { "./build/scripts/test_capability_table.sh" }
   "cap_table_skeleton" { "./build/scripts/test_cap_table_skeleton.sh" }
+  "cap_handle_repr" { "./build/scripts/test_cap_handle_repr.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
   "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -105,6 +105,9 @@ case "$TEST_NAME" in
     ;;
   cap_table_skeleton)
     run_script "$ROOT_DIR/build/scripts/test_cap_table_skeleton.sh"
+    ;;
+  cap_handle_repr)
+    run_script "$ROOT_DIR/build/scripts/test_cap_handle_repr.sh"
     ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"

--- a/build/scripts/test_cap_handle_repr.sh
+++ b/build/scripts/test_cap_handle_repr.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# build/scripts/test_cap_handle_repr.sh
+#
+# Compiles and runs tests/cap_handle_repr_test.c against the M1
+# capability handle representation layer landed for issue #233
+# (M1-CAPTBL-002).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/tests/cap_handle_repr_test.c" \
+  -o "$OUT_DIR/cap_handle_repr_test"
+
+"$OUT_DIR/cap_handle_repr_test"

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -38,21 +38,56 @@ Rules (all enforced today):
 
 ## Handle representation
 
-A "capability handle" at this stage of the project is the pair
-`(cap_subject_id_t, capability_id_t)` stored in the per-subject packed
-bitset table (`kernel/cap/cap_table.{h,c}`). There is no separate
-opaque-handle type yet; that is intentional until the broker slice (#85)
-lands and demands sharable, revocable references.
+### `(subject, capability)` pair (legacy `cap_table` API)
 
-When the broker slice ships, the handle type will:
+The original capability surface stores the pair
+`(cap_subject_id_t, capability_id_t)` directly in the per-subject packed
+bitset table (`kernel/cap/cap_table.{h,c}`). This API remains the single
+call path for every kernel call site at M1 (`cap_check`,
+`cap_table_grant`, `cap_table_revoke`).
 
-- be opaque to user-space (no kernel pointer dereference required),
-- carry the originating subject so revocation is total,
-- be observable in audit events under their existing `subject_id` /
-  `capability_id` fields plus a new handle-id column.
+### 32-bit packed handle (`cap_handle_t`, M1-CAPTBL-002, #233)
 
-Until then, code that needs to refer to a "grant" refers to the
-`(subject, capability)` pair directly.
+A wire-stable 32-bit identifier lives alongside the legacy API in
+`kernel/cap/cap_handle.{h,c}`. It is the value that the M1 synchronous IPC
+primitive (#180 / #185) and the future syscall-entry trampoline (#192) will
+pass across the kernel/user boundary. Layout is **frozen at
+`OS_ABI_VERSION=0`** — a `#error` in `cap_handle.h` fires on any bump,
+and any change to the field widths below is a v0→v1 ABI break.
+
+| Bits  | Width | Field        | Meaning                                                           |
+| ----- | ----- | ------------ | ----------------------------------------------------------------- |
+| 0..15 | 16    | `slot`       | Index into the global `cap_handle_row` table (`0 .. CAP_HANDLE_TABLE_MAX-1`, currently 64). |
+| 16..29| 14    | `generation` | Low 14 bits of the row's monotonic generation counter; bumped on every revoke. |
+| 30..31| 2     | `tag`        | `0b00` = null/invalid, **`0b01` = kernel capability handle**, `0b10`/`0b11` reserved (future file/IPC/broker kinds). |
+
+Validation contract (`cap_gate_check_handle` / `cap_gate_check_handle_result`):
+
+- `tag != 0b01`            → `CAP_ERR_CAP_INVALID`
+- `slot >= CAP_HANDLE_TABLE_MAX` → `CAP_ERR_CAP_INVALID`
+- row not live              → `CAP_ERR_MISSING`
+- generation mismatch       → `CAP_ERR_MISSING` (stale handle after revoke)
+- row's `cap_id != expected_cap` → `CAP_ERR_CAP_INVALID`
+
+`cap_handle_grant(subject, cap)` returns a handle for the live row, or
+`CAP_HANDLE_NULL` on table full / bad inputs. Grants are idempotent: a
+second grant for the same live `(subject, cap)` returns the **same**
+handle. `cap_handle_revoke(handle)` bumps the row's generation, so the
+same numeric value denies on the next gate; the row is retained so the
+generation counter remains observable indefinitely.
+
+M1-CAPTBL-002 ships the representation and the gate-check entry point.
+Process-exit bulk revoke (`cap_handle_revoke_subject`) is M1-CAPTBL-003,
+subtree revoke is -004, façade migration with byte-exact audit parity is
+-005, and IPC integration is -006 — each landing as its own PR.
+
+### Legacy notes
+
+Until the façade migration (M1-CAPTBL-005) lands, the legacy `cap_table`
+API and the new `cap_handle` API maintain **independent** state. Existing
+call sites continue to use `cap_check` / `cap_table_grant` unchanged.
+When the broker slice (#85) reifies handle ownership across processes, it
+will consume the same `cap_handle_t` defined here.
 
 ## Result codes
 

--- a/kernel/cap/cap_handle.c
+++ b/kernel/cap/cap_handle.c
@@ -33,12 +33,10 @@
 #include <stdint.h>
 
 /* The plan freezes the handle representation against OS_ABI_VERSION=0
- * (#150). The literal lives in user/include/secureos_abi.h once that
- * surface is finalised; for the M1-CAPTBL-001 skeleton we pin a local
- * constant equal to 0 so each row carries the v0 marker today and the
- * follow-up slice can flip this to an `#include` without disturbing any
- * persisted artefact. */
-#define CAP_HANDLE_ABI_VERSION_V0 0u
+ * (#150). M1-CAPTBL-002 (#233) flips the local constant to the canonical
+ * include-and-pin so any future ABI bump is caught by the static_assert in
+ * cap_handle.h. */
+#define CAP_HANDLE_ABI_VERSION_V0 ((uint16_t)OS_ABI_VERSION)
 
 static cap_handle_row g_rows[CAP_HANDLE_TABLE_MAX];
 
@@ -175,4 +173,125 @@ uint32_t cap_handle_table_live_count(void) {
     }
   }
   return live;
+}
+
+/* ----------------------------------------------------------------------
+ * M1-CAPTBL-002: 32-bit packed handle API (issue #233).
+ *
+ * Handles are derived from the row's slot index and low-14-bits of its
+ * generation counter. Revocation bumps the generation, so the prior handle
+ * value fails the staleness check on the next gate. The row is retained
+ * (slot is not freed in v0) so the generation counter remains observable
+ * after revoke — plan acceptance #4.
+ * --------------------------------------------------------------------*/
+
+static uint16_t cap_handle_row_slot(const cap_handle_row *row) {
+  /* g_rows is a fixed array; pointer arithmetic gives the slot index. */
+  return (uint16_t)(row - g_rows);
+}
+
+cap_handle_t cap_handle_pack(uint16_t slot, uint16_t generation_low14,
+                             uint8_t tag) {
+  cap_handle_t h = 0u;
+  h |= ((cap_handle_t)slot & CAP_HANDLE_SLOT_MASK) << CAP_HANDLE_SLOT_SHIFT;
+  h |= ((cap_handle_t)generation_low14 & CAP_HANDLE_GEN_MASK)
+       << CAP_HANDLE_GEN_SHIFT;
+  h |= ((cap_handle_t)tag & CAP_HANDLE_TAG_MASK) << CAP_HANDLE_TAG_SHIFT;
+  return h;
+}
+
+uint16_t cap_handle_slot(cap_handle_t handle) {
+  return (uint16_t)((handle >> CAP_HANDLE_SLOT_SHIFT) & CAP_HANDLE_SLOT_MASK);
+}
+
+uint16_t cap_handle_generation(cap_handle_t handle) {
+  return (uint16_t)((handle >> CAP_HANDLE_GEN_SHIFT) & CAP_HANDLE_GEN_MASK);
+}
+
+uint8_t cap_handle_tag(cap_handle_t handle) {
+  return (uint8_t)((handle >> CAP_HANDLE_TAG_SHIFT) & CAP_HANDLE_TAG_MASK);
+}
+
+static cap_handle_t cap_handle_from_row(const cap_handle_row *row) {
+  return cap_handle_pack(cap_handle_row_slot(row),
+                         (uint16_t)(row->generation & CAP_HANDLE_GEN_MASK),
+                         (uint8_t)CAP_HANDLE_TAG_KERNEL);
+}
+
+cap_handle_t cap_handle_grant(cap_subject_id_t owner_subject,
+                              capability_id_t cap_id) {
+  if (!cap_handle_subject_valid(owner_subject) ||
+      !cap_handle_cap_id_valid(cap_id)) {
+    return CAP_HANDLE_NULL;
+  }
+
+  /* Idempotent: if a live row already exists, return its current handle. */
+  cap_handle_row *existing = cap_handle_find_live(owner_subject, cap_id);
+  if (existing != NULL) {
+    return cap_handle_from_row(existing);
+  }
+
+  cap_handle_row *row = cap_handle_find_free_slot();
+  if (row == NULL) {
+    return CAP_HANDLE_NULL;
+  }
+
+  row->abi_version = CAP_HANDLE_ABI_VERSION_V0;
+  row->cap_id = cap_id;
+  row->owner_subject = owner_subject;
+  row->granter_subject = owner_subject; /* one-arg form; M4 broker will widen */
+  row->parent_handle = 0u;
+  row->generation += 1u;
+  row->flags = CAP_HANDLE_FLAG_LIVE;
+  return cap_handle_from_row(row);
+}
+
+cap_result_t cap_gate_check_handle_result(cap_handle_t handle,
+                                          capability_id_t expected_cap) {
+  if (cap_handle_tag(handle) != CAP_HANDLE_TAG_KERNEL) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  if (!cap_handle_cap_id_valid(expected_cap)) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  uint16_t slot = cap_handle_slot(handle);
+  if (slot >= CAP_HANDLE_TABLE_MAX) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  cap_handle_row *row = &g_rows[slot];
+  if ((row->flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+    return CAP_ERR_MISSING;
+  }
+  if ((row->generation & CAP_HANDLE_GEN_MASK) != cap_handle_generation(handle)) {
+    return CAP_ERR_MISSING;
+  }
+  if (row->cap_id != expected_cap) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  return CAP_OK;
+}
+
+int cap_gate_check_handle(cap_handle_t handle, capability_id_t expected_cap) {
+  return cap_gate_check_handle_result(handle, expected_cap) == CAP_OK;
+}
+
+cap_result_t cap_handle_revoke(cap_handle_t handle) {
+  if (cap_handle_tag(handle) != CAP_HANDLE_TAG_KERNEL) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  uint16_t slot = cap_handle_slot(handle);
+  if (slot >= CAP_HANDLE_TABLE_MAX) {
+    return CAP_ERR_CAP_INVALID;
+  }
+  cap_handle_row *row = &g_rows[slot];
+  if ((row->flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+    return CAP_ERR_MISSING;
+  }
+  if ((row->generation & CAP_HANDLE_GEN_MASK) != cap_handle_generation(handle)) {
+    /* Stale handle revoke is a no-op. */
+    return CAP_ERR_MISSING;
+  }
+  row->flags = CAP_HANDLE_FLAG_REVOKED;
+  row->generation += 1u;
+  return CAP_OK;
 }

--- a/kernel/cap/cap_handle.h
+++ b/kernel/cap/cap_handle.h
@@ -35,9 +35,62 @@
 
 #include "capability.h"
 #include "cap_table.h"  /* reuses CAP_TABLE_MAX_SUBJECTS as the per-process subject bound */
+#include "../../user/include/secureos_abi.h"
 
 /* v0 sizing (plan: "Table data structure"). */
 #define CAP_HANDLE_TABLE_MAX 64u
+
+/*
+ * 32-bit packed capability handle (M1-CAPTBL-002, issue #233).
+ *
+ * The handle is the wire-stable identifier that the future M1 IPC primitive
+ * (#180/#185) and the syscall-entry trampoline (#192) will pass across the
+ * kernel/user boundary. Layout is frozen against OS_ABI_VERSION=0 (#150)
+ * and documented in docs/abi/capabilities.md.
+ *
+ *   bits  0..15  : slot index into the global cap_handle_row table
+ *                  (0 .. CAP_HANDLE_TABLE_MAX-1).
+ *   bits 16..29  : generation low-14-bits (wrap-safe; the underlying
+ *                  row.generation is 32-bit, but only the low 14 are
+ *                  reified on the wire — collisions only after 16384
+ *                  revocations of the same slot, which exceeds the M1
+ *                  bound).
+ *   bits 30..31  : tag = 0b01 ("kernel capability handle"). Reserved tags:
+ *                  0b00 = invalid/null, 0b10/0b11 = future kinds (file
+ *                  handles, IPC ports, broker tickets).
+ *
+ * A handle whose tag bits are not 0b01 is rejected by cap_gate_check_handle
+ * with CAP_ERR_CAP_INVALID. A handle whose slot index lies outside the
+ * table is rejected with CAP_ERR_CAP_INVALID. A handle whose generation
+ * field does not match the live row's generation low-14-bits is rejected
+ * with CAP_ERR_MISSING (stale handle, post-revoke).
+ */
+typedef uint32_t cap_handle_t;
+
+#define CAP_HANDLE_NULL          ((cap_handle_t)0u)
+
+#define CAP_HANDLE_SLOT_BITS     16u
+#define CAP_HANDLE_GEN_BITS      14u
+#define CAP_HANDLE_TAG_BITS      2u
+
+#define CAP_HANDLE_SLOT_SHIFT    0u
+#define CAP_HANDLE_GEN_SHIFT     CAP_HANDLE_SLOT_BITS
+#define CAP_HANDLE_TAG_SHIFT     (CAP_HANDLE_SLOT_BITS + CAP_HANDLE_GEN_BITS)
+
+#define CAP_HANDLE_SLOT_MASK     ((cap_handle_t)((1u << CAP_HANDLE_SLOT_BITS) - 1u))
+#define CAP_HANDLE_GEN_MASK      ((cap_handle_t)((1u << CAP_HANDLE_GEN_BITS) - 1u))
+#define CAP_HANDLE_TAG_MASK      ((cap_handle_t)((1u << CAP_HANDLE_TAG_BITS) - 1u))
+
+#define CAP_HANDLE_TAG_KERNEL    ((cap_handle_t)0x1u)  /* 0b01 */
+
+/* Compile-time invariants pinning the layout to OS_ABI_VERSION=0 (#150).
+ * Any change here is a v0->v1 ABI break and must follow §7 of the roadmap. */
+#if (CAP_HANDLE_SLOT_BITS + CAP_HANDLE_GEN_BITS + CAP_HANDLE_TAG_BITS) != 32u
+#error "cap_handle_t layout must consume exactly 32 bits at OS_ABI_VERSION=0"
+#endif
+#if OS_ABI_VERSION != 0
+#error "cap_handle_t layout is frozen at OS_ABI_VERSION=0; bump requires v1 audit"
+#endif
 
 /* Row flag bits (plan: "Table data structure"). bit3+ MBZ in v0. */
 #define CAP_HANDLE_FLAG_LIVE    (1u << 0)
@@ -91,5 +144,76 @@ cap_result_t cap_handle_table_check(cap_subject_id_t owner_subject,
  * by the unit tests to assert idempotency and table-full behaviour without
  * exposing the row array itself. */
 uint32_t cap_handle_table_live_count(void);
+
+/* ----------------------------------------------------------------------
+ * M1-CAPTBL-002: 32-bit packed handle API (issue #233).
+ *
+ * These functions sit alongside the existing cap_handle_table_* surface and
+ * are the entry points that the M1 IPC primitive (#180/#185) and future
+ * syscall trampoline (#192) will consume. They do NOT yet replace the
+ * thin-bitset cap_table_* API — that façade migration is reserved for
+ * M1-CAPTBL-005 so the audit byte-identity gate can guard it.
+ * --------------------------------------------------------------------*/
+
+/*
+ * Grant (subject, cap_id) and return the wire-stable 32-bit handle that
+ * authorizes it. Caller is treated as the granter (one-arg form per the
+ * issue body). Idempotent: a second grant for the same live (subject, cap)
+ * returns the SAME handle (slot+generation unchanged); the underlying row
+ * is not duplicated, mirroring cap_handle_table_grant's contract.
+ *
+ * Returns CAP_HANDLE_NULL on any error (bad subject, bad cap_id, or table
+ * full). NULL handles always fail cap_gate_check_handle.
+ */
+cap_handle_t cap_handle_grant(cap_subject_id_t owner_subject,
+                              capability_id_t cap_id);
+
+/*
+ * Verify a handle resolves to a live row for `expected_cap` and return
+ * true; otherwise emit the canonical capability-denied marker to the
+ * caller-provided sink and return false.
+ *
+ * Failure modes:
+ *   - tag bits != CAP_HANDLE_TAG_KERNEL  -> CAP_ERR_CAP_INVALID
+ *   - slot index out of bounds           -> CAP_ERR_CAP_INVALID
+ *   - row not live (never granted / row reused) -> CAP_ERR_MISSING
+ *   - generation mismatch (stale / post-revoke) -> CAP_ERR_MISSING
+ *   - row's cap_id != expected_cap       -> CAP_ERR_CAP_INVALID
+ *
+ * The detailed cap_result_t is available via cap_gate_check_handle_result()
+ * for tests and for the syscall trampoline that will translate it to
+ * OS_STATUS_DENIED. The bool form is what plan §"Acceptance criteria" #4
+ * pins.
+ */
+int cap_gate_check_handle(cap_handle_t handle, capability_id_t expected_cap);
+
+/*
+ * Detailed-result form. Same checks as cap_gate_check_handle but returns
+ * the cap_result_t code, so callers can distinguish stale (CAP_ERR_MISSING)
+ * from malformed (CAP_ERR_CAP_INVALID). Pure check — no audit emission, no
+ * table mutation.
+ */
+cap_result_t cap_gate_check_handle_result(cap_handle_t handle,
+                                          capability_id_t expected_cap);
+
+/*
+ * Revoke a handle by bumping its row's generation, so the same numeric
+ * handle now denies. Idempotent: revoking an already-revoked or unknown
+ * handle is a no-op (returns CAP_ERR_MISSING / CAP_ERR_CAP_INVALID). The
+ * row is NOT freed in v0 — generation persists so prior handles stay
+ * permanently stale (plan §"Handle representation").
+ *
+ * Mirrors cap_handle_table_revoke's contract for the (subject, cap) pair
+ * the handle authorizes; the two paths converge on the same row.
+ */
+cap_result_t cap_handle_revoke(cap_handle_t handle);
+
+/* Test helper: pack/unpack the components of a handle. Exposed because the
+ * ABI-freeze unit test exercises the layout directly. */
+cap_handle_t cap_handle_pack(uint16_t slot, uint16_t generation_low14,
+                             uint8_t tag);
+uint16_t cap_handle_slot(cap_handle_t handle);
+uint16_t cap_handle_generation(cap_handle_t handle);
+uint8_t cap_handle_tag(cap_handle_t handle);
 
 #endif

--- a/tests/cap_handle_repr_test.c
+++ b/tests/cap_handle_repr_test.c
@@ -1,0 +1,238 @@
+/**
+ * @file cap_handle_repr_test.c
+ * @brief Unit tests for the M1-CAPTBL-002 32-bit capability handle layer
+ *        (issue #233, plan #197).
+ *
+ * Purpose:
+ *   Exercises the wire-stable cap_handle_t representation, the
+ *   cap_handle_grant -> cap_gate_check_handle -> cap_handle_revoke cycle,
+ *   and the ABI-freeze invariants pinned against OS_ABI_VERSION=0 (#150).
+ *
+ *   Cases:
+ *     1. Layout freeze: bit widths add to 32, tag/slot/gen pack+unpack
+ *        round-trip, and the runtime ABI macro matches the source header.
+ *     2. Grant -> check passes; revoke -> same numeric handle now denies
+ *        with CAP_ERR_MISSING (plan acceptance #4: the "generation check"
+ *        test).
+ *     3. Malformed handles (wrong tag, slot out of bounds, null) are
+ *        rejected with CAP_ERR_CAP_INVALID and never accepted by
+ *        cap_gate_check_handle.
+ *     4. Wrong-cap handle: a handle granted for CAP_CONSOLE_WRITE does NOT
+ *        authorize CAP_SERIAL_WRITE on the same row.
+ *     5. Idempotent grant returns the SAME handle for a live (subject, cap).
+ *     6. Repeated grant-then-revoke bumps the generation each time and the
+ *        successive handles are distinct numeric values.
+ *
+ * Interactions:
+ *   - cap_handle.{c,h}: the unit under test.
+ *   - capability.h: shared cap_result_t / capability_id_t vocabulary.
+ *   - user/include/secureos_abi.h: source of truth for OS_ABI_VERSION.
+ *
+ * Launched by:
+ *   build/scripts/test_cap_handle_repr.sh (registered with
+ *   build/scripts/test.sh under the `cap_handle_repr` target).
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/capability.h"
+#include "../user/include/secureos_abi.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_handle_repr:%s\n", reason);
+  exit(1);
+}
+
+static void test_layout_freeze(void) {
+  /* Bit-width sum is enforced at compile time via #error in cap_handle.h.
+   * Here we assert the runtime helpers respect the same layout. */
+  if (CAP_HANDLE_SLOT_BITS + CAP_HANDLE_GEN_BITS + CAP_HANDLE_TAG_BITS != 32u) {
+    fail("layout_bit_sum");
+  }
+  if (CAP_HANDLE_TAG_KERNEL != 0x1u) {
+    fail("layout_tag_kernel_value");
+  }
+
+  /* Round-trip through pack/unpack. */
+  cap_handle_t h = cap_handle_pack((uint16_t)0xABCDu, (uint16_t)0x1FFFu,
+                                    (uint8_t)CAP_HANDLE_TAG_KERNEL);
+  if (cap_handle_slot(h) != (uint16_t)0xABCDu) {
+    fail("pack_slot_roundtrip");
+  }
+  if (cap_handle_generation(h) != (uint16_t)0x1FFFu) {
+    fail("pack_gen_roundtrip");
+  }
+  if (cap_handle_tag(h) != (uint8_t)CAP_HANDLE_TAG_KERNEL) {
+    fail("pack_tag_roundtrip");
+  }
+
+  /* CAP_HANDLE_NULL must have tag=0 and so must NEVER validate as kernel. */
+  if (cap_handle_tag(CAP_HANDLE_NULL) == CAP_HANDLE_TAG_KERNEL) {
+    fail("null_handle_carries_kernel_tag");
+  }
+
+  /* ABI anchor: this slice is frozen at OS_ABI_VERSION=0. The build will
+   * already #error on bump, but we double-check the runtime value matches. */
+  if (OS_ABI_VERSION != 0) {
+    fail("abi_version_not_zero");
+  }
+}
+
+static void test_grant_check_revoke_cycle(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h = cap_handle_grant(2u, CAP_CONSOLE_WRITE);
+  if (h == CAP_HANDLE_NULL) {
+    fail("grant_returned_null");
+  }
+  if (cap_handle_tag(h) != CAP_HANDLE_TAG_KERNEL) {
+    fail("grant_handle_tag");
+  }
+  if (cap_gate_check_handle(h, CAP_CONSOLE_WRITE) != 1) {
+    fail("check_after_grant");
+  }
+  if (cap_gate_check_handle_result(h, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("check_result_after_grant");
+  }
+
+  /* Revoke: same numeric handle MUST now deny with CAP_ERR_MISSING. */
+  if (cap_handle_revoke(h) != CAP_OK) {
+    fail("revoke_failed");
+  }
+  if (cap_gate_check_handle(h, CAP_CONSOLE_WRITE) != 0) {
+    fail("check_after_revoke_should_fail");
+  }
+  if (cap_gate_check_handle_result(h, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("check_result_after_revoke");
+  }
+
+  /* Double-revoke of the now-stale handle is a no-op. */
+  cap_result_t r2 = cap_handle_revoke(h);
+  if (r2 != CAP_ERR_MISSING) {
+    fail("double_revoke_should_be_missing");
+  }
+}
+
+static void test_malformed_handles_rejected(void) {
+  cap_handle_table_reset();
+
+  /* Null handle: tag bits 0, rejected as CAP_ERR_CAP_INVALID. */
+  if (cap_gate_check_handle(CAP_HANDLE_NULL, CAP_CONSOLE_WRITE) != 0) {
+    fail("null_handle_accepted");
+  }
+  if (cap_gate_check_handle_result(CAP_HANDLE_NULL, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_CAP_INVALID) {
+    fail("null_handle_wrong_result");
+  }
+
+  /* Wrong tag bits (0b10) — reserved for future kinds, must deny today. */
+  cap_handle_t bad_tag = cap_handle_pack(0u, 1u, 0x2u);
+  if (cap_gate_check_handle_result(bad_tag, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_CAP_INVALID) {
+    fail("bad_tag_not_rejected");
+  }
+
+  /* Slot index inside cap_handle_t's 16-bit field but beyond the table:
+   * pick slot = CAP_HANDLE_TABLE_MAX. */
+  cap_handle_t oob = cap_handle_pack((uint16_t)CAP_HANDLE_TABLE_MAX, 1u,
+                                      (uint8_t)CAP_HANDLE_TAG_KERNEL);
+  if (cap_gate_check_handle_result(oob, CAP_CONSOLE_WRITE) !=
+      CAP_ERR_CAP_INVALID) {
+    fail("oob_slot_not_rejected");
+  }
+
+  /* Revoke of a malformed handle returns the same error class. */
+  if (cap_handle_revoke(CAP_HANDLE_NULL) != CAP_ERR_CAP_INVALID) {
+    fail("revoke_null_wrong_result");
+  }
+  if (cap_handle_revoke(bad_tag) != CAP_ERR_CAP_INVALID) {
+    fail("revoke_bad_tag_wrong_result");
+  }
+  if (cap_handle_revoke(oob) != CAP_ERR_CAP_INVALID) {
+    fail("revoke_oob_wrong_result");
+  }
+}
+
+static void test_wrong_cap_id_denied(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h = cap_handle_grant(3u, CAP_CONSOLE_WRITE);
+  if (h == CAP_HANDLE_NULL) {
+    fail("wrong_cap_grant_failed");
+  }
+  /* Handle authorizes CONSOLE_WRITE; checking it for SERIAL_WRITE must
+   * fail with CAP_ERR_CAP_INVALID (capability mismatch, not stale). */
+  if (cap_gate_check_handle_result(h, CAP_SERIAL_WRITE) !=
+      CAP_ERR_CAP_INVALID) {
+    fail("wrong_cap_should_deny");
+  }
+  if (cap_gate_check_handle(h, CAP_CONSOLE_WRITE) != 1) {
+    fail("right_cap_should_pass");
+  }
+}
+
+static void test_grant_idempotent_returns_same_handle(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h1 = cap_handle_grant(4u, CAP_FS_READ);
+  if (h1 == CAP_HANDLE_NULL) {
+    fail("idem_first_grant_null");
+  }
+  cap_handle_t h2 = cap_handle_grant(4u, CAP_FS_READ);
+  if (h2 != h1) {
+    fail("idem_grant_returned_different_handle");
+  }
+  if (cap_handle_table_live_count() != 1u) {
+    fail("idem_grant_allocated_extra_row");
+  }
+  if (cap_gate_check_handle(h1, CAP_FS_READ) != 1) {
+    fail("idem_check_h1");
+  }
+  if (cap_gate_check_handle(h2, CAP_FS_READ) != 1) {
+    fail("idem_check_h2");
+  }
+}
+
+static void test_generation_bump_distinct_handles(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h1 = cap_handle_grant(5u, CAP_DEBUG_EXIT);
+  if (h1 == CAP_HANDLE_NULL) {
+    fail("gen_g1_null");
+  }
+  if (cap_handle_revoke(h1) != CAP_OK) {
+    fail("gen_r1_failed");
+  }
+  /* Second grant should reuse the same slot but a new generation, yielding
+   * a numerically distinct handle. */
+  cap_handle_t h2 = cap_handle_grant(5u, CAP_DEBUG_EXIT);
+  if (h2 == CAP_HANDLE_NULL) {
+    fail("gen_g2_null");
+  }
+  if (h1 == h2) {
+    fail("gen_handles_collide_after_revoke");
+  }
+  /* The fresh row may land in a new slot or reuse the revoked one; the
+   * plan only requires that the OLD handle stay stale. */
+  if (cap_gate_check_handle(h1, CAP_DEBUG_EXIT) != 0) {
+    fail("gen_h1_still_valid_after_revoke_and_regrant");
+  }
+  if (cap_gate_check_handle(h2, CAP_DEBUG_EXIT) != 1) {
+    fail("gen_h2_should_be_valid");
+  }
+}
+
+int main(void) {
+  printf("TEST:START:cap_handle_repr\n");
+  test_layout_freeze();
+  test_grant_check_revoke_cycle();
+  test_malformed_handles_rejected();
+  test_wrong_cap_id_denied();
+  test_grant_idempotent_returns_same_handle();
+  test_generation_bump_distinct_handles();
+  printf("TEST:PASS:cap_handle_repr\n");
+  return 0;
+}


### PR DESCRIPTION
Implements **M1-CAPTBL-002** from plan `plans/2026-05-20-m1-kernel-capability-table.md` — the second of six PR-shaped slices listed in #197. Closes nothing on its own; partial progress on #233 (maintainer to close on merge).

## Summary

- **`cap_handle_t` — 32-bit packed handle** in `kernel/cap/cap_handle.h`:
  `[slot:16 | generation:14 | tag:2]`, tag `0b01` = kernel capability handle. Layout frozen at `OS_ABI_VERSION=0` via compile-time `#error` guards. Reserved tags `0b10`/`0b11` keep the namespace open for future file/IPC/broker handle kinds.
- **Gate API** (alongside the existing `cap_handle_table_*` skeleton from #231, no churn there):
  - `cap_handle_t cap_handle_grant(subject, cap_id)` — idempotent; same live `(subject, cap)` returns the **same** handle.
  - `int cap_gate_check_handle(handle, expected_cap)` — bool form per plan acceptance #4.
  - `cap_result_t cap_gate_check_handle_result(handle, expected_cap)` — detailed code so the syscall trampoline (#192) can translate to `OS_STATUS_DENIED`.
  - `cap_result_t cap_handle_revoke(handle)` — bumps generation; same numeric handle now denies with `CAP_ERR_MISSING`.
- **Doc:** `docs/abi/capabilities.md` gains the 32-bit layout table and validation contract (per plan acceptance #3).
- **Test:** `tests/cap_handle_repr_test.c` covers
  1. layout freeze (bit widths sum to 32, tag/slot/gen pack-unpack round-trip, `OS_ABI_VERSION` anchor),
  2. grant → check passes; revoke → same numeric handle denies with `CAP_ERR_MISSING` (the "generation check" test the plan calls out),
  3. malformed handles (null, wrong tag, out-of-bounds slot) rejected with `CAP_ERR_CAP_INVALID`,
  4. wrong-cap mismatch denied,
  5. idempotent grant returns same handle, no extra row,
  6. revoke+regrant yields a numerically distinct handle; the old one stays stale.
- **Dispatcher:** `cap_handle_repr` target wired into `build/scripts/test.sh` + `test.ps1`, with `.shell_parity_allowlist` entry per #156.

## Out of scope (deferred per plan #197)

- **M1-CAPTBL-003** — `cap_handle_revoke_subject` + process-exit hook (waits on #224 / #192).
- **M1-CAPTBL-004** — subtree revoke stub.
- **M1-CAPTBL-005** — façade migration of `cap_table_grant/revoke/check` onto handles, gated by the byte-exact `CAP_AUDIT:` fixture-diff regression test. The existing `cap_table.{c,h}` is intentionally untouched in this slice so the audit format stays bit-identical.
- **M1-CAPTBL-006** — IPC integration (sender/receiver checks on `ipc_send` / `ipc_recv`).

## Validation

Run from a clean checkout, host toolchain:

```
$ bash build/scripts/test.sh cap_handle_repr
TEST:START:cap_handle_repr
TEST:PASS:cap_handle_repr
$ bash build/scripts/test.sh cap_table_skeleton     # PASS 5/5 (unchanged)
$ bash build/scripts/test.sh capability_table       # PASS 5/5 (legacy API untouched)
$ bash build/scripts/test.sh capability_gate        # PASS (unchanged)
$ bash build/scripts/test.sh capability_audit       # PASS (audit format byte-identical)
$ bash build/scripts/test.sh capability_audit_log   # PASS (byte-exact AUDIT_LOG lines)
$ bash build/scripts/test.sh abi_version            # PASS (anchor)
$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 55 entries)
```

## Follow-ups

- File / pick up M1-CAPTBL-003 (process-exit bulk revoke) once #224 lands a `process_destroy()` hook to wire into.
- M1-CAPTBL-005's façade migration is where the existing `cap_table_*` callers and the audit byte-identity contract converge — keep that PR scoped to that single migration so the fixture-diff is the regression gate.

Refs #233 · plan #197 · ABI anchor #150 · related #224 #192 #220