### PR TITLE
fix #246: M1-CAPTBL-006 IPC ops gated via cap_gate_check_handle

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -51,6 +51,7 @@ test_helloapp_deny
 test_https
 test_ipc_sync_v0
 test_ipc_port_lifecycle
+test_ipc_handle_gate
 test_syscall_entry_stub
 test_kernel_persistence
 test_launcher_console

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -254,6 +254,12 @@ case "$TEST_NAME" in
     # generation, stale handles are rejected, and the wrap-around
     # guard keeps IPC_PORT_INVALID unreachable.
     run_script "$ROOT_DIR/build/scripts/test_ipc_port_lifecycle.sh"
+    ;;
+  ipc_handle_gate)
+    # Issue #246 (M1-CAPTBL-006): handle-gated ipc_send_h / ipc_recv_h
+    # — allow + wrong-cap deny + stale deny + wrong-owner-on-recv deny
+    # + cap_handle_owner contract. Locks in plan #197's final slice.
+    run_script "$ROOT_DIR/build/scripts/test_ipc_handle_gate.sh"
     ;;
   syscall_entry_stub)
     # Issue #232: M1 syscall entry stub — reserved ABI vector range,

--- a/build/scripts/test_ipc_handle_gate.sh
+++ b/build/scripts/test_ipc_handle_gate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build + run the M1 handle-gated IPC tests (issue #246, M1-CAPTBL-006).
+#
+# Covers:
+#   - allow path (ipc_send_h / ipc_recv_h with valid handles)
+#   - deny path: handle for the wrong cap (CAP_CONSOLE_WRITE -> ipc_send_h)
+#   - deny path: stale handle (granted then revoked)
+#   - deny path: wrong owner on recv (handle owner != port owner)
+#   - cap_handle_owner contract: stale handle -> owner == 0
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/ipc_handle_gate_test.c" \
+  -o "$OUT_DIR/ipc_handle_gate_test"
+
+LOG_PATH="$OUT_DIR/ipc_handle_gate_test.log"
+"$OUT_DIR/ipc_handle_gate_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:ipc_handle_gate_owner_accessor" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_handle_gate_allow"          "$LOG_PATH"
+grep -q "TEST:PASS:ipc_handle_gate_deny_wrong_cap" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_handle_gate_deny_stale"     "$LOG_PATH"
+grep -q "TEST:PASS:ipc_handle_gate_deny_wrong_owner" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_handle_gate"                "$LOG_PATH"
+# Canonical deny markers per docs/abi/capability-deny-contract.md §4.
+grep -Eq "^CAP:DENY:[0-9]+:ipc_send:-$" "$LOG_PATH"
+grep -Eq "^CAP:DENY:[0-9]+:ipc_recv:-$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/test_ipc_sync_v0.sh
+++ b/build/scripts/test_ipc_sync_v0.sh
@@ -22,6 +22,7 @@ mkdir -p "$OUT_DIR"
 cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \
   "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
   "$ROOT_DIR/tests/ipc_sync_v0_test.c" \

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -44,6 +44,7 @@ TEST_TARGETS=(
     validator_report
     ipc_sync_v0
     ipc_port_lifecycle
+    ipc_handle_gate
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/kernel/cap/cap_handle.c
+++ b/kernel/cap/cap_handle.c
@@ -347,3 +347,36 @@ cap_result_t cap_handle_revoke_subtree(cap_handle_t root_handle) {
   (void)root_handle;
   return CAP_ERR_CAP_INVALID;
 }
+
+/* ----------------------------------------------------------------------
+ * M1-CAPTBL-006: kernel-trusted owner accessor (issue #246).
+ *
+ * IPC ops gated via cap_gate_check_handle need to derive the sender /
+ * receiver subject from the handle itself (spec §2.4: never trust the
+ * caller-supplied value). This helper mirrors the validation in
+ * cap_gate_check_handle_result but does not require the caller to know
+ * the cap_id up front (the IPC op resolves the port's send/recv cap
+ * separately and then re-checks the handle against it).
+ *
+ * Returns 0 for any malformed or stale handle. 0 is the reserved
+ * invalid subject id (CAP_SUBJECT_NONE in the audit ring), so callers
+ * that propagate it into envelope.sender_subject will be rejected by
+ * the existing `sender == 0 -> IPC_ERR_INVALID_MSG` guard in ipc_ops.
+ * --------------------------------------------------------------------*/
+cap_subject_id_t cap_handle_owner(cap_handle_t handle) {
+  if (cap_handle_tag(handle) != CAP_HANDLE_TAG_KERNEL) {
+    return 0u;
+  }
+  uint16_t slot = cap_handle_slot(handle);
+  if (slot >= CAP_HANDLE_TABLE_MAX) {
+    return 0u;
+  }
+  cap_handle_row *row = &g_rows[slot];
+  if ((row->flags & CAP_HANDLE_FLAG_LIVE) == 0u) {
+    return 0u;
+  }
+  if ((row->generation & CAP_HANDLE_GEN_MASK) != cap_handle_generation(handle)) {
+    return 0u;
+  }
+  return row->owner_subject;
+}

--- a/kernel/cap/cap_handle.h
+++ b/kernel/cap/cap_handle.h
@@ -239,6 +239,19 @@ uint32_t cap_handle_revoke_subject(cap_subject_id_t owner_subject);
  */
 cap_result_t cap_handle_revoke_subtree(cap_handle_t root_handle);
 
+/*
+ * Resolve a handle to its kernel-trusted owner subject. Returns 0 (the
+ * reserved invalid subject id) for any handle that would fail
+ * cap_gate_check_handle_result with CAP_ERR_CAP_INVALID or
+ * CAP_ERR_MISSING (bad tag, oob slot, dead row, stale generation). On
+ * a live row this returns `row->owner_subject` regardless of cap_id,
+ * because handle-gated callers (M1-CAPTBL-006, issue #246) need the
+ * authenticated subject *before* they know which cap to gate against.
+ *
+ * No audit emission, no table mutation, no side effects.
+ */
+cap_subject_id_t cap_handle_owner(cap_handle_t handle);
+
 /* Test helper: pack/unpack the components of a handle. Exposed because the
  * ABI-freeze unit test exercises the layout directly. */
 cap_handle_t cap_handle_pack(uint16_t slot, uint16_t generation_low14,

--- a/kernel/ipc/ipc_ops.c
+++ b/kernel/ipc/ipc_ops.c
@@ -40,6 +40,7 @@
 #include "ipc_msg.h"
 #include "ipc_port.h"
 #include "../cap/capability.h"
+#include "../cap/cap_handle.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -223,4 +224,125 @@ ipc_result_t ipc_call(cap_subject_id_t caller,
   }
 
   return ipc_recv(caller, reply_port, out_reply);
+}
+
+/* --------------------------------------------------------------------
+ * M1-CAPTBL-006 (issue #246): handle-gated send/recv.
+ *
+ * These re-use the same envelope validation, deny-marker emission, and
+ * cap_check audit-ring path as the subject-keyed legacy entry points,
+ * but the authoritative subject + capability decision both come from
+ * `cap_handle_t` instead of trusting the caller-supplied subject id.
+ *
+ * On success the staged envelope's sender_subject is the kernel-trusted
+ * owner from the handle's row — not the caller-supplied value. This is
+ * the M1 ABI obligation from docs/abi/ipc-wire.md §2.4 made enforceable
+ * without relying on test-harness discipline.
+ * --------------------------------------------------------------------*/
+ipc_result_t ipc_send_h(cap_handle_t send_handle,
+                        ipc_port_t target,
+                        const ipc_msg_v0 *msg) {
+  ipc_result_t v = validate_outbound_envelope(msg);
+  if (v != IPC_OK) {
+    return v;
+  }
+
+  capability_id_t required_send = CAP_IPC_SEND;
+  ipc_result_t pr = ipc_port_send_cap(target, &required_send);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+
+  /* Recover the kernel-trusted sender id BEFORE the gate check so the
+   * deny marker carries the same subject the audit ring will record.
+   * A malformed/stale handle has owner == 0; we still want to gate on
+   * a real subject id, so fall back to subject 0 and let the cap_check
+   * deny path handle it (its audit event will record actor_subject=0
+   * which is the canonical "unknown subject" marker). */
+  cap_subject_id_t sender = cap_handle_owner(send_handle);
+
+  /* Handle-keyed cap decision. */
+  cap_result_t hr = cap_gate_check_handle_result(send_handle, required_send);
+  if (hr != CAP_OK) {
+    /* Mirror the legacy path: drive the audit ring via cap_check so
+     * the existing CAP_AUDIT fixture diff (#243) stays byte-identical
+     * for the gated-deny case, then emit the canonical marker. */
+    (void)cap_check(sender, required_send);
+    ipc_emit_deny_marker(sender, required_send);
+    return IPC_ERR_CAP_DENIED;
+  }
+
+  /* Allow-path audit parity: also drive cap_check so the audit ring is
+   * indistinguishable from a legacy ipc_send call. The bitset table is
+   * managed by the cap_table façade today (M1-CAPTBL-005), so this
+   * second check is a pure ring side effect. */
+  (void)cap_check(sender, required_send);
+
+  /* sender == 0 should be impossible after a CAP_OK handle check
+   * (cap_handle_grant rejects subject 0 via cap_handle_subject_valid),
+   * but defend in depth: treat it as a malformed envelope per spec. */
+  if (sender == 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  ipc_msg_v0 outbound;
+  memcpy(&outbound, msg, sizeof(outbound));
+  outbound.sender_subject = sender;
+
+  return ipc_port_stage(target, &outbound);
+}
+
+ipc_result_t ipc_recv_h(cap_handle_t recv_handle,
+                        ipc_port_t self_port,
+                        ipc_msg_v0 *out_msg) {
+  if (out_msg == NULL) {
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  cap_subject_id_t owner = 0u;
+  ipc_result_t pr = ipc_port_owner(self_port, &owner);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+
+  cap_subject_id_t receiver = cap_handle_owner(recv_handle);
+  if (owner != receiver) {
+    /* Wrong-owner-on-recv: treat as CAP_IPC_RECV deny so the policy
+     * leakage surface matches the legacy ipc_recv path. */
+    ipc_emit_deny_marker(receiver, CAP_IPC_RECV);
+    return IPC_ERR_CAP_DENIED;
+  }
+
+  capability_id_t required_recv = CAP_IPC_RECV;
+  pr = ipc_port_recv_cap(self_port, &required_recv);
+  if (pr != IPC_OK) {
+    return pr;
+  }
+
+  cap_result_t hr = cap_gate_check_handle_result(recv_handle, required_recv);
+  if (hr != CAP_OK) {
+    (void)cap_check(receiver, required_recv);
+    ipc_emit_deny_marker(receiver, required_recv);
+    return IPC_ERR_CAP_DENIED;
+  }
+  (void)cap_check(receiver, required_recv);
+
+  ipc_result_t cr = ipc_port_consume(self_port, out_msg);
+  if (cr != IPC_OK) {
+    return cr;
+  }
+
+  if (out_msg->sender_subject == 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->abi_version != (uint16_t)OS_ABI_VERSION) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->flags != 0u) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  if (out_msg->payload_len > IPC_MSG_PAYLOAD_MAX) {
+    return IPC_ERR_INVALID_MSG;
+  }
+  return IPC_OK;
 }

--- a/kernel/ipc/ipc_ops.h
+++ b/kernel/ipc/ipc_ops.h
@@ -27,6 +27,7 @@
 #include "ipc_msg.h"
 #include "ipc_port.h"
 #include "../cap/capability.h"
+#include "../cap/cap_handle.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,42 @@ ipc_result_t ipc_call(cap_subject_id_t caller,
                       const ipc_msg_v0 *req,
                       ipc_port_t reply_port,
                       ipc_msg_v0 *out_reply);
+
+/* --------------------------------------------------------------------
+ * M1-CAPTBL-006 (issue #246): handle-gated IPC entry points.
+ *
+ * These sit alongside the subject-keyed `ipc_send` / `ipc_recv` above
+ * and route the capability decision through
+ * `cap_gate_check_handle(handle, required_cap)` instead of
+ * `cap_check(subject, required_cap)`. The handle's row also supplies
+ * the authenticated subject, so the caller does not get to spoof it.
+ *
+ * Same wire format, same deny vocabulary, same audit ring. The legacy
+ * `ipc_send` / `ipc_recv` paths are left intact so existing tests pass
+ * unmodified (plan #197 acceptance \#2).
+ * --------------------------------------------------------------------*/
+
+/*
+ * Handle-gated send. The kernel-trusted sender id is derived from
+ * `send_handle` (via cap_handle_owner). `send_handle` must resolve to a
+ * live row whose cap_id matches the port's send_cap; otherwise the call
+ * fails with IPC_ERR_CAP_DENIED and emits the canonical
+ * CAP:DENY:<owner>:<send_cap_name>:- marker.
+ */
+ipc_result_t ipc_send_h(cap_handle_t send_handle,
+                        ipc_port_t target,
+                        const ipc_msg_v0 *msg);
+
+/*
+ * Handle-gated receive. Mirrors ipc_recv but takes a `recv_handle`
+ * whose owner must match the port owner, and whose cap_id must match
+ * the port's recv_cap. Wrong-owner-on-recv is treated as a CAP_IPC_RECV
+ * deny (deny marker emitted) so the policy-leakage surface is identical
+ * to the legacy path.
+ */
+ipc_result_t ipc_recv_h(cap_handle_t recv_handle,
+                        ipc_port_t self_port,
+                        ipc_msg_v0 *out_msg);
 
 #ifdef __cplusplus
 }

