### PR TITLE
feat(kernel/proc): M1 flat-with-bounds address_space_t + .proc_arena carve-out (#248)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -36,6 +36,7 @@ test_cap_handle_repr
 test_cap_handle_revoke_subject
 test_cap_handle_revoke_subtree
 test_process_table
+test_aspace_carve
 test_cert_chain
 test_codesign
 test_ed25519

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -117,6 +117,9 @@ case "$TEST_NAME" in
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"
+    ;;
+  aspace_carve)
+    run_script "$ROOT_DIR/build/scripts/test_aspace_carve.sh"
     ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"

--- a/build/scripts/test_aspace_carve.sh
+++ b/build/scripts/test_aspace_carve.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# build/scripts/test_aspace_carve.sh
+#
+# Build + run the M1 address-space partitioning unit test
+# (issue #248, plan plans/2026-05-20-m1-process-address-space.md
+# slice 2).
+#
+# Covers:
+#   - Equal-sized, non-overlapping, monotonically-increasing windows.
+#   - stack_top + ipc_scratch land inside each window.
+#   - pt_reserved is initialised to NULL.
+#   - ASPACE_ERR_ARENA_TOO_SMALL when per-window < aspace_window_min_bytes().
+#   - ASPACE_ERR_INVALID_ARG on NULL out / zero count.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/tests/aspace_carve_test.c" \
+  -o "$OUT_DIR/aspace_carve_test"
+
+LOG_PATH="$OUT_DIR/aspace_carve_test.log"
+"$OUT_DIR/aspace_carve_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:aspace_carve_partition_layout" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_carve_arena_too_small" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_carve_invalid_arg" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_carve_min_window_bytes" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_carve$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/arch/x86/boot/linker.ld
+++ b/kernel/arch/x86/boot/linker.ld
@@ -36,6 +36,18 @@ SECTIONS
     *(.bss .bss.*)
   }
 
