### PR TITLE
docs(abi): add Owner/Status/Last reviewed headers to ABI stubs (#181)

### DIFF
--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -1,5 +1,11 @@
 # SecureOS Capability ABI
 
+> **Owner:** kernel / capability subsystem
+> **Status:** draft `v0` — append-only enum, handle layer in progress (#233)
+> **Last reviewed:** 2026-05-22
+> **Applies to:** `OS_ABI_VERSION = 0`
+> **Tracking issues:** [#150](https://github.com/rwrife/SecureOS/issues/150), [#163](https://github.com/rwrife/SecureOS/issues/163), [#233](https://github.com/rwrife/SecureOS/issues/233)
+
 This document is the ABI-level summary of the capability subsystem. For
 implementation history and per-CAP-NNN deltas, see
 [`docs/architecture/CAPABILITIES.md`](../architecture/CAPABILITIES.md).

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -1,6 +1,10 @@
 # SecureOS Launcher Manifest
 
-Status: **draft, `OS_ABI_VERSION=0`**.
+> **Owner:** launcher / user-runtime
+> **Status:** draft `v0` — on-disk schema not yet load-bearing
+> **Last reviewed:** 2026-05-22
+> **Applies to:** `OS_ABI_VERSION = 0`
+> **Tracking issues:** [#82](https://github.com/rwrife/SecureOS/issues/82), [#83](https://github.com/rwrife/SecureOS/issues/83)
 
 At this milestone, the "manifest" is the in-code launcher registration
 API plus the explicit grant calls it exposes. The on-disk JSON form is

--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -1,8 +1,13 @@
 # SecureOS Syscall / User API Surface
 
-Status: **draft, `OS_ABI_VERSION=0`** — surface is still iterating. Adding new
-calls is allowed; signatures of listed calls are append-only-with-care (see
-[versioning.md](versioning.md)).
+> **Owner:** kernel / user-API
+> **Status:** draft `v0` — surface still iterating
+> **Last reviewed:** 2026-05-22
+> **Applies to:** `OS_ABI_VERSION = 0`
+> **Tracking issue:** [#93](https://github.com/rwrife/SecureOS/issues/93)
+
+Adding new calls is allowed; signatures of listed calls are
+append-only-with-care (see [versioning.md](versioning.md)).
 
 User-space applications call into the kernel through the prototypes declared
 in [`user/include/secureos_api.h`](../../user/include/secureos_api.h). On


### PR DESCRIPTION
Closes the last remaining checkbox on #181: every stub under `docs/abi/` now carries the same "Owner / Status / Last reviewed / Applies to / Tracking issue" header block already used by `docs/abi/ipc-wire.md`.

## What changed

- `docs/abi/syscalls.md` — header pointing at #93.
- `docs/abi/capabilities.md` — header pointing at #150 / #163 / #233.
- `docs/abi/manifest.md` — header pointing at #82 / #83.

The directory itself, `README.md` index, four stub files, and the top-level `README.md` link to `docs/abi/` were already landed in earlier work; this just normalizes the per-file provenance.

## Validation

- No code changed; only three markdown files touched.
- `build/scripts/validate_capability_registry.sh` still PASS (sanity check that the doc edits don't break the capability registry linter that reads under `docs/abi/`).

## Follow-ups

- #149: plan-directory reorg (intentionally deferred per #181 scope).
- #150: once the `OS_ABI_VERSION` source-of-truth lands, replace the `Applies to: OS_ABI_VERSION = 0` lines with a link to the constant.

Refs #181.