--- a/tests/ipc_handle_gate_test.c
+++ b/tests/ipc_handle_gate_test.c
@@ -1,0 +1,249 @@
+/**
+ * @file ipc_handle_gate_test.c
+ * @brief Acceptance test for handle-gated IPC ops (M1-CAPTBL-006, issue #246).
+ *
+ * Covers the done-when bullets from issue #246:
+ *
+ *   1. Allow path: cap_handle_grant(S, CAP_IPC_SEND) -> ipc_send_h with
+ *      the resulting handle stages an envelope, and the kernel-stamped
+ *      sender_subject equals the handle's owner (not a caller-supplied
+ *      argument). Receiver uses ipc_recv_h with a CAP_IPC_RECV handle.
+ *      Emits TEST:PASS:ipc_handle_gate_allow.
+ *
+ *   2. Wrong-cap-handle path: handle granted for CAP_CONSOLE_WRITE
+ *      routed to ipc_send_h -> IPC_ERR_CAP_DENIED + canonical marker.
+ *      Emits TEST:PASS:ipc_handle_gate_deny_wrong_cap.
+ *
+ *   3. Stale-handle path: grant -> cap_handle_revoke -> re-call with
+ *      the now-stale handle -> IPC_ERR_CAP_DENIED + marker.
+ *      Emits TEST:PASS:ipc_handle_gate_deny_stale.
+ *
+ *   4. Wrong-owner-on-recv path: ipc_recv_h called with a handle whose
+ *      owner != port owner -> IPC_ERR_CAP_DENIED + marker.
+ *      Emits TEST:PASS:ipc_handle_gate_deny_wrong_owner.
+ *
+ *   5. Aggregate marker TEST:PASS:ipc_handle_gate is the harness
+ *      rollup.
+ *
+ * Launched by:
+ *   build/scripts/test_ipc_handle_gate.sh (dispatched via test.sh and
+ *   validate_bundle.sh).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:ipc_handle_gate:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  cap_reset_for_tests();
+  cap_table_reset();
+  cap_handle_table_reset();
+  ipc_port_table_reset();
+  cap_audit_reset_for_tests();
+}
+
+static void make_msg(ipc_msg_v0 *m, uint32_t tag, const char *payload) {
+  memset(m, 0, sizeof(*m));
+  m->abi_version = (uint16_t)OS_ABI_VERSION;
+  m->flags = 0u;
+  m->sender_subject = 0u;
+  m->tag = tag;
+  size_t len = strlen(payload);
+  if (len > IPC_MSG_PAYLOAD_MAX) {
+    len = IPC_MSG_PAYLOAD_MAX;
+  }
+  memcpy(m->payload, payload, len);
+  m->payload_len = (uint32_t)len;
+}
+
+static void test_allow(void) {
+  const cap_subject_id_t sender = 1u;
+  const cap_subject_id_t receiver = 2u;
+
+  reset_world();
+  /* Grant via cap_table for the legacy bitset (which the allow-path
+   * audit parity hit also touches), AND via cap_handle for the
+   * handle-keyed decision. Both layers are required because the
+   * gated path makes the handle authoritative for the decision and
+   * delegates the audit ring write to cap_check for byte-identical
+   * audit output. */
+  if (cap_table_grant(sender, CAP_IPC_SEND) != CAP_OK) {
+    die("grant_send_legacy");
+  }
+  if (cap_table_grant(receiver, CAP_IPC_RECV) != CAP_OK) {
+    die("grant_recv_legacy");
+  }
+  cap_handle_t send_h = cap_handle_grant(sender, CAP_IPC_SEND);
+  if (send_h == CAP_HANDLE_NULL) {
+    die("handle_grant_send");
+  }
+  cap_handle_t recv_h = cap_handle_grant(receiver, CAP_IPC_RECV);
+  if (recv_h == CAP_HANDLE_NULL) {
+    die("handle_grant_recv");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK
+      || port == IPC_PORT_INVALID) {
+    die("port_create");
+  }
+
+  ipc_msg_v0 out;
+  make_msg(&out, 0xC0DEu, "hello-handle-gate");
+  /* Deliberately set sender_subject to an attacker-supplied value;
+   * the handle-gated path must overwrite with the handle's owner. */
+  out.sender_subject = 0xFEEDFACEu;
+  if (ipc_send_h(send_h, port, &out) != IPC_OK) {
+    die("send_h_allow_failed");
+  }
+
+  ipc_msg_v0 in;
+  memset(&in, 0xAA, sizeof(in));
+  if (ipc_recv_h(recv_h, port, &in) != IPC_OK) {
+    die("recv_h_allow_failed");
+  }
+  if (in.sender_subject != sender) {
+    die("sender_not_handle_owner");
+  }
+  if (in.tag != 0xC0DEu) {
+    die("tag_corrupted");
+  }
+  if (in.payload_len != strlen("hello-handle-gate")) {
+    die("payload_len_corrupted");
+  }
+  if (memcmp(in.payload, "hello-handle-gate", in.payload_len) != 0) {
+    die("payload_corrupted");
+  }
+  printf("TEST:PASS:ipc_handle_gate_allow\n");
+}
+
+static void test_deny_wrong_cap(void) {
+  const cap_subject_id_t sender = 3u;
+  const cap_subject_id_t receiver = 4u;
+
+  reset_world();
+  /* Grant a non-IPC cap so the handle resolves but the cap_id check
+   * inside cap_gate_check_handle_result rejects it. */
+  cap_handle_t bad_h = cap_handle_grant(sender, CAP_CONSOLE_WRITE);
+  if (bad_h == CAP_HANDLE_NULL) {
+    die("handle_grant_console");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK) {
+    die("port_create_deny_cap");
+  }
+
+  ipc_msg_v0 m;
+  make_msg(&m, 0u, "denied-cap");
+
+  ipc_result_t r = ipc_send_h(bad_h, port, &m);
+  if (r != IPC_ERR_CAP_DENIED) {
+    die("wrong_cap_not_denied");
+  }
+  if (ipc_port_has_pending_for_tests(port)) {
+    die("envelope_leaked_on_deny");
+  }
+  printf("TEST:PASS:ipc_handle_gate_deny_wrong_cap\n");
+}
+
+static void test_deny_stale(void) {
+  const cap_subject_id_t sender = 5u;
+  const cap_subject_id_t receiver = 6u;
+
+  reset_world();
+  cap_handle_t send_h = cap_handle_grant(sender, CAP_IPC_SEND);
+  if (send_h == CAP_HANDLE_NULL) {
+    die("handle_grant_stale_setup");
+  }
+  /* Revoke makes the same numeric handle stale (generation bumped). */
+  if (cap_handle_revoke(send_h) != CAP_OK) {
+    die("handle_revoke_setup");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK) {
+    die("port_create_stale");
+  }
+
+  ipc_msg_v0 m;
+  make_msg(&m, 0u, "denied-stale");
+
+  ipc_result_t r = ipc_send_h(send_h, port, &m);
+  if (r != IPC_ERR_CAP_DENIED) {
+    die("stale_handle_not_denied");
+  }
+  if (ipc_port_has_pending_for_tests(port)) {
+    die("envelope_leaked_on_stale_deny");
+  }
+  printf("TEST:PASS:ipc_handle_gate_deny_stale\n");
+}
+
+static void test_deny_wrong_owner_on_recv(void) {
+  const cap_subject_id_t port_owner = 1u;
+  const cap_subject_id_t intruder = 2u;
+
+  reset_world();
+  /* Both subjects hold CAP_IPC_RECV via cap_handle, but only one owns
+   * the port. The handle-gated recv must reject the non-owner. */
+  cap_handle_t intruder_recv = cap_handle_grant(intruder, CAP_IPC_RECV);
+  if (intruder_recv == CAP_HANDLE_NULL) {
+    die("handle_grant_intruder_recv");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(port_owner, CAP_IPC_SEND, CAP_IPC_RECV, &port) != IPC_OK) {
+    die("port_create_owner_check");
+  }
+
+  ipc_msg_v0 in;
+  memset(&in, 0, sizeof(in));
+  ipc_result_t r = ipc_recv_h(intruder_recv, port, &in);
+  if (r != IPC_ERR_CAP_DENIED) {
+    die("wrong_owner_not_denied");
+  }
+  printf("TEST:PASS:ipc_handle_gate_deny_wrong_owner\n");
+}
+
+static void test_owner_accessor_stale_returns_zero(void) {
+  /* M1-CAPTBL-006 extends cap_handle.h with cap_handle_owner; the spec
+   * requires it returns 0 for a stale handle. Cover here so the
+   * helper carries its own contract test. */
+  reset_world();
+  cap_handle_t h = cap_handle_grant(7u, CAP_IPC_SEND);
+  if (h == CAP_HANDLE_NULL) {
+    die("owner_accessor_grant");
+  }
+  if (cap_handle_owner(h) != 7u) {
+    die("owner_accessor_live_mismatch");
+  }
+  if (cap_handle_revoke(h) != CAP_OK) {
+    die("owner_accessor_revoke");
+  }
+  if (cap_handle_owner(h) != 0u) {
+    die("owner_accessor_stale_not_zero");
+  }
+  printf("TEST:PASS:ipc_handle_gate_owner_accessor\n");
+}
+
+int main(void) {
+  test_owner_accessor_stale_returns_zero();
+  test_allow();
+  test_deny_wrong_cap();
+  test_deny_stale();
+  test_deny_wrong_owner_on_recv();
+  printf("TEST:PASS:ipc_handle_gate\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #246. Implements the final PR-shaped slice from plan #197
(`plans/2026-05-20-m1-kernel-capability-table.md`, M1-CAPTBL-006):
route the M1 sync IPC primitive's capability decision through the
capability handle layer landed by #237.

## What changed

- **`kernel/cap/cap_handle.{c,h}`** — new `cap_handle_owner(handle)`
  accessor returning the kernel-trusted owner subject for live rows
  and `0` (the reserved invalid subject id) for stale/invalid/oob
  handles. No audit emission, no table mutation.

- **`kernel/ipc/ipc_ops.{c,h}`** — new handle-gated entry points
  `ipc_send_h` / `ipc_recv_h` sit alongside the legacy
  `ipc_send` / `ipc_recv`:
  - Cap decision routes through `cap_gate_check_handle_result(handle, port_cap)`
    so a revoked handle, wrong-cap handle, or bad tag denies.
  - Sender / receiver subject is derived from the handle row, not the
    caller-supplied argument — closes the spec §2.4 spoof surface
    without test-harness discipline.
  - Wrong-owner-on-recv (handle owner ≠ port owner) maps to
    `IPC_ERR_CAP_DENIED` + canonical
    `CAP:DENY:<owner>:ipc_recv:-` marker, matching the legacy
    path's policy-leakage shape.
  - Audit ring parity: both allow and deny paths drive `cap_check`
    so audit bytes match a legacy `ipc_send` call. `cap_handle_repr`,
    `cap_handle_revoke_subject/subtree`, and
    `capability_audit_fixture` all stay green.
  - **`ipc_send` / `ipc_recv` / `ipc_call` are unchanged** so every
    existing IPC test passes without source edits (plan acceptance
    #2, façade compatibility).

- **`tests/ipc_handle_gate_test.c` +
  `build/scripts/test_ipc_handle_gate.sh`** — five sub-tests:
  1. `ipc_handle_gate_owner_accessor` — `cap_handle_owner` returns
     the subject for a live row and `0` for a revoked one.
  2. `ipc_handle_gate_allow` — `ipc_send_h` + `ipc_recv_h` round-trip;
     asserts `sender_subject` was overwritten with the handle's owner
     even though the caller put `0xFEEDFACE` in it.
  3. `ipc_handle_gate_deny_wrong_cap` — handle granted for
     `CAP_CONSOLE_WRITE` routed to `ipc_send_h` →
     `IPC_ERR_CAP_DENIED` + marker, no envelope leaks into the port.
  4. `ipc_handle_gate_deny_stale` — grant → `cap_handle_revoke` →
     same numeric handle now denies.
  5. `ipc_handle_gate_deny_wrong_owner` — `ipc_recv_h` with a handle
     whose owner ≠ port owner → deny + marker.

- **`build/scripts/test.sh`** + **`validate_bundle.sh`** + (issue
  #156) **`.shell_parity_allowlist`** wired per the standard pattern.

## Validation

Local runs (all green):

```
test.sh cap_handle_repr             → TEST:PASS:cap_handle_repr
test.sh cap_handle_revoke_subject   → TEST:PASS:cap_handle_revoke_subject
test.sh cap_handle_revoke_subtree   → TEST:PASS:cap_handle_revoke_subtree
test.sh ipc_sync_v0                 → TEST:PASS:ipc_sync_v0
test.sh ipc_port_lifecycle          → TEST:PASS:ipc_port_lifecycle
test.sh ipc_handle_gate             → TEST:PASS:ipc_handle_gate
test.sh capability_audit_fixture    → TEST:PASS:capability_audit_fixture (no audit byte drift)
test.sh cap_table_skeleton          → TEST:PASS:cap_table_skeleton
check_shell_parity.sh               → PARITY:OK
```

`ipc_sync_v0` script now also compiles `kernel/cap/cap_handle.c` because
`ipc_ops.c` newly depends on it for `cap_handle_owner` /
`cap_gate_check_handle_result`. That's the only edit to existing
scripts.

## Follow-ups

- Once callers (M2 console service, M3 fs_service launcher edges) are
  migrated to the handle-gated path, the legacy subject-keyed
  `ipc_send` / `ipc_recv` become candidates for removal. Out of scope
  here per plan acceptance #2.
- Cross-process handle import/export (when subjects live in different
  processes) is still owned by the M4 broker plan — handles are
  in-kernel-only in v0.

Filed and authored by the hourly issue-work cron (`secureos-hourly-issue-work`).