+  /* M1 process arena (issue #248, plan plans/2026-05-20-m1-process-address-space.md
+   * slice 2). 1 MiB BSS-resident region carved into per-process windows at
+   * boot by the cooperative-scheduler slice via aspace_partition(). Page-
+   * aligned so the partitioning helper's 16-byte stack alignment is
+   * preserved across windows. Symbols __proc_arena_start / __proc_arena_end
+   * give the kernel C side stable anchors. */
+  .proc_arena : ALIGN(4K) {
+    __proc_arena_start = .;
+    . = . + 1M;
+    __proc_arena_end = .;
+  }
+
   /DISCARD/ : {
     *(.comment)
     *(.note*)

--- a/kernel/proc/address_space.c
+++ b/kernel/proc/address_space.c
@@ -1,0 +1,87 @@
+/**
+ * @file address_space.c
+ * @brief M1 flat-with-bounds address-space partitioning (issue #248).
+ *
+ * Purpose:
+ *   Implements `aspace_partition`, the pure deterministic helper that
+ *   carves a kernel-reserved arena into N equal-sized address-space
+ *   windows. Each window's high `PROC_KSTACK_BYTES` are the kernel
+ *   stack and its first `IPC_MSG_PAYLOAD_MAX` bytes back the per-
+ *   process IPC envelope scratch.
+ *
+ *   No global state, no allocation. Callers (the cooperative
+ *   scheduler in plan #198 slice 3 will be the first) supply the
+ *   arena bounds and the output array. The function refuses to
+ *   produce a partition where a window would be smaller than the
+ *   stack + scratch fixed cost.
+ *
+ *   Per-window size is the arena size divided by the window count,
+ *   floored to a 16-byte multiple so `stack_top` and `base` keep
+ *   16-byte alignment regardless of the (already page-aligned) arena
+ *   base.
+ *
+ * Interactions:
+ *   - address_space.h: public interface.
+ *   - kernel/ipc/ipc_msg.h: source of `IPC_MSG_PAYLOAD_MAX`.
+ *
+ * Launched by:
+ *   Not a standalone process. Linked into the kernel image and into
+ *   the host-side `aspace_carve` unit-test binary.
+ *
+ * Issue: #248.
+ */
+
+#include "address_space.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../ipc/ipc_msg.h"
+
+/*
+ * Per-window minimum: kernel stack + at least IPC_MSG_PAYLOAD_MAX of
+ * scratch (the scratch lives at the low end of the window, the stack
+ * at the high end). A 16-byte safety margin keeps stack_top alignable.
+ */
+#define ASPACE_ALIGN 16u
+
+static size_t aspace_window_align_down(size_t value) {
+  return value & ~(size_t)(ASPACE_ALIGN - 1u);
+}
+
+size_t aspace_window_min_bytes(void) {
+  /* Both regions plus one alignment slot of padding. */
+  size_t need = (size_t)PROC_KSTACK_BYTES + (size_t)IPC_MSG_PAYLOAD_MAX
+                + (size_t)ASPACE_ALIGN;
+  return aspace_window_align_down(need + (ASPACE_ALIGN - 1u));
+}
+
+aspace_result_t aspace_partition(uintptr_t arena_base,
+                                 size_t arena_size,
+                                 address_space_t *out,
+                                 size_t count) {
+  if (out == NULL || count == 0u) {
+    return ASPACE_ERR_INVALID_ARG;
+  }
+
+  /* Floor per-window size to ASPACE_ALIGN so successive `base` values
+   * stay aligned (assuming arena_base is itself aligned, which the
+   * linker script guarantees via ALIGN(4K)). */
+  size_t per = arena_size / count;
+  per = aspace_window_align_down(per);
+
+  if (per < aspace_window_min_bytes()) {
+    return ASPACE_ERR_ARENA_TOO_SMALL;
+  }
+
+  for (size_t i = 0; i < count; ++i) {
+    uintptr_t base = arena_base + (uintptr_t)(per * i);
+    out[i].base        = base;
+    out[i].size        = per;
+    out[i].stack_top   = base + (uintptr_t)per;
+    out[i].ipc_scratch = (uint8_t *)base;
+    out[i].pt_reserved = NULL;
+  }
+
+  return ASPACE_OK;
+}

--- a/kernel/proc/address_space.h
+++ b/kernel/proc/address_space.h
@@ -1,0 +1,131 @@
+/**
+ * @file address_space.h
+ * @brief M1 flat-with-bounds address_space_t + arena partitioning helper
+ *        (issue #248, plan plans/2026-05-20-m1-process-address-space.md
+ *        slice 2).
+ *
+ * Purpose:
+ *   Lands the concrete `address_space_t` shape that the M1 plan reserved
+ *   as an opaque pointer in #224. Each address space describes a single
+ *   contiguous `[base, base+size)` window carved out of a kernel-reserved
+ *   `.proc_arena` BSS region (see kernel/arch/x86/boot/linker.ld). The
+ *   high `PROC_KSTACK_BYTES` of each window are the per-process kernel
+ *   stack (top = `stack_top`); the low `IPC_MSG_PAYLOAD_MAX` bytes back
+ *   the per-process IPC envelope scratch buffer (`ipc_scratch`).
+ *
+ *   `aspace_partition` is deterministic and pure: given an arena
+ *   `[base, base+size)` and a window count, it produces `count`
+ *   non-overlapping, equal-sized address spaces in caller-provided
+ *   storage. No global state, no allocation. The cooperative scheduler
+ *   slice (plan #198 slice 3) is the first caller that will wire this
+ *   to `__proc_arena_start` / `__proc_arena_end` from boot.
+ *
+ *   What this slice DOES NOT do (explicit non-asks):
+ *     - No MMU enforcement, no page-table construction. `pt_reserved`
+ *       is the forward-compat hook for the M2 paging slice and is
+ *       always initialised to NULL here.
+ *     - No coupling to `process_t`. `process_create` continues to
+ *       store whatever `address_space_t *` the caller passes; wiring
+ *       `proc_init` to consume partitioned slots lands with slice 3.
+ *     - No syscall or IPC surface change. `IPC_MSG_PAYLOAD_MAX` is
+ *       consumed by reference only.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_msg.h: source of `IPC_MSG_PAYLOAD_MAX` (#220).
+ *   - kernel/proc/process.h: keeps `address_space_t` as an opaque
+ *     pointer; this header completes the struct definition.
+ *   - kernel/arch/x86/boot/linker.ld: defines the `.proc_arena`
+ *     section + `__proc_arena_start` / `__proc_arena_end` anchors.
+ *
+ * Launched by:
+ *   Not a standalone process. Header consumed by the kernel image and
+ *   the host-side `aspace_carve` unit-test binary.
+ *
+ * Issue: #248. Plan: plans/2026-05-20-m1-process-address-space.md.
+ */
+
+#ifndef SECUREOS_KERNEL_PROC_ADDRESS_SPACE_H
+#define SECUREOS_KERNEL_PROC_ADDRESS_SPACE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Per-process kernel-stack size. Matches the value called out in the
+ * plan ("fixed 16 KiB"). Kept as a kernel-internal constant — not part
+ * of the user/kernel ABI surface, so adjusting it does NOT require an
+ * OS_ABI_VERSION bump.
+ */
+#define PROC_KSTACK_BYTES (16u * 1024u)
+
+/*
+ * Total bytes reserved for the process arena in the kernel image.
+ * The linker script (kernel/arch/x86/boot/linker.ld) carves out a
+ * `.proc_arena` BSS region of exactly this size, page-aligned, and
+ * exposes `__proc_arena_start` / `__proc_arena_end` for the scheduler
+ * slice to feed into `aspace_partition`.
+ */
+#define PROC_ARENA_BYTES (1u * 1024u * 1024u)
+
+/*
+ * Concrete address-space shape. Field order is part of the v0
+ * contract — tests pin sizeof/offsetof in aspace_carve_test.c. New
+ * fields go at the end.
+ */
+typedef struct address_space {
+  uintptr_t  base;         /* low end of the bounds window (inclusive) */
+  size_t     size;         /* total bytes in the window */
+  uintptr_t  stack_top;    /* top of the per-process kernel stack */
+  uint8_t   *ipc_scratch;  /* IPC_MSG_PAYLOAD_MAX bytes, inside [base,base+size) */
+  void      *pt_reserved;  /* page-table handle slot, reserved for M2+ */
+} address_space_t;
+
+/*
+ * Result vocabulary. Distinct enum keeps callers from accidentally
+ * merging an aspace error into a proc/ipc/cap switch.
+ */
+typedef enum {
+  ASPACE_OK = 0,
+  ASPACE_ERR_INVALID_ARG = 1,
+  ASPACE_ERR_ARENA_TOO_SMALL = 2,
+} aspace_result_t;
+
+/*
+ * Minimum bytes per window. The kernel stack and IPC scratch must
+ * both fit, and the layout requires `stack_top` to live inside the
+ * window. Exposed for tests and the partitioning helper.
+ */
+size_t aspace_window_min_bytes(void);
+
+/*
+ * Deterministically partition `[arena_base, arena_base + arena_size)`
+ * into `count` non-overlapping, equal-sized windows and populate
+ * `out[0 .. count-1]`. All fields are initialised:
+ *   - base       : arena_base + i * per_window_size
+ *   - size       : per_window_size (== arena_size / count, rounded down
+ *                  to a multiple of 16 so stack_top stays aligned)
+ *   - stack_top  : base + size  (top-of-stack, grows downward)
+ *   - ipc_scratch: (uint8_t *) base
+ *   - pt_reserved: NULL
+ *
+ * Returns:
+ *   ASPACE_OK                 - all `count` windows initialised.
+ *   ASPACE_ERR_INVALID_ARG    - out == NULL || count == 0.
+ *   ASPACE_ERR_ARENA_TOO_SMALL- per_window_size < aspace_window_min_bytes().
+ *
+ * On any error the contents of `out` are unspecified.
+ */
+aspace_result_t aspace_partition(uintptr_t arena_base,
+                                 size_t arena_size,
+                                 address_space_t *out,
+                                 size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_PROC_ADDRESS_SPACE_H */

--- a/tests/aspace_carve_test.c
+++ b/tests/aspace_carve_test.c
@@ -1,0 +1,150 @@
+/**
+ * @file aspace_carve_test.c
+ * @brief Host-side unit tests for kernel/proc/address_space.c
+ *        (issue #248, plan #198 slice 2).
+ *
+ * Covers the invariants spelled out in the issue:
+ *
+ *   1. Partitioning a 1 MiB-class arena into N windows yields N
+ *      non-overlapping, equal-sized address spaces with strictly
+ *      increasing `base`, every `stack_top` inside its own window,
+ *      every `ipc_scratch` inside its own window, and `pt_reserved`
+ *      always NULL.
+ *   2. Arena too small for the requested count → ASPACE_ERR_ARENA_TOO_SMALL.
+ *   3. NULL `out` or zero `count` → ASPACE_ERR_INVALID_ARG.
+ *   4. Field-order / size invariants on `address_space_t` are pinned via
+ *      compile-time `_Static_assert`s so future struct churn is loud.
+ *
+ * Launched by:
+ *   build/scripts/test_aspace_carve.sh (dispatched via
+ *   build/scripts/test.sh aspace_carve).
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/proc/address_space.h"
+#include "../kernel/ipc/ipc_msg.h"
+
+/* Layout freeze: any reorder is a deliberate v0 ABI-of-record change. */
+_Static_assert(offsetof(address_space_t, base) == 0,
+               "address_space_t.base must be the first field");
+_Static_assert(offsetof(address_space_t, size) > offsetof(address_space_t, base),
+               "address_space_t.size must follow .base");
+_Static_assert(offsetof(address_space_t, stack_top) > offsetof(address_space_t, size),
+               "address_space_t.stack_top must follow .size");
+_Static_assert(offsetof(address_space_t, ipc_scratch) > offsetof(address_space_t, stack_top),
+               "address_space_t.ipc_scratch must follow .stack_top");
+_Static_assert(offsetof(address_space_t, pt_reserved) > offsetof(address_space_t, ipc_scratch),
+               "address_space_t.pt_reserved must follow .ipc_scratch");
+
+static int g_fail = 0;
+
+#define CHECK(cond, name) do { \
+  if (!(cond)) { \
+    fprintf(stderr, "TEST:FAIL:%s\n", (name)); \
+    g_fail = 1; \
+  } \
+} while (0)
+
+/* A simple backing buffer "arena" sitting in the host process address
+ * space — the partitioner only manipulates the [base,base+size) triple,
+ * it never dereferences ipc_scratch, so this is fine for unit tests. */
+static uint8_t g_arena[1u * 1024u * 1024u];
+
+static void test_partition_layout_invariants(void) {
+  const size_t N = 4u;
+  address_space_t spaces[8];
+  memset(spaces, 0xCC, sizeof(spaces));
+
+  aspace_result_t r = aspace_partition((uintptr_t)g_arena,
+                                       sizeof(g_arena),
+                                       spaces,
+                                       N);
+  CHECK(r == ASPACE_OK, "aspace_partition_ok_returned");
+
+  size_t per = spaces[0].size;
+  CHECK(per >= aspace_window_min_bytes(), "aspace_partition_window_min");
+
+  for (size_t i = 0; i < N; ++i) {
+    CHECK(spaces[i].size == per, "aspace_partition_equal_size");
+    CHECK(spaces[i].base == (uintptr_t)g_arena + per * i,
+          "aspace_partition_base_progression");
+    CHECK(spaces[i].stack_top == spaces[i].base + per,
+          "aspace_partition_stack_top_inside");
+    CHECK(spaces[i].ipc_scratch == (uint8_t *)spaces[i].base,
+          "aspace_partition_scratch_inside");
+    CHECK(spaces[i].pt_reserved == NULL, "aspace_partition_pt_reserved_null");
+
+    if (i > 0) {
+      CHECK(spaces[i].base > spaces[i - 1].base,
+            "aspace_partition_base_monotonic");
+      CHECK(spaces[i].base >= spaces[i - 1].stack_top
+            || spaces[i - 1].stack_top <= spaces[i].base,
+            "aspace_partition_no_overlap");
+    }
+  }
+
+  /* Slots beyond N must remain untouched (sentinel 0xCC). */
+  const uint8_t *raw = (const uint8_t *)&spaces[N];
+  CHECK(raw[0] == 0xCC, "aspace_partition_no_overrun");
+
+  printf("TEST:PASS:aspace_carve_partition_layout\n");
+}
+
+static void test_arena_too_small(void) {
+  /* Force per-window size below aspace_window_min_bytes(). Asking for
+   * many windows out of a small arena triggers the floor check. */
+  address_space_t spaces[4];
+  aspace_result_t r = aspace_partition((uintptr_t)g_arena,
+                                       /* arena_size = */ 256u,
+                                       spaces,
+                                       /* count = */ 4u);
+  CHECK(r == ASPACE_ERR_ARENA_TOO_SMALL,
+        "aspace_carve_arena_too_small_rejects");
+  printf("TEST:PASS:aspace_carve_arena_too_small\n");
+}
+
+static void test_invalid_arg(void) {
+  address_space_t spaces[2];
+
+  aspace_result_t r1 = aspace_partition((uintptr_t)g_arena,
+                                        sizeof(g_arena),
+                                        NULL,
+                                        2u);
+  CHECK(r1 == ASPACE_ERR_INVALID_ARG, "aspace_carve_null_out_rejects");
+
+  aspace_result_t r2 = aspace_partition((uintptr_t)g_arena,
+                                        sizeof(g_arena),
+                                        spaces,
+                                        0u);
+  CHECK(r2 == ASPACE_ERR_INVALID_ARG, "aspace_carve_zero_count_rejects");
+
+  printf("TEST:PASS:aspace_carve_invalid_arg\n");
+}
+
+static void test_min_window_bytes(void) {
+  /* Sanity: minimum window must accommodate both stack and scratch. */
+  size_t min = aspace_window_min_bytes();
+  CHECK(min >= (size_t)PROC_KSTACK_BYTES + (size_t)IPC_MSG_PAYLOAD_MAX,
+        "aspace_carve_min_covers_stack_and_scratch");
+  printf("TEST:PASS:aspace_carve_min_window_bytes\n");
+}
+
+int main(void) {
+  test_min_window_bytes();
+  test_partition_layout_invariants();
+  test_arena_too_small();
+  test_invalid_arg();
+
+  if (g_fail) {
+    fprintf(stderr, "TEST:FAIL:aspace_carve\n");
+    return EXIT_FAILURE;
+  }
+  printf("TEST:PASS:aspace_carve\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes #248.

Slice 2 of plan `plans/2026-05-20-m1-process-address-space.md` (#198). Slices 1 (PCB table, #224 / #238) and 5 (syscall entry stub, #232 / #235) already merged; this PR fills the address-space half so the upcoming cooperative-scheduler slice (3) has somewhere to swap stacks to.

## What landed

- **`kernel/proc/address_space.{c,h}`** — concrete `address_space_t` shape (`base` / `size` / `stack_top` / `ipc_scratch` / `pt_reserved`) matching the plan §"Address-space representation" verbatim. Field order pinned via `offsetof` static_asserts.
- **`aspace_partition()`** — pure deterministic helper. Carves `[arena_base, arena_base+arena_size)` into N equal-sized, non-overlapping windows. Per-window size is floored to 16 bytes so `stack_top` stays aligned regardless of arena base. Returns `ASPACE_ERR_ARENA_TOO_SMALL` if per-window < stack + scratch + alignment slack, `ASPACE_ERR_INVALID_ARG` on NULL out / count==0. No global state, no allocation, kernel-internal only.
- **`kernel/arch/x86/boot/linker.ld`** — new `.proc_arena` BSS section (1 MiB, page-aligned) with `__proc_arena_start` / `__proc_arena_end` anchors. Slice 3 will wire `proc_init` to feed these into `aspace_partition`.
- **`tests/aspace_carve_test.c` + `build/scripts/test_aspace_carve.sh`** — covers all four done-when invariants:
  - equal-size + monotonic-base + no-overlap + `stack_top` inside window + `ipc_scratch` inside window + `pt_reserved == NULL`;
  - arena-too-small → `ASPACE_ERR_ARENA_TOO_SMALL`;
  - NULL out / zero count → `ASPACE_ERR_INVALID_ARG`;
  - `aspace_window_min_bytes()` covers stack + scratch;
  - emits `TEST:PASS:aspace_carve` summary + per-case markers.
- **`build/scripts/test.sh`** — new `aspace_carve` target dispatched via the defensive `run_script` harness (#91).
- **`build/scripts/.shell_parity_allowlist`** — adds `test_aspace_carve` to the `.sh`-only allowlist matching the existing `test_process_table` pattern (#156 phased rollout). Drop the entry when the PowerShell peer lands.

## Scope held (explicit non-asks per #248)

- `process_t.aspace` / `process_create` unchanged. Wiring `proc_init` to consume partitioned slots is the slice-3 cooperative-scheduler issue.
- No MMU enforcement / no page tables. `pt_reserved` is the M2+ forward-compat hook, always initialised to NULL.
- No IPC or syscall ABI changes; `IPC_MSG_PAYLOAD_MAX` is consumed by reference only.
- `validate_bundle.sh TEST_TARGETS` not modified — consistent with the existing `process_table` slice (#129 / #224 pattern; opt-in once a follow-up confirms stability).

## Validation (local, Linux toolchain)

```
$ bash build/scripts/test.sh aspace_carve
TEST:PASS:aspace_carve_min_window_bytes
TEST:PASS:aspace_carve_partition_layout
TEST:PASS:aspace_carve_arena_too_small
TEST:PASS:aspace_carve_invalid_arg
TEST:PASS:aspace_carve

$ bash build/scripts/test.sh process_table     # untouched
TEST:PASS:process_table

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 61 entries)
```

## Follow-ups (deliberately out of scope)

- Slice 3: cooperative scheduler + `proc_yield` + context switch; first caller of `aspace_partition(__proc_arena_start, ...)`.
- Slice 4: two-module IPC demo + allow/deny acceptance harness.
- PowerShell parity peer for `test_aspace_carve` (retire allowlist entry).
- Bundle inclusion (`TEST_TARGETS`) once a stability window has elapsed, same as `process_table`.

— secureos-hourly-issue-work cron, run `e4c62e32`, 2026-05-23 02:31 UTC