### PR TITLE
test(cap): byte-exact CAP_AUDIT fixture-diff (M1-CAPTBL-005, closes #243)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -27,6 +27,7 @@ test_cap_api_contract
 test_cap_broker
 test_cap_deny_marker_shape
 test_capability_audit
+test_capability_audit_fixture
 test_capability_audit_log
 test_capability_gate
 test_capability_table

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -48,6 +48,7 @@ $testScript = switch ($TestName) {
   "cap_handle_revoke_subtree" { "./build/scripts/test_cap_handle_revoke_subtree.sh" }
   "capability_gate" { "./build/scripts/test_capability_gate.sh" }
   "capability_audit" { "./build/scripts/test_capability_audit.sh" }
+  "capability_audit_fixture" { "./build/scripts/test_capability_audit_fixture.sh" }
   "cap_deny_marker_shape" { "./build/scripts/test_cap_deny_marker_shape.sh" }
   "event_bus" { "./build/scripts/test_event_bus.sh" }
   "scheduler" { "./build/scripts/test_scheduler.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -123,6 +123,9 @@ case "$TEST_NAME" in
     ;;
   capability_audit)
     run_script "$ROOT_DIR/build/scripts/test_capability_audit.sh"
+    ;;
+  capability_audit_fixture)
+    run_script "$ROOT_DIR/build/scripts/test_capability_audit_fixture.sh"
     ;;
   capability_audit_log)
     run_script "$ROOT_DIR/build/scripts/test_capability_audit_log.sh"

--- a/build/scripts/test_capability_audit_fixture.sh
+++ b/build/scripts/test_capability_audit_fixture.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build + run the M2 console capability-audit byte-exact fixture-diff test
+# (M1-CAPTBL-005, plan plans/2026-05-20-m1-kernel-capability-table.md).
+#
+# This test pins the byte-stream emitted by the capability subsystem under a
+# representative M2 console sequence so a future migration of cap_table.{c,h}
+# onto cap_handle.{c,h} cannot silently alter the audit ABI.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/tests/capability_audit_fixture_test.c" \
+  -o "$OUT_DIR/capability_audit_fixture_test"
+
+LOG_PATH="$OUT_DIR/capability_audit_fixture_test.log"
+"$OUT_DIR/capability_audit_fixture_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:capability_audit_fixture_bytes_identical" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_fixture_reset_idempotent" "$LOG_PATH"
+grep -q "TEST:PASS:capability_audit_fixture$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -18,6 +18,7 @@ TEST_TARGETS=(
   capability_table
   capability_gate
   capability_audit
