### PR TITLE
feat(cap): reserve cap_handle_revoke_subtree stub (M1-CAPTBL-004, #241)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -33,6 +33,7 @@ test_capability_table
 test_cap_table_skeleton
 test_cap_handle_repr
 test_cap_handle_revoke_subject
+test_cap_handle_revoke_subtree
 test_process_table
 test_cert_chain
 test_codesign

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -45,6 +45,7 @@ $testScript = switch ($TestName) {
   "cap_table_skeleton" { "./build/scripts/test_cap_table_skeleton.sh" }
   "cap_handle_repr" { "./build/scripts/test_cap_handle_repr.sh" }
   "cap_handle_revoke_subject" { "./build/scripts/test_cap_handle_revoke_subject.sh" }
+  "cap_handle_revoke_subtree" { "./build/scripts/test_cap_handle_revoke_subtree.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
   "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -111,6 +111,9 @@ case "$TEST_NAME" in
     ;;
   cap_handle_revoke_subject)
     run_script "$ROOT_DIR/build/scripts/test_cap_handle_revoke_subject.sh"
+    ;;
+  cap_handle_revoke_subtree)
+    run_script "$ROOT_DIR/build/scripts/test_cap_handle_revoke_subtree.sh"
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"

--- a/build/scripts/test_cap_handle_revoke_subtree.sh
+++ b/build/scripts/test_cap_handle_revoke_subtree.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# build/scripts/test_cap_handle_revoke_subtree.sh
+#
+# Compiles and runs tests/cap_handle_revoke_subtree_test.c against the
+# M1-CAPTBL-004 reserved-symbol stub of cap_handle_revoke_subtree
+# (issue #241, plan #197).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/tests/cap_handle_revoke_subtree_test.c" \
+  -o "$OUT_DIR/cap_handle_revoke_subtree_test"
+
+LOG_PATH="$OUT_DIR/cap_handle_revoke_subtree_test.log"
+"$OUT_DIR/cap_handle_revoke_subtree_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:cap_handle_revoke_subtree_null_handle_invalid" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subtree_no_side_effects" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subtree_malformed_tag_invalid" "$LOG_PATH"
+grep -q "TEST:PASS:cap_handle_revoke_subtree$" "$LOG_PATH"

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -85,9 +85,17 @@ handle for those rows now fails the gate with `CAP_ERR_MISSING`. The
 successful destroy, making process exit the authoritative "all handles
 for this subject are stale" trigger. Bulk revoke is best-effort by
 contract (no error code; bad subject ids return `0` revoked).
-Subtree revoke (`cap_handle_revoke_subject_subtree`) is M1-CAPTBL-004,
-façade migration with byte-exact audit parity is
--005, and IPC integration is -006 — each landing as its own PR.
+Subtree revoke (`cap_handle_revoke_subtree`) is M1-CAPTBL-004 (#241):
+the symbol is declared in `kernel/cap/cap_handle.h` and **reserved at
+v0** so the M5 ownership-graph cascading-deletion work (#118) and the
+M4 broker subtree-revoke (#115) have a stable kernel symbol to compile
+against. In v0 the implementation is a deliberate stub that
+**unconditionally returns `CAP_ERR_CAP_INVALID` with zero side effects**
+— there is no graph to walk (the `parent_handle` field on
+`cap_handle_row` is reserved-and-zero today). Callers MUST NOT depend
+on subtree-revoke semantics until #118 lands the real walk. Façade
+migration with byte-exact audit parity is -005, and IPC integration is
+-006 — each landing as its own PR.
 
 ### Legacy notes
 

--- a/kernel/cap/cap_handle.c
+++ b/kernel/cap/cap_handle.c
@@ -327,3 +327,23 @@ uint32_t cap_handle_revoke_subject(cap_subject_id_t owner_subject) {
   }
   return revoked;
 }
+
+/* ----------------------------------------------------------------------
+ * M1-CAPTBL-004: reserved subtree-revoke stub (issue #241).
+ *
+ * Reserves the kernel symbol for the M5 ownership-graph cascading
+ * deletion (#118) and the M4 broker subtree-revoke (#115). v0 contract
+ * is unconditionally CAP_ERR_CAP_INVALID with zero side effects: the
+ * parent_handle field on cap_handle_row is reserved-and-zero today, so
+ * there is no graph to walk. The real implementation belongs to #118.
+ *
+ * NOTE: we intentionally do NOT validate `root_handle` here. The return
+ * code is the same for every input, and (more importantly) silently
+ * succeeding on a "valid" handle would be a footgun once #118 wires up
+ * the real walk \u2014 callers might accidentally rely on a no-op. Returning
+ * CAP_ERR_CAP_INVALID universally keeps the contract honest.
+ * --------------------------------------------------------------------*/
+cap_result_t cap_handle_revoke_subtree(cap_handle_t root_handle) {
+  (void)root_handle;
+  return CAP_ERR_CAP_INVALID;
+}

--- a/kernel/cap/cap_handle.h
+++ b/kernel/cap/cap_handle.h
@@ -224,6 +224,21 @@ cap_result_t cap_handle_revoke(cap_handle_t handle);
  */
 uint32_t cap_handle_revoke_subject(cap_subject_id_t owner_subject);
 
+/*
+ * Reserved symbol for M5 ownership-graph cascading deletion (#118) and
+ * M4 broker subtree-revoke (#115). Frozen so downstream work can compile
+ * against this symbol while the underlying cap_handle layer is still
+ * small and easy to reason about (M1-CAPTBL-004, issue #241, plan #197).
+ *
+ * v0 contract: unconditionally returns CAP_ERR_CAP_INVALID. No table
+ * mutation, no audit emission, no side effects whatsoever. Callers MUST
+ * NOT depend on subtree-revoke semantics yet — the parent_handle field
+ * on cap_handle_row is reserved-and-zero in v0, so there is no graph to
+ * walk. The real implementation is owned by #118 and may change error
+ * codes and semantics; this stub only reserves the symbol shape.
+ */
+cap_result_t cap_handle_revoke_subtree(cap_handle_t root_handle);
+
 /* Test helper: pack/unpack the components of a handle. Exposed because the
  * ABI-freeze unit test exercises the layout directly. */
 cap_handle_t cap_handle_pack(uint16_t slot, uint16_t generation_low14,

--- a/tests/cap_handle_revoke_subtree_test.c
+++ b/tests/cap_handle_revoke_subtree_test.c
@@ -1,0 +1,92 @@
+/**
+ * @file cap_handle_revoke_subtree_test.c
+ * @brief Unit tests for the M1-CAPTBL-004 reserved-symbol stub of
+ *        cap_handle_revoke_subtree (issue #241, plan
+ *        plans/2026-05-20-m1-kernel-capability-table.md).
+ *
+ * The v0 contract for cap_handle_revoke_subtree is "unconditionally
+ * returns CAP_ERR_CAP_INVALID with zero side effects". These tests
+ * prove exactly that:
+ *
+ *   1. Returns CAP_ERR_CAP_INVALID for CAP_HANDLE_NULL.
+ *   2. Returns CAP_ERR_CAP_INVALID for an otherwise-valid live handle.
+ *   3. After (2), the underlying row is still LIVE and
+ *      cap_gate_check_handle still succeeds (proves the stub did not
+ *      accidentally revoke or otherwise mutate the table).
+ *   4. Returns CAP_ERR_CAP_INVALID for a malformed-tag handle, same as
+ *      (1) \u2014 pins that the universal-failure contract is not
+ *      accidentally tag-gated.
+ *
+ * Launched by:
+ *   build/scripts/test_cap_handle_revoke_subtree.sh (registered with
+ *   build/scripts/test.sh under the `cap_handle_revoke_subtree` target).
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/capability.h"
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:cap_handle_revoke_subtree:%s\n", reason);
+  exit(1);
+}
+
+static void test_null_handle_invalid(void) {
+  cap_handle_table_reset();
+  if (cap_handle_revoke_subtree(CAP_HANDLE_NULL) != CAP_ERR_CAP_INVALID) {
+    fail("CAP_HANDLE_NULL did not return CAP_ERR_CAP_INVALID");
+  }
+  printf("TEST:PASS:cap_handle_revoke_subtree_null_handle_invalid\n");
+}
+
+static void test_live_handle_invalid_no_side_effects(void) {
+  cap_handle_table_reset();
+
+  cap_handle_t h = cap_handle_grant((cap_subject_id_t)1, (capability_id_t)1);
+  if (h == CAP_HANDLE_NULL) {
+    fail("setup: grant returned CAP_HANDLE_NULL");
+  }
+  if (!cap_gate_check_handle(h, (capability_id_t)1)) {
+    fail("setup: freshly granted handle did not pass gate");
+  }
+  uint32_t live_before = cap_handle_table_live_count();
+  if (live_before != 1u) {
+    fail("setup: expected live_count == 1 after grant");
+  }
+
+  if (cap_handle_revoke_subtree(h) != CAP_ERR_CAP_INVALID) {
+    fail("live handle did not return CAP_ERR_CAP_INVALID");
+  }
+
+  /* No side effects: row is still LIVE, gate still passes, live_count
+   * unchanged. */
+  if (!cap_gate_check_handle(h, (capability_id_t)1)) {
+    fail("handle was unexpectedly stale after stub call");
+  }
+  if (cap_handle_table_live_count() != live_before) {
+    fail("live_count changed across stub call");
+  }
+  printf("TEST:PASS:cap_handle_revoke_subtree_no_side_effects\n");
+}
+
+static void test_malformed_tag_invalid(void) {
+  cap_handle_table_reset();
+  /* Tag 0b11 is reserved-and-invalid in v0. */
+  cap_handle_t bad = cap_handle_pack(/*slot=*/0u, /*generation_low14=*/0u,
+                                     /*tag=*/0x3u);
+  if (cap_handle_revoke_subtree(bad) != CAP_ERR_CAP_INVALID) {
+    fail("malformed-tag handle did not return CAP_ERR_CAP_INVALID");
+  }
+  printf("TEST:PASS:cap_handle_revoke_subtree_malformed_tag_invalid\n");
+}
+
+int main(void) {
+  test_null_handle_invalid();
+  test_live_handle_invalid_no_side_effects();
+  test_malformed_tag_invalid();
+  printf("TEST:PASS:cap_handle_revoke_subtree\n");
+  return 0;
+}


### PR DESCRIPTION
Implements **M1-CAPTBL-004** from plan `plans/2026-05-20-m1-kernel-capability-table.md` (#197). Closes #241 on merge.

## Summary

Reserves the kernel symbol `cap_handle_revoke_subtree` at `OS_ABI_VERSION=0` so the M5 ownership-graph cascading-deletion work (#118) and the M4 broker subtree-revoke (#115) have a stable kernel symbol to compile against while the cap_handle layer is still small and easy to reason about.

The v0 contract is intentionally a stub: **unconditionally returns `CAP_ERR_CAP_INVALID` with zero side effects**. The `parent_handle` field on `cap_handle_row` is reserved-and-zero today, so there is no graph to walk; the real implementation belongs to #118.

Why "always invalid", even for an otherwise-valid live handle? Silently no-op'ing on a valid handle would be a footgun once #118 wires up the real walk — callers might accidentally start depending on the no-op. Returning `CAP_ERR_CAP_INVALID` universally keeps the contract honest.

## Changes

- `kernel/cap/cap_handle.h` — declare `cap_handle_revoke_subtree(cap_handle_t)` with the v0 contract documented in a header comment.
- `kernel/cap/cap_handle.c` — stub implementation; `return CAP_ERR_CAP_INVALID;`.
- `tests/cap_handle_revoke_subtree_test.c` — 3 sub-cases:
  1. `CAP_HANDLE_NULL` → `CAP_ERR_CAP_INVALID`
  2. otherwise-valid live handle → `CAP_ERR_CAP_INVALID`, **row still LIVE**, `cap_gate_check_handle` still succeeds, `live_count` unchanged (proves zero side effects)
  3. malformed-tag handle (tag `0b11`) → `CAP_ERR_CAP_INVALID` (pins that the universal-failure contract is not tag-gated)
- `build/scripts/test_cap_handle_revoke_subtree.sh` — host wrapper.
- `build/scripts/test.sh` + `test.ps1` — new `cap_handle_revoke_subtree` dispatcher target.
- `build/scripts/.shell_parity_allowlist` — peer entry per #156.
- `docs/abi/capabilities.md` — document reserved-but-unimplemented status; warn callers not to depend on subtree-revoke semantics.

## Out of scope (deferred per plan #197)

- **M1-CAPTBL-005** — façade migration of `cap_table_grant/revoke/check` onto handles, gated by byte-exact `CAP_AUDIT:` fixture diff.
- **M1-CAPTBL-006** — IPC integration on top of `cap_gate_check_handle`.
- The actual subtree walk (owned by #118 / #115).

## Validation (host, clean checkout)

```
$ bash build/scripts/test.sh cap_handle_revoke_subtree
TEST:PASS:cap_handle_revoke_subtree_null_handle_invalid
TEST:PASS:cap_handle_revoke_subtree_no_side_effects
TEST:PASS:cap_handle_revoke_subtree_malformed_tag_invalid
TEST:PASS:cap_handle_revoke_subtree

$ bash build/scripts/test.sh cap_handle_repr            # PASS (unchanged)
$ bash build/scripts/test.sh cap_handle_revoke_subject  # PASS (unchanged)
$ bash build/scripts/test.sh cap_table_skeleton         # PASS (unchanged)
$ bash build/scripts/test.sh capability_table           # PASS (unchanged)
$ bash build/scripts/test.sh capability_audit           # PASS (byte-identical)
$ bash build/scripts/test.sh abi_version                # PASS (anchor)
$ bash build/scripts/test.sh parity                     # PASS (58 entries)
```

## Follow-ups

- File / pick up **M1-CAPTBL-005** (façade migration on top of the handle layer, gated by the byte-exact `CAP_AUDIT:` fixture-diff regression test).
- File / pick up **M1-CAPTBL-006** (IPC integration: `ipc_send` / `ipc_recv` consume handles via `cap_gate_check_handle`).
- When #118 lands the real subtree walk, it will replace the stub body — this PR pins the symbol shape so that change is a one-file body swap, not an ABI break.

Refs #241 · plan #197 · related #115 #118
