### PR TITLE
feat(kernel/proc): M1 process-table skeleton + scheduler-visible PID (#224)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -32,6 +32,7 @@ test_capability_gate
 test_capability_table
 test_cap_table_skeleton
 test_cap_handle_repr
+test_process_table
 test_cert_chain
 test_codesign
 test_ed25519

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -65,6 +65,7 @@ $testScript = switch ($TestName) {
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
+  "process_table" { "./build/scripts/test_process_table.sh" }
   "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
   "validate_capability_registry" { "./build/scripts/validate_capability_registry.sh" }
   "capability_registry_drift" { "./tests/harness/capability_registry_drift_test.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -109,6 +109,9 @@ case "$TEST_NAME" in
   cap_handle_repr)
     run_script "$ROOT_DIR/build/scripts/test_cap_handle_repr.sh"
     ;;
+  process_table)
+    run_script "$ROOT_DIR/build/scripts/test_process_table.sh"
+    ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"
     ;;

--- a/build/scripts/test_process_table.sh
+++ b/build/scripts/test_process_table.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build + run the M1 process-table lifecycle test (issue #224).
+#
+# Covers:
+#   - create → lookup snapshot preserves subject + aspace.
+#   - destroy invalidates the PID (stale lookup, double-destroy,
+#     destroy(PID_INVALID) all return PROC_ERR_INVALID_PID).
+#   - create → destroy → create reuses the slot index but advances
+#     the generation field (matches the #220 / #237 lifecycle pattern).
+#   - PROC_TABLE_MAX fill → next create returns PROC_ERR_TABLE_FULL
+#     and writes PID_INVALID to the out param.
+#   - process_table_reset invalidates every previously issued PID.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/tests/process_table_test.c" \
+  -o "$OUT_DIR/process_table_test"
+
+LOG_PATH="$OUT_DIR/process_table_test.log"
+"$OUT_DIR/process_table_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:process_table_create_lookup" "$LOG_PATH"
+grep -q "TEST:PASS:process_table_destroy_semantics" "$LOG_PATH"
+grep -q "TEST:PASS:process_table_pid_advances" "$LOG_PATH"
+grep -q "TEST:PASS:process_table_full_rejected" "$LOG_PATH"
+grep -q "TEST:PASS:process_table_reset_invalidates" "$LOG_PATH"
+grep -q "TEST:PASS:process_table$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -1,0 +1,172 @@
+/**
+ * @file process.c
+ * @brief Process table implementation for the M1 process abstraction
+ *        v0 scaffold (issue #224).
+ *
+ * Purpose:
+ *   Maintains a small fixed-size array of PCB slots indexed by a
+ *   16-bit table index, with a 16-bit generation counter packed into
+ *   the high half of `process_id_t` to detect use-after-destroy. The
+ *   handle layout deliberately mirrors `ipc_port_t` (#220) and
+ *   `cap_handle_t` (#237) so the same lifecycle invariants and tests
+ *   carry over.
+ *
+ *   No synchronization primitives: the v0 scaffold is single-threaded
+ *   (cooperative scheduling is a separate follow-up). No dynamic
+ *   allocation: the PCB array is a static BSS-resident table.
+ *
+ *   Scope guard — this file MUST NOT grow scheduler state, exit
+ *   bookkeeping, IPC integration, or paging fields. Each is its own
+ *   sibling issue. Adding any of them here defeats the point of the
+ *   single-session execute slice.
+ *
+ * Interactions:
+ *   - process.h: public interface implemented here.
+ *   - user/include/secureos_abi.h: anchors OS_ABI_VERSION = 0 for the
+ *     static_assert that locks the handle layout.
+ *
+ * Launched by:
+ *   Not a standalone process. Compiled into the kernel image and into
+ *   the host-side process_table test binary.
+ *
+ * Issue: #224.
+ */
+
+#include "process.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "../../user/include/secureos_abi.h"
+
+/* Handle layout: low 16 bits = table index, high 16 bits = generation.
+ * Static-asserted against OS_ABI_VERSION = 0 so any future packing
+ * change is a deliberate ABI bump rather than an accidental edit. */
+#define PROC_INDEX_MASK 0xFFFFu
+#define PROC_GEN_SHIFT 16u
+
+_Static_assert(OS_ABI_VERSION == 0,
+               "process_id_t layout is frozen under OS_ABI_VERSION = 0; "
+               "any change here requires an ABI bump (#150).");
+_Static_assert(sizeof(process_id_t) == 4,
+               "process_id_t MUST be exactly 32 bits in OS_ABI_VERSION = 0.");
+_Static_assert(PROC_TABLE_MAX <= 0xFFFFu,
+               "PROC_TABLE_MAX must fit in the 16-bit index half of "
+               "process_id_t.");
+
+typedef struct {
+  bool live;
+  uint16_t generation;
+  cap_subject_id_t subject;
+  address_space_t *aspace;
+} process_slot_t;
+
+static process_slot_t g_procs[PROC_TABLE_MAX];
+static bool g_table_initialized = false;
+
+static process_id_t encode_pid(uint16_t index, uint16_t generation) {
+  /* Index 0 with generation 0 collides with PID_INVALID, so we always
+   * start generations at 1 and bump on each (re)use. */
+  return ((process_id_t)generation << PROC_GEN_SHIFT) | (process_id_t)index;
+}
+
+static bool decode_pid(process_id_t pid, uint16_t *out_index, uint16_t *out_gen) {
+  if (pid == PID_INVALID) {
+    return false;
+  }
+  *out_index = (uint16_t)(pid & PROC_INDEX_MASK);
+  *out_gen = (uint16_t)((pid >> PROC_GEN_SHIFT) & 0xFFFFu);
+  return *out_index < PROC_TABLE_MAX;
+}
+
+static process_slot_t *resolve(process_id_t pid) {
+  uint16_t index = 0u;
+  uint16_t gen = 0u;
+  if (!decode_pid(pid, &index, &gen)) {
+    return NULL;
+  }
+  process_slot_t *slot = &g_procs[index];
+  if (!slot->live || slot->generation != gen) {
+    return NULL;
+  }
+  return slot;
+}
+
+void process_table_init(void) {
+  process_table_reset();
+}
+
+void process_table_reset(void) {
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    /* Reset bumps generation so any handle issued before the reset
+     * fails on resolve(). Preserve the "never zero" invariant. */
+    if (g_table_initialized) {
+      g_procs[i].generation = (uint16_t)(g_procs[i].generation + 1u);
+      if (g_procs[i].generation == 0u) {
+        g_procs[i].generation = 1u;
+      }
+    } else if (g_procs[i].generation == 0u) {
+      g_procs[i].generation = 1u;
+    }
+    g_procs[i].live = false;
+    g_procs[i].subject = 0u;
+    g_procs[i].aspace = NULL;
+  }
+  g_table_initialized = true;
+}
+
+proc_result_t process_create(cap_subject_id_t subject,
+                             address_space_t *aspace,
+                             process_id_t *out_pid) {
+  if (!g_table_initialized) {
+    process_table_init();
+  }
+  if (out_pid == NULL) {
+    return PROC_ERR_INVALID_ARG;
+  }
+  *out_pid = PID_INVALID;
+
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (!g_procs[i].live) {
+      g_procs[i].live = true;
+      g_procs[i].subject = subject;
+      g_procs[i].aspace = aspace;
+      *out_pid = encode_pid(i, g_procs[i].generation);
+      return PROC_OK;
+    }
+  }
+  return PROC_ERR_TABLE_FULL;
+}
+
+proc_result_t process_destroy(process_id_t pid) {
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  slot->live = false;
+  slot->generation = (uint16_t)(slot->generation + 1u);
+  if (slot->generation == 0u) {
+    slot->generation = 1u;
+  }
+  slot->subject = 0u;
+  slot->aspace = NULL;
+  return PROC_OK;
+}
+
+proc_result_t process_lookup(process_id_t pid, process_t *out_proc) {
+  if (out_proc == NULL) {
+    return PROC_ERR_INVALID_ARG;
+  }
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  out_proc->pid = pid;
+  out_proc->subject = slot->subject;
+  out_proc->aspace = slot->aspace;
+  return PROC_OK;
+}
+
+bool process_is_live_for_tests(process_id_t pid) {
+  return resolve(pid) != NULL;
+}

