### PR TITLE
feat(kernel/cap,proc): M1 cap_handle_revoke_subject + process_destroy hook (#239)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -32,6 +32,7 @@ test_capability_gate
 test_capability_table
 test_cap_table_skeleton
 test_cap_handle_repr
+test_cap_handle_revoke_subject
 test_process_table
 test_cert_chain
 test_codesign

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -44,6 +44,7 @@ $testScript = switch ($TestName) {
   "capability_table" { "./build/scripts/test_capability_table.sh" }
   "cap_table_skeleton" { "./build/scripts/test_cap_table_skeleton.sh" }
   "cap_handle_repr" { "./build/scripts/test_cap_handle_repr.sh" }
+  "cap_handle_revoke_subject" { "./build/scripts/test_cap_handle_revoke_subject.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
   "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -108,6 +108,9 @@ case "$TEST_NAME" in
     ;;
   cap_handle_repr)
     run_script "$ROOT_DIR/build/scripts/test_cap_handle_repr.sh"
+    ;;
+  cap_handle_revoke_subject)
+    run_script "$ROOT_DIR/build/scripts/test_cap_handle_revoke_subject.sh"
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"

--- a/build/scripts/test_cap_handle_revoke_subject.sh
+++ b/build/scripts/test_cap_handle_revoke_subject.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# build/scripts/test_cap_handle_revoke_subject.sh
+#
+# Compiles and runs tests/cap_handle_revoke_subject_test.c against the
+# M1-CAPTBL-003 bulk-revoke-by-owner entry point and the
+# process_destroy() hook that calls it (issue #239, plan #197).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/tests/cap_handle_revoke_subject_test.c" \
+  -o "$OUT_DIR/cap_handle_revoke_subject_test"
+
+LOG_PATH="$OUT_DIR/cap_handle_revoke_subject_test.log"
+"$OUT_DIR/cap_handle_revoke_subject_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:cap_handle_revoke_subject_bulk_one_owner" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subject_isolates_owners" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subject_no_rows" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subject_bad_subject" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subject_process_destroy_hook" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subject$" "$LOG_PATH"

--- a/build/scripts/test_process_table.sh
+++ b/build/scripts/test_process_table.sh
@@ -24,6 +24,7 @@ mkdir -p "$OUT_DIR"
 cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/tests/process_table_test.c" \
   -o "$OUT_DIR/process_table_test"

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -77,8 +77,16 @@ same numeric value denies on the next gate; the row is retained so the
 generation counter remains observable indefinitely.
 
 M1-CAPTBL-002 ships the representation and the gate-check entry point.
-Process-exit bulk revoke (`cap_handle_revoke_subject`) is M1-CAPTBL-003,
-subtree revoke is -004, façade migration with byte-exact audit parity is
+M1-CAPTBL-003 (#239) adds `cap_handle_revoke_subject(owner)` — a single
+pass over the global table that transitions every live row owned by
+`owner` to REVOKED and bumps its generation, so every previously-issued
+handle for those rows now fails the gate with `CAP_ERR_MISSING`. The
+`kernel/proc/process.c::process_destroy` path calls this hook on every
+successful destroy, making process exit the authoritative "all handles
+for this subject are stale" trigger. Bulk revoke is best-effort by
+contract (no error code; bad subject ids return `0` revoked).
+Subtree revoke (`cap_handle_revoke_subject_subtree`) is M1-CAPTBL-004,
+façade migration with byte-exact audit parity is
 -005, and IPC integration is -006 — each landing as its own PR.
 
 ### Legacy notes

--- a/kernel/cap/cap_handle.c
+++ b/kernel/cap/cap_handle.c
@@ -295,3 +295,35 @@ cap_result_t cap_handle_revoke(cap_handle_t handle) {
   row->generation += 1u;
   return CAP_OK;
 }
+
+/* ----------------------------------------------------------------------
+ * M1-CAPTBL-003: bulk revoke by owner (issue #239).
+ *
+ * Single pass over the global table. Each live row whose `owner_subject`
+ * matches is transitioned LIVE -> REVOKED with its generation bumped, so
+ * any previously-issued handle for that row now fails the staleness check
+ * in `cap_gate_check_handle_result`. Best-effort by contract: a bad
+ * subject id (out of range) simply matches no rows and returns 0; there
+ * is no separate error code. Audit-chain emission stays owned by the
+ * legacy cap_table layer until M1-CAPTBL-005's façade migration lands
+ * (plan acceptance #2 — audit byte-identity is reserved for that PR).
+ * --------------------------------------------------------------------*/
+uint32_t cap_handle_revoke_subject(cap_subject_id_t owner_subject) {
+  if (!cap_handle_subject_valid(owner_subject)) {
+    return 0u;
+  }
+  uint32_t revoked = 0u;
+  for (uint32_t i = 0; i < CAP_HANDLE_TABLE_MAX; ++i) {
+    cap_handle_row *row = &g_rows[i];
+    if ((row->flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+      continue;
+    }
+    if (row->owner_subject != owner_subject) {
+      continue;
+    }
+    row->flags = CAP_HANDLE_FLAG_REVOKED;
+    row->generation += 1u;
+    revoked += 1u;
+  }
+  return revoked;
+}

--- a/kernel/cap/cap_handle.h
+++ b/kernel/cap/cap_handle.h
@@ -208,6 +208,22 @@ cap_result_t cap_gate_check_handle_result(cap_handle_t handle,
  */
 cap_result_t cap_handle_revoke(cap_handle_t handle);
 
+/*
+ * Bulk-revoke every live row owned by `owner_subject` (M1-CAPTBL-003,
+ * issue #239). Single pass over the global table; each matching live
+ * row is transitioned LIVE -> REVOKED with its generation bumped, so
+ * every handle previously issued for it now fails `cap_gate_check_handle`
+ * with CAP_ERR_MISSING. Returns the number of rows actually revoked
+ * (0 if the subject held none or if `owner_subject` is out of range).
+ *
+ * Best-effort by contract: there is no error code. Callers that need a
+ * detailed result use `cap_handle_revoke` on individual handles instead.
+ *
+ * Called by `kernel/proc/process.c::process_destroy` so process exit
+ * authoritatively stales every capability handle the process owned.
+ */
+uint32_t cap_handle_revoke_subject(cap_subject_id_t owner_subject);
+
 /* Test helper: pack/unpack the components of a handle. Exposed because the
  * ABI-freeze unit test exercises the layout directly. */
 cap_handle_t cap_handle_pack(uint16_t slot, uint16_t generation_low14,

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "../cap/cap_handle.h"
 #include "../../user/include/secureos_abi.h"
 
 /* Handle layout: low 16 bits = table index, high 16 bits = generation.
@@ -143,6 +144,12 @@ proc_result_t process_destroy(process_id_t pid) {
   if (slot == NULL) {
     return PROC_ERR_INVALID_PID;
   }
+  /* M1-CAPTBL-003 (#239): on process exit, bulk-revoke every capability
+   * handle owned by this PCB's subject so any stored handle issued before
+   * destroy now fails cap_gate_check_handle with CAP_ERR_MISSING. Must
+   * happen BEFORE we clear slot->subject. Best-effort; no return-value
+   * change from this function. */
+  cap_subject_id_t exiting_subject = slot->subject;
   slot->live = false;
   slot->generation = (uint16_t)(slot->generation + 1u);
   if (slot->generation == 0u) {
@@ -150,6 +157,7 @@ proc_result_t process_destroy(process_id_t pid) {
   }
   slot->subject = 0u;
   slot->aspace = NULL;
+  (void)cap_handle_revoke_subject(exiting_subject);
   return PROC_OK;
 }
 

--- a/tests/cap_handle_revoke_subject_test.c
+++ b/tests/cap_handle_revoke_subject_test.c
@@ -1,0 +1,197 @@
+/**
+ * @file cap_handle_revoke_subject_test.c
+ * @brief Unit tests for the M1-CAPTBL-003 bulk-revoke-by-owner entry
+ *        point and the process_destroy() hook that calls it (issue
+ *        #239, plan plans/2026-05-20-m1-kernel-capability-table.md).
+ *
+ * Cases:
+ *   1. Three caps granted to one owner -> cap_handle_revoke_subject
+ *      returns 3, each prior handle now denies with CAP_ERR_MISSING,
+ *      and live_count drops to 0.
+ *   2. Two owners, two caps each -> revoking owner-A leaves owner-B's
+ *      handles passing the gate; live_count reflects the half-table
+ *      state.
+ *   3. Revoke on an owner with zero live rows returns 0 (no-op).
+ *   4. Revoke on an out-of-range subject id returns 0 (bounds check).
+ *   5. Integration: process_create(subject) + cap_handle_grant(subject)
+ *      + process_destroy(pid) -> the previously-issued handle denies
+ *      with CAP_ERR_MISSING. Exercises the process.c hook end-to-end.
+ *
+ * Launched by:
+ *   build/scripts/test_cap_handle_revoke_subject.sh (registered with
+ *   build/scripts/test.sh under the `cap_handle_revoke_subject` target).
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/proc/process.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_handle_revoke_subject:%s\n", reason);
+  exit(1);
+}
+
+static void test_bulk_revoke_one_owner(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h_console = cap_handle_grant((cap_subject_id_t)2, CAP_CONSOLE_WRITE);
+  cap_handle_t h_serial  = cap_handle_grant((cap_subject_id_t)2, CAP_SERIAL_WRITE);
+  cap_handle_t h_fs      = cap_handle_grant((cap_subject_id_t)2, CAP_FS_WRITE);
+  if (h_console == CAP_HANDLE_NULL || h_serial == CAP_HANDLE_NULL || h_fs == CAP_HANDLE_NULL) {
+    fail("grant_null");
+  }
+  if (!cap_gate_check_handle(h_console, CAP_CONSOLE_WRITE) ||
+      !cap_gate_check_handle(h_serial,  CAP_SERIAL_WRITE) ||
+      !cap_gate_check_handle(h_fs,      CAP_FS_WRITE)) {
+    fail("pre_revoke_check");
+  }
+  if (cap_handle_table_live_count() != 3u) {
+    fail("pre_revoke_live_count");
+  }
+
+  uint32_t revoked = cap_handle_revoke_subject((cap_subject_id_t)2);
+  if (revoked != 3u) {
+    fail("revoke_count");
+  }
+  if (cap_handle_table_live_count() != 0u) {
+    fail("post_revoke_live_count");
+  }
+
+  if (cap_gate_check_handle_result(h_console, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("stale_handle_console");
+  }
+  if (cap_gate_check_handle_result(h_serial, CAP_SERIAL_WRITE) != CAP_ERR_MISSING) {
+    fail("stale_handle_serial");
+  }
+  if (cap_gate_check_handle_result(h_fs, CAP_FS_WRITE) != CAP_ERR_MISSING) {
+    fail("stale_handle_fs");
+  }
+
+  printf("TEST:PASS:cap_handle_revoke_subject_bulk_one_owner\n");
+}
+
+static void test_revoke_isolates_owners(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t a1 = cap_handle_grant((cap_subject_id_t)3, CAP_CONSOLE_WRITE);
+  cap_handle_t a2 = cap_handle_grant((cap_subject_id_t)3, CAP_SERIAL_WRITE);
+  cap_handle_t b1 = cap_handle_grant((cap_subject_id_t)4, CAP_CONSOLE_WRITE);
+  cap_handle_t b2 = cap_handle_grant((cap_subject_id_t)4, CAP_FS_WRITE);
+  if (a1 == CAP_HANDLE_NULL || a2 == CAP_HANDLE_NULL ||
+      b1 == CAP_HANDLE_NULL || b2 == CAP_HANDLE_NULL) {
+    fail("grant_two_owners");
+  }
+  if (cap_handle_table_live_count() != 4u) {
+    fail("two_owner_initial_live_count");
+  }
+
+  uint32_t revoked = cap_handle_revoke_subject((cap_subject_id_t)3);
+  if (revoked != 2u) {
+    fail("isolated_revoke_count");
+  }
+  if (cap_handle_table_live_count() != 2u) {
+    fail("post_isolated_live_count");
+  }
+
+  if (cap_gate_check_handle(a1, CAP_CONSOLE_WRITE) ||
+      cap_gate_check_handle(a2, CAP_SERIAL_WRITE)) {
+    fail("owner_a_handles_still_pass");
+  }
+  if (!cap_gate_check_handle(b1, CAP_CONSOLE_WRITE) ||
+      !cap_gate_check_handle(b2, CAP_FS_WRITE)) {
+    fail("owner_b_handles_did_not_survive");
+  }
+
+  printf("TEST:PASS:cap_handle_revoke_subject_isolates_owners\n");
+}
+
+static void test_revoke_no_rows(void) {
+  cap_handle_table_reset();
+
+  if (cap_handle_revoke_subject((cap_subject_id_t)5) != 0u) {
+    fail("empty_owner_nonzero");
+  }
+  /* Grant for one subject; revoke a different one. */
+  cap_handle_t h = cap_handle_grant((cap_subject_id_t)1, CAP_CONSOLE_WRITE);
+  if (h == CAP_HANDLE_NULL) {
+    fail("grant_for_other");
+  }
+  if (cap_handle_revoke_subject((cap_subject_id_t)6) != 0u) {
+    fail("other_owner_nonzero");
+  }
+  if (!cap_gate_check_handle(h, CAP_CONSOLE_WRITE)) {
+    fail("other_owner_revoke_disturbed_live_row");
+  }
+
+  printf("TEST:PASS:cap_handle_revoke_subject_no_rows\n");
+}
+
+static void test_revoke_bad_subject(void) {
+  cap_handle_table_reset();
+  /* CAP_TABLE_MAX_SUBJECTS == 8 at OS_ABI_VERSION=0. */
+  if (cap_handle_revoke_subject((cap_subject_id_t)99) != 0u) {
+    fail("out_of_range_subject_revoked_rows");
+  }
+  printf("TEST:PASS:cap_handle_revoke_subject_bad_subject\n");
+}
+
+static void test_process_destroy_revokes_caps(void) {
+  cap_handle_table_reset();
+  process_table_reset();
+
+  process_id_t pid = PID_INVALID;
+  if (process_create((cap_subject_id_t)2, NULL, &pid) != PROC_OK) {
+    fail("process_create");
+  }
+  cap_handle_t h = cap_handle_grant((cap_subject_id_t)2, CAP_CONSOLE_WRITE);
+  if (h == CAP_HANDLE_NULL) {
+    fail("integ_grant_null");
+  }
+  if (!cap_gate_check_handle(h, CAP_CONSOLE_WRITE)) {
+    fail("integ_pre_destroy_check");
+  }
+
+  if (process_destroy(pid) != PROC_OK) {
+    fail("process_destroy");
+  }
+  if (cap_gate_check_handle_result(h, CAP_CONSOLE_WRITE) != CAP_ERR_MISSING) {
+    fail("integ_post_destroy_handle_not_stale");
+  }
+  if (cap_handle_table_live_count() != 0u) {
+    fail("integ_post_destroy_live_count");
+  }
+
+  /* Re-create a fresh process for a *different* subject; its grant must
+   * not be touched by an unrelated destroy. */
+  process_id_t pid2 = PID_INVALID;
+  if (process_create((cap_subject_id_t)3, NULL, &pid2) != PROC_OK) {
+    fail("process_create_b");
+  }
+  cap_handle_t h2 = cap_handle_grant((cap_subject_id_t)3, CAP_FS_WRITE);
+  if (h2 == CAP_HANDLE_NULL) {
+    fail("integ_grant_b_null");
+  }
+  /* Destroying pid2 stales h2 but must not affect any prior subject. */
+  if (process_destroy(pid2) != PROC_OK) {
+    fail("process_destroy_b");
+  }
+  if (cap_gate_check_handle_result(h2, CAP_FS_WRITE) != CAP_ERR_MISSING) {
+    fail("integ_pid2_handle_not_stale");
+  }
+
+  printf("TEST:PASS:cap_handle_revoke_subject_process_destroy_hook\n");
+}
+
+int main(void) {
+  test_bulk_revoke_one_owner();
+  test_revoke_isolates_owners();
+  test_revoke_no_rows();
+  test_revoke_bad_subject();
+  test_process_destroy_revokes_caps();
+  printf("TEST:PASS:cap_handle_revoke_subject\n");
+  return 0;
+}


### PR DESCRIPTION
Implements **M1-CAPTBL-003** from `plans/2026-05-20-m1-kernel-capability-table.md` (closes #239).

## What landed

- **`kernel/cap/cap_handle.{c,h}`** — new `uint32_t cap_handle_revoke_subject(cap_subject_id_t owner)`. Single pass over the global table; live rows owned by `owner` transition LIVE → REVOKED with `generation` bumped, so every previously-issued handle for those rows now fails `cap_gate_check_handle` with `CAP_ERR_MISSING`. Best-effort by contract — no error code; out-of-range subject ids return `0`.
- **`kernel/proc/process.c`** — `process_destroy()` calls the new hook on the exiting slot's subject before clearing it. `PROC_OK` / `PROC_ERR_INVALID_PID` return semantics unchanged.
- **`tests/cap_handle_revoke_subject_test.c`** — 5 cases:
  1. Three caps granted to one owner → revoke returns 3, all three handles deny with `CAP_ERR_MISSING`, `live_count` drops to 0.
  2. Two owners × two caps → revoke owner-A only; owner-B handles still pass the gate.
  3. Revoke on owner with no live rows → 0.
  4. Revoke on out-of-range subject id → 0.
  5. Integration: `process_create` → `cap_handle_grant` → `process_destroy` → handle denies. Repeated with a second subject to prove isolation.
- **`build/scripts/test_cap_handle_revoke_subject.sh`** + `test.sh` / `test.ps1` wiring + `.shell_parity_allowlist` entry (PS1 peer deferred under #156).
- **`build/scripts/test_process_table.sh`** — link `cap_handle.c` too (`process.c` now references `cap_handle_revoke_subject`).
- **`docs/abi/capabilities.md`** — document the new entry point + the `process_destroy` linkage; subtree revoke / façade migration / IPC integration still scoped to -004 / -005 / -006.

## Out of scope (per plan)

- `cap_handle_revoke_subject_subtree` — M1-CAPTBL-004 (still depends on the delegation graph).
- `cap_table_*` façade migration + audit byte-identity gate — M1-CAPTBL-005. Audit fixtures stay byte-identical here (verified locally by `capability_audit` / `capability_audit_log` running clean).
- IPC sender/receiver gate plumbing — M1-CAPTBL-006.

## Local validation

```
bash build/scripts/test.sh cap_handle_revoke_subject   # PASS (6/6 markers)
bash build/scripts/test.sh cap_handle_repr             # PASS
bash build/scripts/test.sh cap_table_skeleton          # PASS
bash build/scripts/test.sh process_table               # PASS
bash build/scripts/test.sh capability_table            # PASS
bash build/scripts/test.sh capability_gate             # PASS
bash build/scripts/test.sh capability_audit            # PASS
bash build/scripts/test.sh cap_broker                  # PASS
bash build/scripts/test.sh cap_deny_marker_shape       # PASS
bash build/scripts/test.sh launcher_console            # PASS
bash build/scripts/test.sh workflow_rule               # PASS
bash build/scripts/test.sh cap_api_contract            # PASS
bash build/scripts/check_shell_parity.sh               # PARITY:OK (57 entries)
```

No IPC / audit-chain edits; no manifest / schema bump.

Follow-ups remaining from plan #197: M1-CAPTBL-004 (subtree revoke stub), M1-CAPTBL-005 (façade migration + audit byte-identity), M1-CAPTBL-006 (IPC gate plumbing).