+  capability_audit_fixture
   capability_audit_log
   cap_broker
   cap_deny_marker_shape

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -154,4 +154,18 @@ Consumers may read `cap_audit_get_for_tests` / `cap_audit_count_for_tests`
 to walk the retained ring in test/validator contexts. In production the
 broker (#85) will be the single consumer.
 
+### Byte-exact audit fixture-diff (M1-CAPTBL-005)
+
+The textual serialization above is wire ABI. A representative M2 console
+sequence (grant, allow check, deny check, revoke, post-revoke deny,
+second-cap grant, re-grant, plus the three invalid-subject / one
+invalid-cap deny-class paths) is pinned byte-for-byte in
+`tests/capability_audit_fixture_test.c` and run as the
+`capability_audit_fixture` validator target. Any future migration of
+`kernel/cap/cap_table.{c,h}` onto the handle layer
+(`kernel/cap/cap_handle.{c,h}`) MUST preserve every byte of that
+fixture or fail this test loudly with a per-line diff. Updating the
+fixture is allowed only under an explicit audit-ABI bump per
+BUILD_ROADMAP §7.
+
 Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785

--- a/tests/capability_audit_fixture_test.c
+++ b/tests/capability_audit_fixture_test.c
@@ -1,0 +1,280 @@
+/**
+ * @file capability_audit_fixture_test.c
+ * @brief Byte-exact fixture-diff regression test for the M2 console
+ *        capability-audit line set (M1-CAPTBL-005, plan #197).
+ *
+ * Purpose:
+ *   Pins the exact `CAP_AUDIT:` line bytes emitted by a representative
+ *   M2 console capability sequence. The M1 kernel capability table
+ *   skeleton (#225/#231) and the 32-bit handle layer (#237) split the
+ *   capability subsystem into a row/handle store plus a thin legacy
+ *   façade. Plan acceptance #2 requires that the audit byte-stream stay
+ *   bit-identical through that migration — this file is the guard.
+ *
+ *   The fixture is intentionally legacy-API-only (cap_console_write_gate
+ *   + cap_grant_for_tests + cap_revoke_for_tests) so that any future
+ *   refactor of `cap_table.{c,h}` onto `cap_handle.{c,h}` (M1-CAPTBL-005
+ *   façade migration) must keep these lines byte-identical or fail this
+ *   test loudly with a per-line diff.
+ *
+ *   Coverage chosen to be representative without explosion:
+ *     - GRANT OK / REVOKE OK / CHECK OK (ALLOW) / CHECK MISSING (DENY)
+ *     - Invalid-subject GRANT/REVOKE/CHECK paths (the M2 launcher rejects
+ *       these upstream today, but the audit layer would emit DENY-class
+ *       outcomes if a future refactor ever bypassed the launcher guard).
+ *     - Invalid-cap-id GRANT path (same reasoning).
+ *     - Two distinct capability ids (CAP_CONSOLE_WRITE, CAP_SERIAL_WRITE)
+ *       so a typo in cap-id formatting would surface here, not just in
+ *       the cap=1-only audit_log test.
+ *
+ *   On mismatch the test prints, for each diverging line:
+ *     TEST:FAIL:capability_audit_fixture:line_mismatch:idx=N:got=...:want=...
+ *   so CI logs are self-diagnostic without needing the .log artefact.
+ *
+ * Interactions:
+ *   - kernel/cap/capability.{h,c}: audit ring + formatter under test.
+ *   - kernel/cap/cap_table.{c,h}: capability decisions feeding the ring.
+ *   - kernel/cap/cap_gate.c: cap_console_write_gate is the M2 entry point.
+ *
+ * Launched by:
+ *   build/scripts/test_capability_audit_fixture.sh, wired into
+ *   build/scripts/test.sh as the `capability_audit_fixture` target.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_gate.h"
+#include "../kernel/cap/cap_table.h"
+
+static int fail_count;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:capability_audit_fixture:%s\n", reason);
+  fail_count++;
+}
+
+/*
+ * Frozen byte-exact fixture for the M2 console + serial sequence.
+ *
+ * If a refactor of the capability subsystem changes any of these bytes
+ * (e.g. cap=1 -> cap=01, or a re-ordering of GRANT vs CHECK), the test
+ * MUST fail. Updating this fixture is allowed only when the audit ABI is
+ * explicitly bumped per BUILD_ROADMAP §7 / docs/abi/capabilities.md.
+ *
+ * Sequence (one line per emitted audit event):
+ *   0: cap_grant_for_tests(app_a=2, CAP_CONSOLE_WRITE)
+ *      -> GRANT OK / GRANTED
+ *   1: cap_console_write_gate(app_a=2, "hi", ...)
+ *      -> CHECK OK / ALLOW
+ *   2: cap_console_write_gate(app_b=3, "no", ...)
+ *      -> CHECK MISSING / DENY  (app_b never granted)
+ *   3: cap_revoke_for_tests(app_a=2, CAP_CONSOLE_WRITE)
+ *      -> REVOKE OK / REVOKED
+ *   4: cap_console_write_gate(app_a=2, "x", ...)
+ *      -> CHECK MISSING / DENY  (post-revoke deny on same subject)
+ *   5: cap_grant_for_tests(app_a=2, CAP_SERIAL_WRITE)
+ *      -> GRANT OK / GRANTED    (different cap-id, same actor)
+ *   6: cap_grant_for_tests(app_a=2, CAP_CONSOLE_WRITE)
+ *      -> GRANT OK / GRANTED    (re-grant after revoke is idempotent OK)
+ *   7: cap_grant_for_tests(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE)
+ *      -> GRANT SUBJECT_INVALID / GRANT_DENIED
+ *   8: cap_revoke_for_tests(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE)
+ *      -> REVOKE SUBJECT_INVALID / REVOKE_DENIED
+ *   9: cap_check(CAP_TABLE_MAX_SUBJECTS, CAP_CONSOLE_WRITE)
+ *      -> CHECK SUBJECT_INVALID / DENY
+ *  10: cap_grant_for_tests(app_a=2, 9999 -- invalid cap id)
+ *      -> GRANT CAP_INVALID / GRANT_DENIED
+ */
+static const char *kFixtureLines[] = {
+  "CAP_AUDIT:seq=0:op=GRANT:actor=2:subject=2:cap=1:result=OK:outcome=GRANTED",
+  "CAP_AUDIT:seq=1:op=CHECK:actor=2:subject=2:cap=1:result=OK:outcome=ALLOW",
+  "CAP_AUDIT:seq=2:op=CHECK:actor=3:subject=3:cap=1:result=MISSING:outcome=DENY",
+  "CAP_AUDIT:seq=3:op=REVOKE:actor=2:subject=2:cap=1:result=OK:outcome=REVOKED",
+  "CAP_AUDIT:seq=4:op=CHECK:actor=2:subject=2:cap=1:result=MISSING:outcome=DENY",
+  "CAP_AUDIT:seq=5:op=GRANT:actor=2:subject=2:cap=2:result=OK:outcome=GRANTED",
+  "CAP_AUDIT:seq=6:op=GRANT:actor=2:subject=2:cap=1:result=OK:outcome=GRANTED",
+  "CAP_AUDIT:seq=7:op=GRANT:actor=8:subject=8:cap=1:result=SUBJECT_INVALID:outcome=GRANT_DENIED",
+  "CAP_AUDIT:seq=8:op=REVOKE:actor=8:subject=8:cap=1:result=SUBJECT_INVALID:outcome=REVOKE_DENIED",
+  "CAP_AUDIT:seq=9:op=CHECK:actor=8:subject=8:cap=1:result=SUBJECT_INVALID:outcome=DENY",
+  "CAP_AUDIT:seq=10:op=GRANT:actor=2:subject=2:cap=9999:result=CAP_INVALID:outcome=GRANT_DENIED",
+};
+
+static const size_t kFixtureLineCount =
+    sizeof(kFixtureLines) / sizeof(kFixtureLines[0]);
+
+/* CAP_TABLE_MAX_SUBJECTS is the first out-of-range subject id. Pin it to a
+ * literal in the fixture (above) so a future bump of the max would also
+ * trip this test and force an audit-ABI review. */
+#if CAP_TABLE_MAX_SUBJECTS != 8u
+#error "Fixture assumes CAP_TABLE_MAX_SUBJECTS == 8; update fixture lines if bumped"
+#endif
+
+static void drive_fixture_sequence(void) {
+  const cap_subject_id_t app_a = 2u;
+  const cap_subject_id_t app_b = 3u;
+  size_t bytes_written = 0u;
+
+  /* seq=0 */
+  if (cap_grant_for_tests(app_a, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("grant_app_a_console_failed");
+  }
+  /* seq=1 */
+  if (cap_console_write_gate(app_a, "hi", &bytes_written) != CAP_OK) {
+    fail("console_write_app_a_allow_failed");
+  }
+  /* seq=2 */
+  if (cap_console_write_gate(app_b, "no", &bytes_written) != CAP_ERR_MISSING) {
+    fail("console_write_app_b_should_deny");
+  }
+  /* seq=3 */
+  if (cap_revoke_for_tests(app_a, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("revoke_app_a_console_failed");
+  }
+  /* seq=4 */
+  if (cap_console_write_gate(app_a, "x", &bytes_written) != CAP_ERR_MISSING) {
+    fail("console_write_app_a_post_revoke_should_deny");
+  }
+  /* seq=5 */
+  if (cap_grant_for_tests(app_a, CAP_SERIAL_WRITE) != CAP_OK) {
+    fail("grant_app_a_serial_failed");
+  }
+  /* seq=6 */
+  if (cap_grant_for_tests(app_a, CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("regrant_app_a_console_failed");
+  }
+  /* seq=7 */
+  if (cap_grant_for_tests((cap_subject_id_t)CAP_TABLE_MAX_SUBJECTS,
+                          CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("grant_invalid_subject_should_reject");
+  }
+  /* seq=8 */
+  if (cap_revoke_for_tests((cap_subject_id_t)CAP_TABLE_MAX_SUBJECTS,
+                           CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("revoke_invalid_subject_should_reject");
+  }
+  /* seq=9 */
+  if (cap_check((cap_subject_id_t)CAP_TABLE_MAX_SUBJECTS,
+                CAP_CONSOLE_WRITE) != CAP_ERR_SUBJECT_INVALID) {
+    fail("check_invalid_subject_should_reject");
+  }
+  /* seq=10 */
+  if (cap_grant_for_tests(app_a, (capability_id_t)9999) != CAP_ERR_CAP_INVALID) {
+    fail("grant_invalid_cap_id_should_reject");
+  }
+}
+
+static void test_fixture_bytes_identical(void) {
+  cap_reset_for_tests();
+  drive_fixture_sequence();
+
+  const size_t emitted = cap_audit_count_for_tests();
+  if (emitted != kFixtureLineCount) {
+    printf("TEST:FAIL:capability_audit_fixture:event_count:got=%zu:want=%zu\n",
+           emitted, kFixtureLineCount);
+    fail_count++;
+    return;
+  }
+
+  if (cap_audit_dropped_for_tests() != 0u) {
+    fail("dropped_events_nonzero");
+  }
+
+  for (size_t i = 0; i < kFixtureLineCount; ++i) {
+    cap_audit_event_t event = {0};
+    if (cap_audit_get_for_tests(i, &event) != CAP_OK) {
+      printf("TEST:FAIL:capability_audit_fixture:missing_event:idx=%zu\n", i);
+      fail_count++;
+      continue;
+    }
+
+    char line[160];
+    int n = cap_audit_format_event(&event, line, sizeof(line));
+    if (n < 0) {
+      printf("TEST:FAIL:capability_audit_fixture:format_failed:idx=%zu\n", i);
+      fail_count++;
+      continue;
+    }
+
+    if (strcmp(line, kFixtureLines[i]) != 0) {
+      printf("TEST:FAIL:capability_audit_fixture:line_mismatch:idx=%zu:got=%s:want=%s\n",
+             i, line, kFixtureLines[i]);
+      fail_count++;
+      continue;
+    }
+
+    /* Mirror the audit_log test's surfacing so CI captures the byte-exact
+     * lines under the fixture name as well. Helps a maintainer diff the
+     * two streams if a future refactor only breaks one of them. */
+    printf("AUDIT_FIXTURE:%s\n", line);
+  }
+
+  if (fail_count == 0) {
+    printf("TEST:PASS:capability_audit_fixture_bytes_identical\n");
+  }
+}
+
+/*
+ * Non-interference: replaying the same fixture twice (with cap_reset_for_tests
+ * between) must produce the same byte stream. This guards against any global
+ * counter (sequence, checkpoint, seal) leaking across resets — a regression
+ * that would silently corrupt audit logs across reboots.
+ */
+static void test_fixture_is_reset_idempotent(void) {
+  cap_reset_for_tests();
+  drive_fixture_sequence();
+
+  char first_run[kFixtureLineCount][160];
+  for (size_t i = 0; i < kFixtureLineCount; ++i) {
+    cap_audit_event_t event = {0};
+    if (cap_audit_get_for_tests(i, &event) != CAP_OK) {
+      fail("first_run_missing_event");
+      return;
+    }
+    if (cap_audit_format_event(&event, first_run[i], sizeof(first_run[i])) < 0) {
+      fail("first_run_format_failed");
+      return;
+    }
+  }
+
+  cap_reset_for_tests();
+  drive_fixture_sequence();
+
+  for (size_t i = 0; i < kFixtureLineCount; ++i) {
+    cap_audit_event_t event = {0};
+    if (cap_audit_get_for_tests(i, &event) != CAP_OK) {
+      fail("second_run_missing_event");
+      return;
+    }
+    char second[160];
+    if (cap_audit_format_event(&event, second, sizeof(second)) < 0) {
+      fail("second_run_format_failed");
+      return;
+    }
+    if (strcmp(first_run[i], second) != 0) {
+      printf("TEST:FAIL:capability_audit_fixture:reset_drift:idx=%zu:run1=%s:run2=%s\n",
+             i, first_run[i], second);
+      fail_count++;
+      return;
+    }
+  }
+
+  printf("TEST:PASS:capability_audit_fixture_reset_idempotent\n");
+}
+
+int main(void) {
+  printf("TEST:START:capability_audit_fixture\n");
+
+  test_fixture_bytes_identical();
+  test_fixture_is_reset_idempotent();
+
+  if (fail_count != 0) {
+    printf("TEST:FAIL:capability_audit_fixture:fail_count=%d\n", fail_count);
+    return 1;
+  }
+
+  printf("TEST:PASS:capability_audit_fixture\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #243. Implements M1-CAPTBL-005 from plan #197 — a byte-exact `CAP_AUDIT:` fixture-diff regression test that pins the audit byte stream across the upcoming `cap_table.{c,h}` → `cap_handle.{c,h}` façade migration.

## What landed

- **`tests/capability_audit_fixture_test.c`** — 11-line frozen fixture covering:
  - GRANT OK / CHECK ALLOW / CHECK DENY (different subject) / REVOKE OK / post-revoke CHECK DENY
  - Second-cap GRANT (`CAP_SERIAL_WRITE`) + re-grant after revoke (idempotent OK)
  - Invalid-subject GRANT / REVOKE / CHECK → `SUBJECT_INVALID` + `GRANT_DENIED` / `REVOKE_DENIED` / `DENY`
  - Invalid-cap GRANT → `CAP_INVALID` / `GRANT_DENIED`
  - Per-line `TEST:FAIL:capability_audit_fixture:line_mismatch:idx=N:got=…:want=…` on any one-byte drift.
  - Two-pass reset-idempotence guard (catches global-counter leaks across `cap_reset_for_tests`).
  - Static_assert pins `CAP_TABLE_MAX_SUBJECTS == 8` so a future bump forces an audit-ABI review.
- **`build/scripts/test_capability_audit_fixture.sh`** — validator with `TEST:PASS:capability_audit_fixture*` markers; emits `AUDIT_FIXTURE:` lines into the log so CI captures the pinned bytes.
- **`build/scripts/test.sh` / `test.ps1` / `.shell_parity_allowlist`** — `capability_audit_fixture` target wired in; `check_shell_parity.sh` reports `PARITY:OK`.
- **`build/scripts/validate_bundle.sh`** — added to `TEST_TARGETS` so every bundle run exercises it.
- **`docs/abi/capabilities.md`** — new subsection under *Audit and sequence guarantees* documents the fixture as the audit-bytes guard with the BUILD_ROADMAP §7 update-policy rule.

Pure-test / docs PR. **No `kernel/` edits.** The façade migration itself (the remaining body of plan acceptance #2) is intentionally the next PR — it will land against this regression net.

## Validation

```
bash build/scripts/test.sh capability_audit_fixture   # PASS (2/2 + AUDIT_FIXTURE markers)
bash build/scripts/test.sh capability_audit           # PASS
bash build/scripts/test.sh capability_audit_log      # PASS (unchanged)
bash build/scripts/test.sh capability_table          # PASS
bash build/scripts/test.sh capability_gate           # PASS
bash build/scripts/test.sh launcher_console          # PASS
bash build/scripts/check_shell_parity.sh             # PARITY:OK
```

## Follow-ups (out of scope here, per plan #197)

- M1-CAPTBL-005 façade migration: rewrite `cap_table.{c,h}` on top of the handle layer; this test is the byte-identity gate it must satisfy.
- M1-CAPTBL-006: IPC integration glue (`ipc_send` / `ipc_recv` via `cap_gate_check_handle`) — independent of this PR.