--- a/kernel/proc/process.h
+++ b/kernel/proc/process.h
@@ -1,0 +1,169 @@
+/**
+ * @file process.h
+ * @brief M1 process table — PCB struct + scheduler-visible PID lookup
+ *        (issue #224, plan plans/2026-05-20-m1-process-address-space.md).
+ *
+ * Purpose:
+ *   First execute slice of the M1 process abstraction. Defines the
+ *   minimal Process Control Block (PCB) shape and a fixed-size process
+ *   table indexed by a stable `process_id_t`. Each PCB carries exactly
+ *   one `cap_subject_id_t` so the IPC primitive (#220) and the
+ *   capability gate (#225 / #237) can address a process by its identity
+ *   without any further indirection.
+ *
+ *   The handle representation mirrors the lifecycle pattern already
+ *   established by `kernel/ipc/ipc_port.{c,h}` (#220) and
+ *   `kernel/cap/cap_handle.{c,h}` (#237): the low 16 bits are the table
+ *   index and the high 16 bits are a generation counter that advances
+ *   on every `process_destroy` so stale PIDs fail cleanly with
+ *   `PROC_ERR_INVALID_PID` rather than aliasing a recycled slot.
+ *
+ *   What this slice DOES NOT do (explicit non-asks from the issue —
+ *   each is its own follow-up):
+ *     - No scheduling logic, no ready-queue, no context switch.
+ *     - No concrete `address_space_t` fields (paging issue, M2+).
+ *     - No syscall entry wiring (#232 / `syscall_entry.{c,h}` owns it).
+ *     - No IPC integration (#220's port table already owns its own
+ *       lifecycle; this table is referenced by name only).
+ *
+ *   `address_space_t` is declared opaque here. v0 only requires that a
+ *   PCB carry an `address_space_t *` slot — its concrete layout is
+ *   reserved for the M2 paging slice. `process_create` accepts a
+ *   caller-supplied pointer (typically NULL in v0 tests) and stores it
+ *   verbatim; no allocation, no validation beyond NULL-vs-non-NULL.
+ *
+ * Interactions:
+ *   - kernel/cap/capability.h: `cap_subject_id_t` is the identity
+ *     bound to each PCB.
+ *   - kernel/ipc/ipc_port.{c,h}: same generation-counter pattern (#220).
+ *   - user/include/secureos_abi.h: `OS_ABI_VERSION = 0` anchors the
+ *     packed handle layout via static_assert in process.c.
+ *
+ * Launched by:
+ *   Not a standalone process. `process_table_init()` is called by
+ *   tests at start-of-run and (when the kernel boots) from kmain at
+ *   subsystem init time. Currently no production caller — wiring
+ *   into `kernel_main` is deferred to the cooperative-scheduler
+ *   follow-up issue.
+ *
+ * Issue: #224. Plan: plans/2026-05-20-m1-process-address-space.md.
+ */
+
+#ifndef SECUREOS_KERNEL_PROC_PROCESS_H
+#define SECUREOS_KERNEL_PROC_PROCESS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../cap/capability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Maximum simultaneously live processes in the v0 in-kernel scaffold.
+ * Sized deliberately small (matches IPC_PORT_TABLE_MAX from #220) —
+ * anything that needs more is out of scope for the session-sized M1
+ * slice. Raising this is allowed at M2+ without ABI churn because the
+ * value is not exposed across the ABI boundary.
+ */
+#define PROC_TABLE_MAX 16u
+
+/*
+ * Reserved invalid PID. `process_create` never returns this value on
+ * success. Tests use it to assert default-zero PIDs are rejected on
+ * every lookup / destroy.
+ */
+#define PID_INVALID 0u
+
+typedef uint32_t process_id_t;
+typedef process_id_t pid_t_proc; /* internal alias to avoid clashing
+                                    with POSIX pid_t in host tests */
+
+/*
+ * Result vocabulary for the process-table API. Kept distinct from
+ * cap_result_t / ipc_result_t so callers cannot accidentally cross
+ * subsystem boundaries with a single switch.
+ */
+typedef enum {
+  PROC_OK = 0,
+  PROC_ERR_INVALID_PID = 1,
+  PROC_ERR_INVALID_ARG = 2,
+  PROC_ERR_TABLE_FULL = 3,
+} proc_result_t;
+
+/*
+ * Forward declaration of the address-space placeholder. The v0
+ * scaffold treats `address_space_t` as an opaque type: concrete fields
+ * are reserved for the M2 paging slice and live behind this pointer
+ * inside the PCB. Declaring it here (rather than in a separate
+ * address_space.h) keeps the v0 surface to a single header.
+ */
+typedef struct address_space address_space_t;
+
+/*
+ * Minimal PCB. Field order is part of the v0 contract — tests assert
+ * sizeof/offsetof against a static_assert table in process.c.
+ *
+ * Out of scope for this slice (these will appear in sibling follow-up
+ * issues; do NOT add them here): state machine, ready-queue links,
+ * exit_code, entry pointer, kernel stack pointer.
+ */
+typedef struct process {
+  process_id_t       pid;      /* stable handle, 0 = invalid */
+  cap_subject_id_t   subject;  /* capability identity bound to this PCB */
+  address_space_t   *aspace;   /* opaque in v0; reserved for M2 paging */
+} process_t;
+
+/*
+ * Initialize / reset the process table to a known-empty state. Both
+ * forms are idempotent. Calling reset invalidates every previously
+ * issued PID (their generations are bumped by the reset).
+ */
+void process_table_init(void);
+void process_table_reset(void);
+
+/*
+ * Create a process bound to `subject`. `aspace` is stored verbatim in
+ * the PCB and may be NULL in v0. Returns PROC_OK and writes the new
+ * PID to `*out_pid` on success; PROC_ERR_INVALID_ARG if `out_pid` is
+ * NULL; PROC_ERR_TABLE_FULL when no slot is free.
+ *
+ * The returned PID is guaranteed never to equal PID_INVALID.
+ */
+proc_result_t process_create(cap_subject_id_t subject,
+                             address_space_t *aspace,
+                             process_id_t *out_pid);
+
+/*
+ * Destroy a process. Subsequent operations on the same PID return
+ * PROC_ERR_INVALID_PID (generation mismatch). Double-destroy is also
+ * PROC_ERR_INVALID_PID; destroying PID_INVALID is PROC_ERR_INVALID_PID.
+ */
+proc_result_t process_destroy(process_id_t pid);
+
+/*
+ * Look up a live PCB. On success writes a snapshot of the PCB fields
+ * into `*out_proc` and returns PROC_OK. On a stale or invalid PID
+ * returns PROC_ERR_INVALID_PID and leaves `*out_proc` untouched.
+ *
+ * The snapshot is a value copy — callers MUST NOT cache the pointer
+ * across other process_table_* calls. v0 intentionally does not
+ * expose live PCB pointers across the API boundary.
+ */
+proc_result_t process_lookup(process_id_t pid, process_t *out_proc);
+
+/*
+ * Test-only helper: is `pid` currently live in the table?
+ * Used by tests/process_table_test.c to assert table-occupancy
+ * transitions without peeking at slot internals.
+ */
+bool process_is_live_for_tests(process_id_t pid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_PROC_PROCESS_H */

--- a/plans/2026-05-20-m1-process-address-space.md
+++ b/plans/2026-05-20-m1-process-address-space.md
@@ -263,11 +263,15 @@ validator JSON report (#110).
 These execute issues are the concrete unit of work this plan unblocks. Each is
 intended to be at most one PR. Proposed titles:
 
-1. **"M1 proc: PCB table skeleton + `proc_init`/`proc_spawn_module` (BUILD_ROADMAP §5.1)"**
+1. **"M1 proc: PCB table skeleton + `proc_init`/`proc_spawn_module` (BUILD_ROADMAP §5.1)"** — **partially landed (#224)**
    - Lands `kernel/proc/process.{c,h}`, the static PCB array, the module
      registry stub, and `proc_init` wiring into `kernel_main`. No scheduler,
      no IPC, no aspace. Validator target: `proc_table_skeleton` asserts
      `proc_lookup(1)` returns the registered name.
+   - Status: the PCB struct + `process_table_init/reset/create/destroy/lookup`
+     surface lands here under `test.sh process_table`. Module registry stub +
+     `kernel_main` wiring are deferred to the sibling cooperative-scheduler
+     issue (see (3)) so the PR stays session-sized.
 2. **"M1 proc: flat-with-bounds `address_space_t` + `.proc_arena` linker carve-out (BUILD_ROADMAP §5.1)"**
    - Adds `kernel/proc/address_space.{c,h}`, `.proc_arena` section in
      `kernel/arch/x86/boot/linker.ld`, partitioning at boot. Validator

--- a/tests/process_table_test.c
+++ b/tests/process_table_test.c
@@ -1,0 +1,234 @@
+/**
+ * @file process_table_test.c
+ * @brief Lifecycle + table-occupancy tests for the M1 process table
+ *        (issue #224).
+ *
+ * Asserts the invariants spelled out in issue #224's scope:
+ *
+ *   1. process_create → process_lookup returns the same subject/aspace
+ *      the caller supplied, and a non-zero PID.
+ *   2. process_destroy invalidates the PID: lookup + double-destroy
+ *      return PROC_ERR_INVALID_PID; destroy(PID_INVALID) too.
+ *   3. process_create → destroy → create on an otherwise-empty table
+ *      reuses the same slot index but advances the generation half of
+ *      the PID (no stale-handle aliasing — matches the #220 / #237
+ *      lifecycle pattern).
+ *   4. Filling the table to PROC_TABLE_MAX returns PROC_OK for every
+ *      slot; the next create returns PROC_ERR_TABLE_FULL and writes
+ *      PID_INVALID to the out param.
+ *   5. process_table_reset invalidates every previously issued PID
+ *      (generation bump on reset).
+ *
+ * Launched by:
+ *   build/scripts/test_process_table.sh (dispatched via
+ *   build/scripts/test.sh process_table).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/proc/process.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:process_table:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  process_table_reset();
+}
+
+static process_id_t create_or_die(cap_subject_id_t subject,
+                                  address_space_t *aspace,
+                                  const char *where) {
+  process_id_t pid = PID_INVALID;
+  proc_result_t rc = process_create(subject, aspace, &pid);
+  if (rc != PROC_OK) {
+    die(where);
+  }
+  if (pid == PID_INVALID) {
+    die("create_returned_invalid_pid");
+  }
+  return pid;
+}
+
+/* Check 1: round-trip create + lookup preserves subject + aspace. */
+static void check_create_lookup_roundtrip(void) {
+  reset_world();
+  /* Use a distinctive sentinel pointer value (cast from an integer
+   * literal) so we can prove process_create stored it verbatim
+   * without dereferencing it. v0 treats address_space_t * as opaque. */
+  address_space_t *sentinel = (address_space_t *)(uintptr_t)0xCAFEBABEu;
+  process_id_t pid = create_or_die((cap_subject_id_t)42u, sentinel,
+                                   "create_roundtrip");
+
+  process_t snap;
+  memset(&snap, 0, sizeof(snap));
+  if (process_lookup(pid, &snap) != PROC_OK) {
+    die("lookup_after_create_failed");
+  }
+  if (snap.pid != pid) {
+    die("snapshot_pid_mismatch");
+  }
+  if (snap.subject != (cap_subject_id_t)42u) {
+    die("snapshot_subject_mismatch");
+  }
+  if (snap.aspace != sentinel) {
+    die("snapshot_aspace_mismatch");
+  }
+  if (!process_is_live_for_tests(pid)) {
+    die("live_check_false_for_live_pid");
+  }
+
+  /* lookup with NULL out-param is PROC_ERR_INVALID_ARG. */
+  if (process_lookup(pid, NULL) != PROC_ERR_INVALID_ARG) {
+    die("lookup_null_outparam_not_rejected");
+  }
+
+  if (process_destroy(pid) != PROC_OK) {
+    die("cleanup_destroy_failed");
+  }
+  printf("TEST:PASS:process_table_create_lookup\n");
+}
+
+/* Check 2: destroy semantics. Stale lookup, double-destroy, and
+ * destroy(PID_INVALID) all return PROC_ERR_INVALID_PID. */
+static void check_destroy_semantics(void) {
+  reset_world();
+  process_id_t pid = create_or_die((cap_subject_id_t)7u, NULL, "destroy_create");
+
+  if (process_destroy(pid) != PROC_OK) {
+    die("first_destroy_failed");
+  }
+
+  process_t snap;
+  memset(&snap, 0, sizeof(snap));
+  if (process_lookup(pid, &snap) != PROC_ERR_INVALID_PID) {
+    die("stale_lookup_not_rejected");
+  }
+  if (process_is_live_for_tests(pid)) {
+    die("live_check_true_for_destroyed_pid");
+  }
+  if (process_destroy(pid) != PROC_ERR_INVALID_PID) {
+    die("double_destroy_not_rejected");
+  }
+  if (process_destroy(PID_INVALID) != PROC_ERR_INVALID_PID) {
+    die("destroy_invalid_not_rejected");
+  }
+  /* Also: lookup(PID_INVALID) is PROC_ERR_INVALID_PID, not a crash. */
+  if (process_lookup(PID_INVALID, &snap) != PROC_ERR_INVALID_PID) {
+    die("lookup_invalid_pid_not_rejected");
+  }
+  printf("TEST:PASS:process_table_destroy_semantics\n");
+}
+
+/* Check 3: create→destroy→create on an empty table reuses the slot
+ * index but advances the generation half. Mirrors the
+ * #220/#237 generation-counter contract so the three subsystems
+ * share one mental model. */
+static void check_pid_advances_on_reuse(void) {
+  reset_world();
+  process_id_t a = create_or_die((cap_subject_id_t)1u, NULL, "first_create");
+  if (process_destroy(a) != PROC_OK) {
+    die("destroy_a");
+  }
+  process_id_t b = create_or_die((cap_subject_id_t)1u, NULL, "second_create");
+  if (a == b) {
+    die("pid_did_not_advance_after_destroy_create");
+  }
+  uint16_t a_idx = (uint16_t)(a & 0xFFFFu);
+  uint16_t b_idx = (uint16_t)(b & 0xFFFFu);
+  uint16_t a_gen = (uint16_t)((a >> 16) & 0xFFFFu);
+  uint16_t b_gen = (uint16_t)((b >> 16) & 0xFFFFu);
+  if (a_idx != b_idx) {
+    die("reused_slot_index_changed");
+  }
+  if (b_gen == a_gen) {
+    die("generation_did_not_advance");
+  }
+  if (process_destroy(b) != PROC_OK) {
+    die("destroy_b");
+  }
+  printf("TEST:PASS:process_table_pid_advances\n");
+}
+
+/* Check 4: table-full rejection. Fill to PROC_TABLE_MAX, then one
+ * more create must fail with PROC_ERR_TABLE_FULL and PID_INVALID. */
+static void check_table_full_rejected(void) {
+  reset_world();
+  process_id_t pids[PROC_TABLE_MAX];
+  for (uint32_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    pids[i] = create_or_die((cap_subject_id_t)(100u + i), NULL,
+                            "table_full_fill");
+  }
+  /* All PIDs must be distinct. */
+  for (uint32_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    for (uint32_t j = i + 1u; j < PROC_TABLE_MAX; ++j) {
+      if (pids[i] == pids[j]) {
+        die("duplicate_pid_in_full_table");
+      }
+    }
+  }
+  /* One more must be rejected. */
+  process_id_t overflow_pid = (process_id_t)0xDEADBEEFu;
+  proc_result_t rc = process_create((cap_subject_id_t)999u, NULL,
+                                    &overflow_pid);
+  if (rc != PROC_ERR_TABLE_FULL) {
+    die("table_full_not_signalled");
+  }
+  if (overflow_pid != PID_INVALID) {
+    die("table_full_did_not_clear_out_pid");
+  }
+  /* NULL out-param is PROC_ERR_INVALID_ARG regardless of table state. */
+  if (process_create((cap_subject_id_t)1u, NULL, NULL) != PROC_ERR_INVALID_ARG) {
+    die("create_null_outparam_not_rejected");
+  }
+  /* Freeing a slot must reopen exactly one create. */
+  if (process_destroy(pids[3]) != PROC_OK) {
+    die("free_one_slot_failed");
+  }
+  process_id_t reused = create_or_die((cap_subject_id_t)1234u, NULL,
+                                      "reuse_after_free");
+  /* Slot index should be the one we just freed. */
+  if ((uint16_t)(reused & 0xFFFFu) != (uint16_t)(pids[3] & 0xFFFFu)) {
+    die("freed_slot_not_reused_first");
+  }
+  printf("TEST:PASS:process_table_full_rejected\n");
+}
+
+/* Check 5: reset invalidates all previously issued PIDs. */
+static void check_reset_invalidates(void) {
+  reset_world();
+  process_id_t pid = create_or_die((cap_subject_id_t)5u, NULL, "reset_create");
+  if (!process_is_live_for_tests(pid)) {
+    die("reset_precheck_live_false");
+  }
+  process_table_reset();
+  if (process_is_live_for_tests(pid)) {
+    die("reset_did_not_invalidate_live");
+  }
+  process_t snap;
+  if (process_lookup(pid, &snap) != PROC_ERR_INVALID_PID) {
+    die("reset_lookup_not_rejected");
+  }
+  /* After reset the next create on slot 0 must NOT collide with the
+   * pre-reset PID's generation. */
+  process_id_t fresh = create_or_die((cap_subject_id_t)5u, NULL,
+                                     "reset_then_create");
+  if (fresh == pid) {
+    die("reset_did_not_advance_generation");
+  }
+  printf("TEST:PASS:process_table_reset_invalidates\n");
+}
+
+int main(void) {
+  check_create_lookup_roundtrip();
+  check_destroy_semantics();
+  check_pid_advances_on_reuse();
+  check_table_full_rejected();
+  check_reset_invalidates();
+  printf("TEST:PASS:process_table\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #224. First execute slice of `plans/2026-05-20-m1-process-address-space.md` (merged via #198).

## What this PR does

Lands the minimal PCB and a fixed-size process table indexed by a stable, generation-tagged `process_id_t` — the same lifecycle pattern already in use by `ipc_port_t` (#220) and `cap_handle_t` (#237), so all three subsystems share one mental model for stale-handle behaviour.

- `kernel/proc/process.{c,h}`:
  - `process_t { pid, subject, aspace }` — minimum fields the issue scope calls for.
  - `process_id_t` = packed `(generation << 16) | index`, `static_assert`ed against `OS_ABI_VERSION = 0` (#150) and `sizeof == 4`, so the layout is frozen early.
  - `PROC_TABLE_MAX = 16` (matches `IPC_PORT_TABLE_MAX`).
  - `PID_INVALID = 0` reserved; encoder guarantees the issued PID is never zero.
  - API: `process_table_init/reset`, `process_create`, `process_destroy`, `process_lookup`, `process_is_live_for_tests`.
  - `address_space_t` declared opaque (concrete fields belong to the M2 paging sibling).
- `tests/process_table_test.c` — five deterministic checks:
  - create→lookup snapshot preserves subject + aspace
  - destroy semantics (stale lookup, double-destroy, `destroy(PID_INVALID)` all `PROC_ERR_INVALID_PID`)
  - create→destroy→create reuses slot index but advances generation half
  - `PROC_TABLE_MAX` fill → next create `PROC_ERR_TABLE_FULL` + writes `PID_INVALID`
  - `process_table_reset` invalidates all prior PIDs
- `build/scripts/test_process_table.sh` wired into `build/scripts/test.sh process_table` and `test.ps1`; `.shell_parity_allowlist` updated under #156.
- Plan checklist annotated to mark the PCB-skeleton bullet as landed via #224 (module registry + `kernel_main` wiring stays deferred to the cooperative-scheduler sibling issue).

## Validation performed

```
$ bash build/scripts/test.sh process_table
TEST:PASS:process_table_create_lookup
TEST:PASS:process_table_destroy_semantics
TEST:PASS:process_table_pid_advances
TEST:PASS:process_table_full_rejected
TEST:PASS:process_table_reset_invalidates
TEST:PASS:process_table

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 56 entries)
```

## Out of scope (explicit, per issue #224)

- No syscall entry stub (#232 owns it — already on `main`).
- No scheduler / context-switch wiring (own follow-up).
- No concrete `address_space_t` fields (paging sibling, M2+).
- No IPC integration of PCBs.
- No `kernel_main` boot-time wiring yet — proc table is host-tested only, since the v0 scaffold has no production caller until the cooperative-scheduler PR lands.

## Follow-ups suggested

- File two sibling issues for plan items (3) and (5) from `plans/2026-05-20-m1-process-address-space.md`: cooperative scheduler + context switch on IPC block, and (when M2 paging starts) the concrete `address_space_t` layout.