### PR TITLE
fix #250: cooperative scheduler + IPC block/wake (M1 plan #198 slice 3)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -36,6 +36,7 @@ test_cap_handle_repr
 test_cap_handle_revoke_subject
 test_cap_handle_revoke_subtree
 test_process_table
+test_proc_sched
 test_aspace_carve
 test_cert_chain
 test_codesign

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -69,6 +69,7 @@ $testScript = switch ($TestName) {
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
   "process_table" { "./build/scripts/test_process_table.sh" }
+  "proc_sched" { "./build/scripts/test_proc_sched.sh" }
   "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
   "validate_capability_registry" { "./build/scripts/validate_capability_registry.sh" }
   "capability_registry_drift" { "./tests/harness/capability_registry_drift_test.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -117,6 +117,9 @@ case "$TEST_NAME" in
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"
+    ;;
+  proc_sched)
+    run_script "$ROOT_DIR/build/scripts/test_proc_sched.sh"
     ;;
   aspace_carve)
     run_script "$ROOT_DIR/build/scripts/test_aspace_carve.sh"

--- a/build/scripts/test_ipc_handle_gate.sh
+++ b/build/scripts/test_ipc_handle_gate.sh
@@ -22,6 +22,8 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \
   "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
   "$ROOT_DIR/tests/ipc_handle_gate_test.c" \

--- a/build/scripts/test_ipc_sync_v0.sh
+++ b/build/scripts/test_ipc_sync_v0.sh
@@ -23,6 +23,8 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \
   "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
   "$ROOT_DIR/tests/ipc_sync_v0_test.c" \

--- a/build/scripts/test_proc_sched.sh
+++ b/build/scripts/test_proc_sched.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build + run the M1 cooperative scheduler + IPC block/wake acceptance
+# test (issue #250, plan plans/2026-05-20-m1-process-address-space.md
+# slice 3).
+#
+# Covers:
+#   - Single-PCB dispatch + exit_code recording.
+#   - Two-PCB cooperative yield interleave (round-robin).
+#   - ipc_recv blocks until matching ipc_send wakes the waiter; payload
+#     and kernel-stamped sender_subject reach the receiver intact.
+#   - ipc_send blocks on a full single-waiter slot until the receiver
+#     consumes the staged envelope.
+#   - Deadlock detection: PROC_SCHED_ERR_DEADLOCK instead of hang when
+#     every live PCB is BLOCKED.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/proc_sched_test.c" \
+  -o "$OUT_DIR/proc_sched_test"
+
+LOG_PATH="$OUT_DIR/proc_sched_test.log"
+"$OUT_DIR/proc_sched_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:proc_sched_single_dispatch"          "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_round_robin"              "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_recv_blocks_until_send"   "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_send_blocks_on_full"      "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_deadlock_detected"        "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched$"                         "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -45,6 +45,7 @@ TEST_TARGETS=(
     ipc_sync_v0
     ipc_port_lifecycle
     ipc_handle_gate
+    proc_sched
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/kernel/ipc/ipc_ops.c
+++ b/kernel/ipc/ipc_ops.c
@@ -41,9 +41,69 @@
 #include "ipc_port.h"
 #include "../cap/capability.h"
 #include "../cap/cap_handle.h"
+#include "../proc/proc_sched.h"
 
 #include <stdio.h>
 #include <string.h>
+
+/* ------------------------------------------------------------------
+ * Slice-3 (#250) block/wake helpers.
+ *
+ * When the cooperative scheduler is driving execution, an occupied
+ * single-waiter slot on send (or an empty slot on recv) must suspend
+ * the current PCB until the peer half of the rendezvous arrives.
+ *
+ * When NO scheduler is active (the pre-#250 in-kernel-only test
+ * harness shape), we fall through to the v0 ordering-driven semantics:
+ * stage_on_full -> IPC_ERR_PEER_GONE and consume_on_empty ->
+ * IPC_ERR_PEER_GONE. This keeps ipc_sync_v0 / ipc_handle_gate /
+ * ipc_port_lifecycle green without changes.
+ * ------------------------------------------------------------------ */
+static ipc_result_t ipc_stage_blocking(ipc_port_t target, const ipc_msg_v0 *outbound) {
+  for (;;) {
+    ipc_result_t sr = ipc_port_stage(target, outbound);
+    if (sr != IPC_ERR_PEER_GONE || !proc_sched_is_active()) {
+      if (sr == IPC_OK) {
+        const void *tok = ipc_port_wait_token(target);
+        if (tok != NULL) {
+          (void)proc_sched_wake_one_on_port(tok);
+        }
+      }
+      return sr;
+    }
+    const void *tok = ipc_port_wait_token(target);
+    if (tok == NULL) {
+      return IPC_ERR_INVALID_PORT;
+    }
+    proc_sched_result_t br = proc_sched_block_current_on_port(tok);
+    if (br != PROC_SCHED_OK) {
+      return IPC_ERR_PEER_GONE;
+    }
+  }
+}
+
+static ipc_result_t ipc_consume_blocking(ipc_port_t self_port, ipc_msg_v0 *out_msg) {
+  for (;;) {
+    ipc_result_t cr = ipc_port_consume(self_port, out_msg);
+    if (cr != IPC_ERR_PEER_GONE || !proc_sched_is_active()) {
+      if (cr == IPC_OK) {
+        const void *tok = ipc_port_wait_token(self_port);
+        if (tok != NULL) {
+          (void)proc_sched_wake_one_on_port(tok);
+        }
+      }
+      return cr;
+    }
+    const void *tok = ipc_port_wait_token(self_port);
+    if (tok == NULL) {
+      return IPC_ERR_INVALID_PORT;
+    }
+    proc_sched_result_t br = proc_sched_block_current_on_port(tok);
+    if (br != PROC_SCHED_OK) {
+      return IPC_ERR_PEER_GONE;
+    }
+  }
+}
 
 /* Spec-mandated canonical name for the CAP:DENY marker resource field
  * when the operation has no resource handle of its own
@@ -141,7 +201,7 @@ ipc_result_t ipc_send(cap_subject_id_t sender, ipc_port_t target, const ipc_msg_
   memcpy(&outbound, msg, sizeof(outbound));
   outbound.sender_subject = sender;
 
-  return ipc_port_stage(target, &outbound);
+  return ipc_stage_blocking(target, &outbound);
 }
 
 ipc_result_t ipc_recv(cap_subject_id_t receiver, ipc_port_t self_port, ipc_msg_v0 *out_msg) {
@@ -173,7 +233,7 @@ ipc_result_t ipc_recv(cap_subject_id_t receiver, ipc_port_t self_port, ipc_msg_v
     return gate;
   }
 
-  ipc_result_t cr = ipc_port_consume(self_port, out_msg);
+  ipc_result_t cr = ipc_consume_blocking(self_port, out_msg);
   if (cr != IPC_OK) {
     return cr;
   }
@@ -289,7 +349,7 @@ ipc_result_t ipc_send_h(cap_handle_t send_handle,
   memcpy(&outbound, msg, sizeof(outbound));
   outbound.sender_subject = sender;
 
-  return ipc_port_stage(target, &outbound);
+  return ipc_stage_blocking(target, &outbound);
 }
 
 ipc_result_t ipc_recv_h(cap_handle_t recv_handle,
@@ -327,7 +387,7 @@ ipc_result_t ipc_recv_h(cap_handle_t recv_handle,
   }
   (void)cap_check(receiver, required_recv);
 
-  ipc_result_t cr = ipc_port_consume(self_port, out_msg);
+  ipc_result_t cr = ipc_consume_blocking(self_port, out_msg);
   if (cr != IPC_OK) {
     return cr;
   }

--- a/kernel/ipc/ipc_port.c
+++ b/kernel/ipc/ipc_port.c
@@ -254,3 +254,10 @@ bool ipc_port_has_pending_for_tests(ipc_port_t port) {
   }
   return slot->slot_occupied;
 }
+
+const void *ipc_port_wait_token(ipc_port_t port) {
+  /* Return the slot pointer itself. Stable for the lifetime of the
+   * handle's generation and unique per live port. Callers must treat
+   * it as an opaque equality token only. */
+  return (const void *)resolve(port);
+}

--- a/kernel/ipc/ipc_port.h
+++ b/kernel/ipc/ipc_port.h
@@ -112,6 +112,21 @@ ipc_result_t ipc_port_consume(ipc_port_t port, ipc_msg_v0 *out_msg);
  */
 bool ipc_port_has_pending_for_tests(ipc_port_t port);
 
+/*
+ * Stable kernel-internal address for a live port. The pointer is
+ * intended only as an opaque equality token shared between the IPC
+ * send/recv slow path and the cooperative scheduler's block/wake
+ * helpers (kernel/proc/proc_sched.{c,h}). The pointed-to bytes are
+ * NOT readable by callers — do not dereference. Returns NULL for a
+ * stale or invalid handle.
+ *
+ * Issue #250 (M1 plan #198 slice 3): wired up so the scheduler can
+ * suspend a PCB on "this exact port" and the matching peer can wake
+ * exactly one waiter for the same port without exposing the slot
+ * representation.
+ */
+const void *ipc_port_wait_token(ipc_port_t port);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/proc/proc_sched.c
+++ b/kernel/proc/proc_sched.c
@@ -1,0 +1,357 @@
+/**
+ * @file proc_sched.c
+ * @brief Cooperative scheduler + IPC block/wake (M1 plan #198 slice 3,
+ *        issue #250).
+ *
+ * Purpose:
+ *   Drives PCBs registered via process_create() (#224) through their
+ *   READY -> RUNNING -> { BLOCKED -> READY }* -> EXITED lifecycle.
+ *   The scheduler keeps a per-PCB POSIX ucontext on the host build so
+ *   IPC send/recv can suspend a running PCB mid-call and resume the
+ *   matching peer when the rendezvous lands — without target-specific
+ *   assembly. Kernel ports supply their own ucontext-equivalent shim
+ *   (out of scope for #250; see #251).
+ *
+ *   The scheduler is single-threaded and cooperative. Pre-emption,
+ *   per-CPU runqueues, and priority bands are deferred to M2.
+ *
+ * Interactions:
+ *   - kernel/proc/process.{c,h}: state / entry / blocked_on_port
+ *     mutators (process_set_*).
+ *   - kernel/ipc/ipc_ops.c: calls proc_sched_block_current_on_port()
+ *     and proc_sched_wake_one_on_port() at the rendezvous boundary.
+ *
+ * Launched by:
+ *   Compiled into the kernel image and into the
+ *   build/scripts/test_proc_sched.sh host-side test binary.
+ *
+ * Issue: #250. Plan: plans/2026-05-20-m1-process-address-space.md.
+ */
+
+#include "proc_sched.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+
+/* Per-PCB coroutine stack. 64 KiB matches the slice-2 default arena
+ * stack window's lower bound (kernel/proc/address_space.h) and is more
+ * than enough for the host-side smoke entries. */
+#define PROC_SCHED_STACK_BYTES (64u * 1024u)
+
+typedef struct {
+  bool in_use;
+  process_id_t pid;
+  ucontext_t ctx;
+  uint8_t *stack;
+  bool started;
+} sched_entry_t;
+
+/* Sized to PROC_TABLE_MAX so registering every live PCB always fits.
+ * PROC_TABLE_MAX is small in v0 (see kernel/proc/process.h). */
+static sched_entry_t g_entries[PROC_TABLE_MAX];
+
+/* Ready-queue: ring of slot indexes into g_entries. */
+static uint16_t g_ready_ring[PROC_TABLE_MAX];
+static uint32_t g_ready_head = 0u;
+static uint32_t g_ready_count = 0u;
+
+static ucontext_t g_scheduler_ctx;
+static int16_t g_current_index = -1;  /* index into g_entries, -1 = none */
+static bool g_dispatching = false;
+
+/* ------------------------------------------------------------------ */
+
+static sched_entry_t *find_entry(process_id_t pid) {
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (g_entries[i].in_use && g_entries[i].pid == pid) {
+      return &g_entries[i];
+    }
+  }
+  return NULL;
+}
+
+static int16_t alloc_entry(process_id_t pid) {
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (!g_entries[i].in_use) {
+      g_entries[i].in_use = true;
+      g_entries[i].pid = pid;
+      g_entries[i].started = false;
+      g_entries[i].stack = (uint8_t *)malloc(PROC_SCHED_STACK_BYTES);
+      if (g_entries[i].stack == NULL) {
+        g_entries[i].in_use = false;
+        return -1;
+      }
+      return (int16_t)i;
+    }
+  }
+  return -1;
+}
+
+static void ready_push(uint16_t entry_index) {
+  /* Caller guarantees we never exceed PROC_TABLE_MAX entries. */
+  uint32_t tail = (g_ready_head + g_ready_count) % PROC_TABLE_MAX;
+  g_ready_ring[tail] = entry_index;
+  g_ready_count++;
+}
+
+static int16_t ready_pop(void) {
+  if (g_ready_count == 0u) {
+    return -1;
+  }
+  uint16_t idx = g_ready_ring[g_ready_head];
+  g_ready_head = (g_ready_head + 1u) % PROC_TABLE_MAX;
+  g_ready_count--;
+  return (int16_t)idx;
+}
+
+/* Drop a ready-queue entry by entry_index. Used when a PCB exits
+ * while still on the ring (shouldn't happen — exit transitions out of
+ * READY first — but guards against double-enqueue bugs). */
+static void ready_drop(uint16_t entry_index) {
+  uint32_t kept = 0u;
+  uint16_t tmp[PROC_TABLE_MAX];
+  for (uint32_t i = 0; i < g_ready_count; ++i) {
+    uint16_t v = g_ready_ring[(g_ready_head + i) % PROC_TABLE_MAX];
+    if (v != entry_index) {
+      tmp[kept++] = v;
+    }
+  }
+  for (uint32_t i = 0; i < kept; ++i) {
+    g_ready_ring[i] = tmp[i];
+  }
+  g_ready_head = 0u;
+  g_ready_count = kept;
+}
+
+/* ------------------------------------------------------------------ */
+
+void proc_sched_reset(void) {
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (g_entries[i].in_use && g_entries[i].stack != NULL) {
+      free(g_entries[i].stack);
+    }
+    g_entries[i].in_use = false;
+    g_entries[i].pid = PID_INVALID;
+    g_entries[i].stack = NULL;
+    g_entries[i].started = false;
+    memset(&g_entries[i].ctx, 0, sizeof(g_entries[i].ctx));
+  }
+  g_ready_head = 0u;
+  g_ready_count = 0u;
+  g_current_index = -1;
+  g_dispatching = false;
+  memset(&g_scheduler_ctx, 0, sizeof(g_scheduler_ctx));
+}
+
+/* Trampoline invoked once when the scheduler first dispatches a PCB.
+ * Implicit proc_exit(0) on natural return. */
+static void sched_trampoline(void) {
+  /* g_current_index is set to this entry by the dispatch loop before
+   * swapcontext()'ing into us. */
+  if (g_current_index < 0) {
+    /* Defensive — should be unreachable. */
+    return;
+  }
+  sched_entry_t *e = &g_entries[g_current_index];
+  process_t snap;
+  if (process_lookup(e->pid, &snap) == PROC_OK && snap.entry != NULL) {
+    snap.entry();
+  }
+  /* Implicit exit on natural return. */
+  (void)proc_exit(0u);
+  /* proc_exit() does not return; if it did, fall back to scheduler. */
+  swapcontext(&e->ctx, &g_scheduler_ctx);
+}
+
+proc_sched_result_t proc_sched_register(process_id_t pid,
+                                        proc_entry_fn_t entry) {
+  if (entry == NULL) {
+    return PROC_SCHED_ERR_INVALID_ARG;
+  }
+  if (!process_is_live_for_tests(pid)) {
+    return PROC_SCHED_ERR_INVALID_PID;
+  }
+  if (find_entry(pid) != NULL) {
+    return PROC_SCHED_ERR_INVALID_PID;
+  }
+  int16_t idx = alloc_entry(pid);
+  if (idx < 0) {
+    return PROC_SCHED_ERR_INVALID_ARG;
+  }
+  if (process_set_entry(pid, entry) != PROC_OK) {
+    /* Should not happen — PCB was live one line ago. */
+    g_entries[idx].in_use = false;
+    free(g_entries[idx].stack);
+    g_entries[idx].stack = NULL;
+    return PROC_SCHED_ERR_INVALID_PID;
+  }
+  (void)process_set_state(pid, PROC_STATE_READY);
+  ready_push((uint16_t)idx);
+  return PROC_SCHED_OK;
+}
+
+/* Switch from currently-running PCB back to the scheduler. */
+static void switch_to_scheduler(void) {
+  int16_t prev = g_current_index;
+  g_current_index = -1;
+  if (prev >= 0) {
+    swapcontext(&g_entries[prev].ctx, &g_scheduler_ctx);
+  }
+}
+
+proc_sched_result_t proc_yield(void) {
+  if (g_current_index < 0) {
+    return PROC_SCHED_ERR_NOT_RUNNING;
+  }
+  sched_entry_t *e = &g_entries[g_current_index];
+  /* Flip RUNNING -> READY and re-queue at the tail for round-robin. */
+  (void)process_set_state(e->pid, PROC_STATE_READY);
+  ready_push((uint16_t)g_current_index);
+  switch_to_scheduler();
+  /* When we resume, the dispatch loop has flipped us back to RUNNING. */
+  return PROC_SCHED_OK;
+}
+
+proc_sched_result_t proc_exit(uint32_t code) {
+  if (g_current_index < 0) {
+    return PROC_SCHED_ERR_NOT_RUNNING;
+  }
+  sched_entry_t *e = &g_entries[g_current_index];
+  (void)process_set_exit_code(e->pid, code);
+  (void)process_set_state(e->pid, PROC_STATE_EXITED);
+  /* Defensive: ensure we are not on the ready ring. */
+  ready_drop((uint16_t)g_current_index);
+  switch_to_scheduler();
+  /* Unreachable in practice — the scheduler never re-dispatches an
+   * EXITED PCB. */
+  return PROC_SCHED_OK;
+}
+
+proc_sched_result_t proc_sched_block_current_on_port(const void *port) {
+  if (port == NULL) {
+    return PROC_SCHED_ERR_INVALID_ARG;
+  }
+  if (g_current_index < 0) {
+    return PROC_SCHED_ERR_NOT_RUNNING;
+  }
+  sched_entry_t *e = &g_entries[g_current_index];
+  (void)process_set_blocked_on(e->pid, port);
+  (void)process_set_state(e->pid, PROC_STATE_BLOCKED);
+  switch_to_scheduler();
+  /* Resumed: scheduler will have cleared blocked_on_port and flipped
+   * state to RUNNING. */
+  return PROC_SCHED_OK;
+}
+
+proc_sched_result_t proc_sched_wake_one_on_port(const void *port) {
+  if (port == NULL) {
+    return PROC_SCHED_ERR_INVALID_ARG;
+  }
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (!g_entries[i].in_use) {
+      continue;
+    }
+    process_t snap;
+    if (process_lookup(g_entries[i].pid, &snap) != PROC_OK) {
+      continue;
+    }
+    if (snap.state == PROC_STATE_BLOCKED && snap.blocked_on_port == port) {
+      (void)process_set_blocked_on(g_entries[i].pid, NULL);
+      (void)process_set_state(g_entries[i].pid, PROC_STATE_READY);
+      ready_push(i);
+      return PROC_SCHED_OK;
+    }
+  }
+  return PROC_SCHED_ERR_NOT_BLOCKED;
+}
+
+/* Count blocked PCBs by walking the entry table. */
+static uint32_t count_blocked(void) {
+  uint32_t n = 0;
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (!g_entries[i].in_use) continue;
+    process_t snap;
+    if (process_lookup(g_entries[i].pid, &snap) != PROC_OK) continue;
+    if (snap.state == PROC_STATE_BLOCKED) n++;
+  }
+  return n;
+}
+
+static uint32_t count_live(void) {
+  uint32_t n = 0;
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    if (!g_entries[i].in_use) continue;
+    process_t snap;
+    if (process_lookup(g_entries[i].pid, &snap) != PROC_OK) continue;
+    if (snap.state != PROC_STATE_EXITED) n++;
+  }
+  return n;
+}
+
+proc_sched_result_t proc_sched_run(void) {
+  if (g_dispatching) {
+    return PROC_SCHED_ERR_INVALID_ARG;
+  }
+  g_dispatching = true;
+
+  for (;;) {
+    int16_t idx = ready_pop();
+    if (idx < 0) {
+      /* No ready PCBs. If any PCB is still BLOCKED we have a
+       * deadlock (no waker possible in v0). Otherwise orderly drain. */
+      uint32_t live = count_live();
+      g_dispatching = false;
+      if (live == 0u) {
+        return PROC_SCHED_OK;
+      }
+      return PROC_SCHED_ERR_DEADLOCK;
+    }
+    sched_entry_t *e = &g_entries[idx];
+    process_t snap;
+    if (process_lookup(e->pid, &snap) != PROC_OK ||
+        snap.state == PROC_STATE_EXITED) {
+      /* Stale entry — skip. */
+      continue;
+    }
+    g_current_index = idx;
+    (void)process_set_state(e->pid, PROC_STATE_RUNNING);
+
+    if (!e->started) {
+      e->started = true;
+      /* First dispatch: build the coroutine context. */
+      if (getcontext(&e->ctx) != 0) {
+        /* Treat as a fatal scheduler error. */
+        (void)process_set_state(e->pid, PROC_STATE_EXITED);
+        g_current_index = -1;
+        continue;
+      }
+      e->ctx.uc_stack.ss_sp = e->stack;
+      e->ctx.uc_stack.ss_size = PROC_SCHED_STACK_BYTES;
+      e->ctx.uc_link = &g_scheduler_ctx;
+      makecontext(&e->ctx, sched_trampoline, 0);
+    }
+    swapcontext(&g_scheduler_ctx, &e->ctx);
+    /* On return, g_current_index has been cleared by switch_to_scheduler. */
+    g_current_index = -1;
+  }
+}
+
+/* ---------------- test-only inspectors ---------------- */
+
+process_id_t proc_sched_current_for_tests(void) {
+  if (g_current_index < 0) return PID_INVALID;
+  return g_entries[g_current_index].pid;
+}
+
+uint32_t proc_sched_ready_count_for_tests(void) {
+  return g_ready_count;
+}
+
+uint32_t proc_sched_blocked_count_for_tests(void) {
+  return count_blocked();
+}
+
+bool proc_sched_is_active(void) {
+  return g_dispatching && g_current_index >= 0;
+}

--- a/kernel/proc/proc_sched.h
+++ b/kernel/proc/proc_sched.h
@@ -1,0 +1,181 @@
+/**
+ * @file proc_sched.h
+ * @brief Cooperative process-level scheduler with IPC block/wake hooks
+ *        (M1 plan #198 slice 3, issue #250).
+ *
+ * Purpose:
+ *   The slice-1 PCB table (#224) only stored static state. The slice-2
+ *   address-space carving (#248) only laid out per-process arenas.
+ *   Slice 3 binds those PCBs to actual execution: each registered PCB
+ *   gets a single entry function and a cooperative trampoline, the
+ *   scheduler keeps a per-PCB execution context, and IPC send / recv
+ *   can suspend a PCB on an empty/occupied IPC port slot and resume
+ *   the matching peer when the rendezvous completes.
+ *
+ *   The v0 scheduler is deliberately small:
+ *     - Single ready-queue (round-robin over READY PCBs).
+ *     - Block-on-IPC is a recorded back-pointer (`blocked_on_port`)
+ *       and a state transition READY -> BLOCKED. The scheduler refuses
+ *       to dispatch BLOCKED PCBs; the IPC layer flips them back to
+ *       READY when the peer rendezvous lands.
+ *     - Cooperative yield only (no timer pre-emption — slice 4 / M2).
+ *     - Single-threaded host model: at most one RUNNING PCB at a time.
+ *
+ *   Host-side context switching uses POSIX `ucontext.h` so the host
+ *   tests can exercise true coroutine block/wake semantics without
+ *   target-specific assembly. The kernel-side build path uses the
+ *   same API: any freestanding port supplies its own ucontext shim
+ *   (out of scope for #250; see #251 for the cap_id wiring follow-up).
+ *
+ * Interactions:
+ *   - kernel/proc/process.{c,h}: owns PCB lifecycle and exposes the
+ *     state / entry / exit_code / blocked_on_port mutator accessors
+ *     this scheduler drives.
+ *   - kernel/ipc/ipc_ops.c: calls proc_sched_block_current_on_port()
+ *     when a recv finds an empty slot or a send finds an occupied slot,
+ *     and proc_sched_wake_one_on_port() when the matching peer op
+ *     completes the rendezvous.
+ *   - tests/proc_sched_test.c (slice-3 acceptance harness).
+ *
+ * Launched by:
+ *   Not a standalone process. The host-side test binary
+ *   build/scripts/test_proc_sched.sh exercises the full scheduler +
+ *   IPC block/wake path with deterministic TEST:PASS markers.
+ *
+ * Issue: #250. Plan: plans/2026-05-20-m1-process-address-space.md.
+ */
+
+#ifndef SECUREOS_KERNEL_PROC_SCHED_H
+#define SECUREOS_KERNEL_PROC_SCHED_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "process.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Scheduler-level result vocabulary. Distinct from proc_result_t so
+ * callers can tell "the PCB-table refused this PID" (proc_result_t)
+ * from "the scheduler refused this operation" (proc_sched_result_t).
+ *
+ * Frozen for OS_ABI_VERSION = 0: additive changes require an ABI bump
+ * (#150). Tests assert exact numeric values for deterministic markers.
+ */
+typedef enum {
+  PROC_SCHED_OK = 0,
+  PROC_SCHED_ERR_INVALID_PID = 1,
+  PROC_SCHED_ERR_INVALID_ARG = 2,
+  PROC_SCHED_ERR_NO_RUNNABLE = 3,  /* no PCB in PROC_STATE_READY */
+  PROC_SCHED_ERR_DEADLOCK = 4,     /* every live PCB is BLOCKED */
+  PROC_SCHED_ERR_NOT_RUNNING = 5,  /* op requires a current PCB but none set */
+  PROC_SCHED_ERR_NOT_BLOCKED = 6,  /* wake target was not BLOCKED on that port */
+} proc_sched_result_t;
+
+/*
+ * Reset the scheduler to a known-empty state. Tears down every
+ * coroutine context owned by previously-registered PCBs without
+ * touching the underlying PCB table (that is process_table_reset's
+ * job). Always call BOTH at the start of a test.
+ */
+void proc_sched_reset(void);
+
+/*
+ * Register a PCB with the scheduler. The PCB transitions
+ * PROC_STATE_NEW -> PROC_STATE_READY and is appended to the
+ * ready-queue rotation. `entry` MUST NOT be NULL.
+ *
+ * The entry runs at most once: on its first dispatch the scheduler
+ * sets up a fresh ucontext stack, invokes entry(), and on return
+ * implicitly performs proc_exit(0).
+ *
+ * Returns PROC_SCHED_ERR_INVALID_ARG on NULL entry, ERR_INVALID_PID
+ * if the PCB is stale or already registered with this scheduler.
+ */
+proc_sched_result_t proc_sched_register(process_id_t pid, proc_entry_fn_t entry);
+
+/*
+ * Cooperative yield from the currently-running PCB. Saves the caller's
+ * coroutine context and dispatches the next READY PCB in round-robin
+ * order. Returns when the caller is next scheduled. Returns
+ * PROC_SCHED_ERR_NOT_RUNNING if no PCB is currently running (i.e.,
+ * called from the scheduler thread itself).
+ */
+proc_sched_result_t proc_yield(void);
+
+/*
+ * Terminate the currently-running PCB with `code`. Transitions its
+ * state to PROC_STATE_EXITED, records `code`, and yields control to
+ * the next READY PCB. This call NEVER returns to the caller; if no
+ * PCB is currently running, returns PROC_SCHED_ERR_NOT_RUNNING.
+ */
+proc_sched_result_t proc_exit(uint32_t code);
+
+/*
+ * Run the scheduler until every registered PCB has exited or every
+ * remaining live PCB is BLOCKED (deadlock). Returns PROC_SCHED_OK on
+ * orderly drain, PROC_SCHED_ERR_DEADLOCK if at least one live PCB
+ * remains BLOCKED with no possible waker.
+ *
+ * Single re-entrant guard: calling proc_sched_run() from inside a
+ * scheduled PCB returns PROC_SCHED_ERR_INVALID_ARG.
+ */
+proc_sched_result_t proc_sched_run(void);
+
+/*
+ * Mark the currently-running PCB as BLOCKED on `port` (opaque
+ * back-pointer; the scheduler only compares it for equality on wake)
+ * and yield. Returns when the matching wake fires. Returns
+ * PROC_SCHED_ERR_NOT_RUNNING if called outside a scheduled PCB and
+ * PROC_SCHED_ERR_INVALID_ARG if `port` is NULL.
+ *
+ * Called by kernel/ipc/ipc_ops.c on the suspend path.
+ */
+proc_sched_result_t proc_sched_block_current_on_port(const void *port);
+
+/*
+ * Wake one PCB blocked on `port` (FIFO over the blocked list). The
+ * woken PCB transitions BLOCKED -> READY and is re-appended to the
+ * ready-queue tail. Returns PROC_SCHED_ERR_NOT_BLOCKED if no PCB is
+ * blocked on that port.
+ *
+ * Called by kernel/ipc/ipc_ops.c when a rendezvous completes.
+ */
+proc_sched_result_t proc_sched_wake_one_on_port(const void *port);
+
+/* ---------------- test-only inspectors (#250 acceptance) ---------- */
+
+/*
+ * Return the PID of the currently-running PCB, or PID_INVALID if no
+ * PCB is running (i.e., called from the scheduler thread or before
+ * proc_sched_run started dispatching).
+ */
+process_id_t proc_sched_current_for_tests(void);
+
+/*
+ * Count of PCBs currently in PROC_STATE_READY (ready-queue depth).
+ */
+uint32_t proc_sched_ready_count_for_tests(void);
+
+/*
+ * Count of PCBs currently in PROC_STATE_BLOCKED.
+ */
+uint32_t proc_sched_blocked_count_for_tests(void);
+
+/*
+ * Is a scheduler dispatch currently in progress? IPC ops use this to
+ * pick between the v0 single-waiter-slot semantics (no scheduler
+ * running -> return IPC_ERR_PEER_GONE) and the slice-3 block/wake
+ * semantics (scheduler running -> suspend current PCB).
+ */
+bool proc_sched_is_active(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_PROC_SCHED_H */

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -60,6 +60,12 @@ typedef struct {
   uint16_t generation;
   cap_subject_id_t subject;
   address_space_t *aspace;
+  /* Slice-3 (#250) cooperative-scheduler bookkeeping. These never
+   * touch the wire ABI — they are kernel-internal only. */
+  process_state_t state;
+  proc_entry_fn_t entry;
+  uint32_t exit_code;
+  const void *blocked_on_port;
 } process_slot_t;
 
 static process_slot_t g_procs[PROC_TABLE_MAX];
@@ -112,6 +118,10 @@ void process_table_reset(void) {
     g_procs[i].live = false;
     g_procs[i].subject = 0u;
     g_procs[i].aspace = NULL;
+    g_procs[i].state = PROC_STATE_NEW;
+    g_procs[i].entry = NULL;
+    g_procs[i].exit_code = 0u;
+    g_procs[i].blocked_on_port = NULL;
   }
   g_table_initialized = true;
 }
@@ -132,6 +142,10 @@ proc_result_t process_create(cap_subject_id_t subject,
       g_procs[i].live = true;
       g_procs[i].subject = subject;
       g_procs[i].aspace = aspace;
+      g_procs[i].state = PROC_STATE_NEW;
+      g_procs[i].entry = NULL;
+      g_procs[i].exit_code = 0u;
+      g_procs[i].blocked_on_port = NULL;
       *out_pid = encode_pid(i, g_procs[i].generation);
       return PROC_OK;
     }
@@ -172,9 +186,51 @@ proc_result_t process_lookup(process_id_t pid, process_t *out_proc) {
   out_proc->pid = pid;
   out_proc->subject = slot->subject;
   out_proc->aspace = slot->aspace;
+  out_proc->state = slot->state;
+  out_proc->entry = slot->entry;
+  out_proc->exit_code = slot->exit_code;
+  out_proc->blocked_on_port = slot->blocked_on_port;
   return PROC_OK;
 }
 
 bool process_is_live_for_tests(process_id_t pid) {
   return resolve(pid) != NULL;
+}
+
+/* ---------------- slice-3 (#250) mutator accessors ---------------- */
+
+proc_result_t process_set_state(process_id_t pid, process_state_t state) {
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  slot->state = state;
+  return PROC_OK;
+}
+
+proc_result_t process_set_entry(process_id_t pid, proc_entry_fn_t entry) {
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  slot->entry = entry;
+  return PROC_OK;
+}
+
+proc_result_t process_set_exit_code(process_id_t pid, uint32_t code) {
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  slot->exit_code = code;
+  return PROC_OK;
+}
+
+proc_result_t process_set_blocked_on(process_id_t pid, const void *port) {
+  process_slot_t *slot = resolve(pid);
+  if (slot == NULL) {
+    return PROC_ERR_INVALID_PID;
+  }
+  slot->blocked_on_port = port;
+  return PROC_OK;
 }

--- a/kernel/proc/process.h
+++ b/kernel/proc/process.h
@@ -95,6 +95,28 @@ typedef enum {
 } proc_result_t;
 
 /*
+ * Cooperative-scheduler state machine (slice 3, issue #250 / plan #198).
+ * The values are part of the v0 in-kernel contract: tests rely on the
+ * specific enumeration order (NEW < READY < RUNNING < BLOCKED < EXITED)
+ * to assert lifecycle transitions. Do not reorder.
+ */
+typedef enum {
+  PROC_STATE_NEW = 0,
+  PROC_STATE_READY = 1,
+  PROC_STATE_RUNNING = 2,
+  PROC_STATE_BLOCKED = 3,
+  PROC_STATE_EXITED = 4,
+} process_state_t;
+
+/*
+ * Slice-3 entry function shape. The cooperative scheduler invokes a
+ * registered entry once when the PCB first runs. Entries may call
+ * proc_yield() (and ipc_send/recv as their only blocking points) and
+ * are expected to call proc_exit() before returning.
+ */
+typedef void (*proc_entry_fn_t)(void);
+
+/*
  * Forward declaration of the address-space placeholder. The v0
  * scaffold treats `address_space_t` as an opaque type: concrete fields
  * are reserved for the M2 paging slice and live behind this pointer
@@ -107,14 +129,22 @@ typedef struct address_space address_space_t;
  * Minimal PCB. Field order is part of the v0 contract — tests assert
  * sizeof/offsetof against a static_assert table in process.c.
  *
- * Out of scope for this slice (these will appear in sibling follow-up
- * issues; do NOT add them here): state machine, ready-queue links,
- * exit_code, entry pointer, kernel stack pointer.
+ * Slice 3 (#250) appends cooperative-scheduler bookkeeping at the tail
+ * (state, entry, exit_code, blocked_on_port) so the existing
+ * sizeof/offsetof contract from slice 1 (pid/subject/aspace at the
+ * front) is preserved. process_lookup() still only fills the first
+ * three fields plus the new state/exit_code so callers that snapshot
+ * a PCB never see uninitialised tail bytes.
  */
 typedef struct process {
-  process_id_t       pid;      /* stable handle, 0 = invalid */
-  cap_subject_id_t   subject;  /* capability identity bound to this PCB */
-  address_space_t   *aspace;   /* opaque in v0; reserved for M2 paging */
+  process_id_t       pid;            /* stable handle, 0 = invalid */
+  cap_subject_id_t   subject;        /* capability identity bound to this PCB */
+  address_space_t   *aspace;         /* opaque in v0; reserved for M2 paging */
+  /* --- slice 3 (#250): cooperative-scheduler tail, append-only --- */
+  process_state_t    state;          /* scheduler lifecycle state */
+  proc_entry_fn_t    entry;          /* registered entry; NULL pre-spawn */
+  uint32_t           exit_code;      /* valid only in PROC_STATE_EXITED */
+  const void        *blocked_on_port;/* opaque IPC port back-ref or NULL */
 } process_t;
 
 /*
@@ -161,6 +191,22 @@ proc_result_t process_lookup(process_id_t pid, process_t *out_proc);
  * transitions without peeking at slot internals.
  */
 bool process_is_live_for_tests(process_id_t pid);
+
+/* ----------------------------------------------------------------
+ * Slice-3 (#250) mutator accessors used by kernel/proc/proc_sched.{c,h}
+ * to drive the cooperative-scheduler state machine without exposing
+ * the raw slot struct. All four return PROC_ERR_INVALID_PID on a stale
+ * or invalid handle and PROC_OK on success.
+ *
+ * These are intentionally NOT part of the public PCB-table API for
+ * non-scheduler callers — the only in-kernel callers (besides the
+ * proc_sched test) are the cooperative scheduler itself and the IPC
+ * send/recv block/wake path in kernel/ipc/ipc_ops.c.
+ * ---------------------------------------------------------------- */
+proc_result_t process_set_state(process_id_t pid, process_state_t state);
+proc_result_t process_set_entry(process_id_t pid, proc_entry_fn_t entry);
+proc_result_t process_set_exit_code(process_id_t pid, uint32_t code);
+proc_result_t process_set_blocked_on(process_id_t pid, const void *port);
 
 #ifdef __cplusplus
 }

--- a/tests/proc_sched_test.c
+++ b/tests/proc_sched_test.c
@@ -1,0 +1,353 @@
+/**
+ * @file proc_sched_test.c
+ * @brief Acceptance harness for the M1 cooperative scheduler + IPC
+ *        block/wake hooks (issue #250, plan #198 slice 3).
+ *
+ * Asserts:
+ *   1. proc_sched_register transitions a NEW PCB to READY and the
+ *      scheduler dispatches it exactly once on proc_sched_run.
+ *   2. Two cooperatively-yielding PCBs interleave round-robin and
+ *      both reach EXITED with the recorded exit_code.
+ *   3. ipc_recv on an empty port blocks the receiver; a peer's
+ *      ipc_send wakes exactly that receiver and the rendezvous
+ *      completes with the kernel-stamped sender_subject.
+ *   4. ipc_send on a full single-waiter slot blocks the sender; the
+ *      receiver's ipc_recv consumes the staged envelope and wakes the
+ *      sender, which then re-stages successfully.
+ *   5. Deadlock detection: a single PCB blocked on a port nobody will
+ *      ever send to causes proc_sched_run to return
+ *      PROC_SCHED_ERR_DEADLOCK without hanging.
+ *
+ * Launched by:
+ *   build/scripts/test_proc_sched.sh (dispatched via
+ *   build/scripts/test.sh proc_sched).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/proc_sched.h"
+#include "../kernel/proc/process.h"
+#include "../user/include/secureos_abi.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:proc_sched:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  proc_sched_reset();
+  process_table_reset();
+  ipc_port_table_reset();
+  cap_reset_for_tests();
+  cap_table_reset();
+}
+
+/* Sentinel address-space pointer; v0 treats it as opaque. */
+static address_space_t *fake_aspace(uintptr_t tag) {
+  return (address_space_t *)tag;
+}
+
+/* ------------------------------------------------------------------ */
+/* (1) Single-PCB dispatch + exit_code                                  */
+/* ------------------------------------------------------------------ */
+
+static int g_single_ticks = 0;
+static void entry_single(void) {
+  g_single_ticks++;
+  (void)proc_exit(42u);
+  /* Should never return. */
+  g_single_ticks = -1000;
+}
+
+static void test_single_dispatch(void) {
+  reset_world();
+  cap_subject_id_t subj = 1u;
+  cap_table_grant(subj, CAP_IPC_SEND);
+  cap_table_grant(subj, CAP_IPC_RECV);
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(subj, fake_aspace(0x1000u), &pid) != PROC_OK) die("create_single");
+  if (proc_sched_register(pid, entry_single) != PROC_SCHED_OK) die("register_single");
+
+  process_t snap;
+  if (process_lookup(pid, &snap) != PROC_OK) die("lookup_after_register");
+  if (snap.state != PROC_STATE_READY) die("state_after_register_not_ready");
+
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_single");
+
+  if (g_single_ticks != 1) die("entry_not_called_once");
+  if (process_lookup(pid, &snap) != PROC_OK) die("lookup_after_run");
+  if (snap.state != PROC_STATE_EXITED) die("state_after_run_not_exited");
+  if (snap.exit_code != 42u) die("exit_code_not_recorded");
+
+  printf("TEST:PASS:proc_sched_single_dispatch\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (2) Round-robin yield between two PCBs                              */
+/* ------------------------------------------------------------------ */
+
+static int g_trace[16];
+static int g_trace_len = 0;
+static void trace(int marker) {
+  if (g_trace_len < (int)(sizeof(g_trace) / sizeof(g_trace[0]))) {
+    g_trace[g_trace_len++] = marker;
+  }
+}
+
+static void entry_a(void) {
+  trace(1);
+  (void)proc_yield();
+  trace(3);
+  (void)proc_yield();
+  trace(5);
+  (void)proc_exit(0u);
+}
+static void entry_b(void) {
+  trace(2);
+  (void)proc_yield();
+  trace(4);
+  (void)proc_exit(0u);
+}
+
+static void test_round_robin(void) {
+  reset_world();
+  cap_subject_id_t sa = 2u, sb = 3u;
+  process_id_t pa = PID_INVALID, pb = PID_INVALID;
+  if (process_create(sa, fake_aspace(0xA000u), &pa) != PROC_OK) die("create_a");
+  if (process_create(sb, fake_aspace(0xB000u), &pb) != PROC_OK) die("create_b");
+  if (proc_sched_register(pa, entry_a) != PROC_SCHED_OK) die("register_a");
+  if (proc_sched_register(pb, entry_b) != PROC_SCHED_OK) die("register_b");
+
+  g_trace_len = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_round_robin");
+
+  /* Expected interleave: A1 B2 A3 B4 A5. */
+  static const int expected[] = {1, 2, 3, 4, 5};
+  if (g_trace_len != 5) die("trace_len_mismatch");
+  for (int i = 0; i < 5; ++i) {
+    if (g_trace[i] != expected[i]) die("round_robin_interleave_mismatch");
+  }
+
+  process_t s;
+  if (process_lookup(pa, &s) != PROC_OK || s.state != PROC_STATE_EXITED) die("a_not_exited");
+  if (process_lookup(pb, &s) != PROC_OK || s.state != PROC_STATE_EXITED) die("b_not_exited");
+
+  printf("TEST:PASS:proc_sched_round_robin\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (3) recv-blocks-until-send                                          */
+/* ------------------------------------------------------------------ */
+
+static ipc_port_t g_recv_port = 0u;
+static cap_subject_id_t g_recv_subj = 0u;
+static cap_subject_id_t g_send_subj = 0u;
+static int g_recv_ok = 0;
+static int g_recv_blocked_observed = 0;
+static int g_send_after_recv_block = 0;
+
+static void entry_receiver(void) {
+  ipc_msg_v0 in;
+  memset(&in, 0, sizeof(in));
+  ipc_result_t r = ipc_recv(g_recv_subj, g_recv_port, &in);
+  if (r != IPC_OK) {
+    (void)proc_exit(101u);
+  }
+  if (in.sender_subject != g_send_subj) {
+    (void)proc_exit(102u);
+  }
+  if (in.payload_len != 4u || memcmp(in.payload, "PING", 4) != 0) {
+    (void)proc_exit(103u);
+  }
+  g_recv_ok = 1;
+  (void)proc_exit(0u);
+}
+
+static void entry_sender(void) {
+  /* Observe that the receiver is BLOCKED before we send. */
+  if (proc_sched_blocked_count_for_tests() == 1u) {
+    g_recv_blocked_observed = 1;
+  }
+  ipc_msg_v0 m;
+  memset(&m, 0, sizeof(m));
+  m.abi_version = (uint16_t)OS_ABI_VERSION;
+  m.tag = 0u;
+  m.payload_len = 4u;
+  memcpy(m.payload, "PING", 4);
+  ipc_result_t r = ipc_send(g_send_subj, g_recv_port, &m);
+  if (r != IPC_OK) {
+    (void)proc_exit(201u);
+  }
+  g_send_after_recv_block = 1;
+  (void)proc_exit(0u);
+}
+
+static void test_recv_blocks_until_send(void) {
+  reset_world();
+  g_recv_subj = 1u;
+  g_send_subj = 2u;
+  cap_table_grant(g_send_subj, CAP_IPC_SEND);
+  cap_table_grant(g_recv_subj, CAP_IPC_RECV);
+
+  if (ipc_port_create(g_recv_subj, CAP_IPC_SEND, CAP_IPC_RECV, &g_recv_port) != IPC_OK) {
+    die("port_create");
+  }
+
+  process_id_t pr = PID_INVALID, ps = PID_INVALID;
+  if (process_create(g_recv_subj, fake_aspace(0xC000u), &pr) != PROC_OK) die("create_recv");
+  if (process_create(g_send_subj, fake_aspace(0xD000u), &ps) != PROC_OK) die("create_send");
+  /* Register receiver first so it runs first and is the one that blocks. */
+  if (proc_sched_register(pr, entry_receiver) != PROC_SCHED_OK) die("register_recv");
+  if (proc_sched_register(ps, entry_sender) != PROC_SCHED_OK) die("register_send");
+
+  g_recv_ok = 0;
+  g_recv_blocked_observed = 0;
+  g_send_after_recv_block = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_recv_blocks");
+
+  if (!g_recv_blocked_observed) die("sender_did_not_see_receiver_blocked");
+  if (!g_send_after_recv_block) die("send_did_not_complete");
+  if (!g_recv_ok) die("recv_did_not_unblock_with_payload");
+
+  process_t s;
+  if (process_lookup(pr, &s) != PROC_OK || s.state != PROC_STATE_EXITED || s.exit_code != 0u) {
+    die("recv_pcb_bad_terminal");
+  }
+  if (process_lookup(ps, &s) != PROC_OK || s.state != PROC_STATE_EXITED || s.exit_code != 0u) {
+    die("send_pcb_bad_terminal");
+  }
+
+  printf("TEST:PASS:proc_sched_recv_blocks_until_send\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (4) send-blocks-on-full-slot                                        */
+/* ------------------------------------------------------------------ */
+
+static ipc_port_t g_full_port = 0u;
+static cap_subject_id_t g_owner_subj = 0u;
+static cap_subject_id_t g_blocker_subj = 0u;
+static int g_second_send_unblocked = 0;
+static int g_owner_drained = 0;
+
+static void entry_blocker_send(void) {
+  /* First send fills the slot; second send must block until the owner
+   * drains. */
+  ipc_msg_v0 m;
+  memset(&m, 0, sizeof(m));
+  m.abi_version = (uint16_t)OS_ABI_VERSION;
+  m.payload_len = 1u;
+  m.payload[0] = 'A';
+  if (ipc_send(g_blocker_subj, g_full_port, &m) != IPC_OK) (void)proc_exit(301u);
+  m.payload[0] = 'B';
+  /* Slot is full; without a scheduler this would return PEER_GONE.
+   * With the scheduler this must block until owner consumes 'A'. */
+  if (ipc_send(g_blocker_subj, g_full_port, &m) != IPC_OK) (void)proc_exit(302u);
+  g_second_send_unblocked = 1;
+  (void)proc_exit(0u);
+}
+
+static void entry_owner_drain(void) {
+  /* Yield so the sender runs first and stages + blocks. */
+  (void)proc_yield();
+  ipc_msg_v0 in;
+  memset(&in, 0, sizeof(in));
+  if (ipc_recv(g_owner_subj, g_full_port, &in) != IPC_OK) (void)proc_exit(401u);
+  if (in.payload_len != 1u || in.payload[0] != 'A') (void)proc_exit(402u);
+  /* Drain the second envelope after the sender re-stages. */
+  if (ipc_recv(g_owner_subj, g_full_port, &in) != IPC_OK) (void)proc_exit(403u);
+  if (in.payload_len != 1u || in.payload[0] != 'B') (void)proc_exit(404u);
+  g_owner_drained = 1;
+  (void)proc_exit(0u);
+}
+
+static void test_send_blocks_on_full(void) {
+  reset_world();
+  g_owner_subj = 1u;
+  g_blocker_subj = 2u;
+  cap_table_grant(g_owner_subj, CAP_IPC_RECV);
+  cap_table_grant(g_blocker_subj, CAP_IPC_SEND);
+
+  if (ipc_port_create(g_owner_subj, CAP_IPC_SEND, CAP_IPC_RECV, &g_full_port) != IPC_OK) {
+    die("full_port_create");
+  }
+
+  process_id_t po = PID_INVALID, pb = PID_INVALID;
+  if (process_create(g_blocker_subj, fake_aspace(0xE000u), &pb) != PROC_OK) die("create_blocker");
+  if (process_create(g_owner_subj, fake_aspace(0xF000u), &po) != PROC_OK) die("create_owner");
+  /* Register sender first so it runs and fills the slot before the owner. */
+  if (proc_sched_register(pb, entry_blocker_send) != PROC_SCHED_OK) die("register_blocker");
+  if (proc_sched_register(po, entry_owner_drain) != PROC_SCHED_OK) die("register_owner");
+
+  g_second_send_unblocked = 0;
+  g_owner_drained = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_send_blocks_on_full");
+
+  if (!g_second_send_unblocked) die("sender_did_not_unblock");
+  if (!g_owner_drained) die("owner_did_not_drain");
+
+  printf("TEST:PASS:proc_sched_send_blocks_on_full\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (5) Deadlock detection                                              */
+/* ------------------------------------------------------------------ */
+
+static ipc_port_t g_dead_port = 0u;
+static cap_subject_id_t g_dead_subj = 0u;
+static int g_deadlock_recv_returned = 0;
+
+static void entry_dead_recv(void) {
+  ipc_msg_v0 in;
+  memset(&in, 0, sizeof(in));
+  /* No peer will ever send. The scheduler must return DEADLOCK rather
+   * than hang. The recv call will not return in this test. */
+  (void)ipc_recv(g_dead_subj, g_dead_port, &in);
+  g_deadlock_recv_returned = 1;
+  (void)proc_exit(0u);
+}
+
+static void test_deadlock_detection(void) {
+  reset_world();
+  g_dead_subj = 1u;
+  cap_table_grant(g_dead_subj, CAP_IPC_RECV);
+
+  if (ipc_port_create(g_dead_subj, CAP_IPC_SEND, CAP_IPC_RECV, &g_dead_port) != IPC_OK) {
+    die("dead_port_create");
+  }
+  process_id_t pd = PID_INVALID;
+  if (process_create(g_dead_subj, fake_aspace(0x10000u), &pd) != PROC_OK) die("create_dead");
+  if (proc_sched_register(pd, entry_dead_recv) != PROC_SCHED_OK) die("register_dead");
+
+  g_deadlock_recv_returned = 0;
+  proc_sched_result_t r = proc_sched_run();
+  if (r != PROC_SCHED_ERR_DEADLOCK) die("expected_deadlock");
+  if (g_deadlock_recv_returned) die("recv_should_not_have_returned");
+
+  process_t s;
+  if (process_lookup(pd, &s) != PROC_OK) die("lookup_after_deadlock");
+  if (s.state != PROC_STATE_BLOCKED) die("expected_blocked_state");
+
+  printf("TEST:PASS:proc_sched_deadlock_detected\n");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+  printf("TEST:START:proc_sched\n");
+  test_single_dispatch();
+  test_round_robin();
+  test_recv_blocks_until_send();
+  test_send_blocks_on_full();
+  test_deadlock_detection();
+  printf("TEST:PASS:proc_sched\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #250. Implements slice 3 of plan #198 (`plans/2026-05-20-m1-process-address-space.md`): a process-level cooperative scheduler that drives PCBs registered via `process_create` (#224) through their READY → RUNNING → { BLOCKED → READY }* → EXITED lifecycle, and wires `kernel/ipc/ipc_ops.c` into it so synchronous IPC actually blocks on an empty/full single-waiter slot and resumes the matching peer when the rendezvous lands.

### What changed

- **`kernel/proc/process.{c,h}`** — append-only PCB tail fields (`state`, `entry`, `exit_code`, `blocked_on_port`) plus four mutator accessors used only by the scheduler. The slice-1 sizeof/offsetof contract (#224) is preserved by appending at the tail.
- **`kernel/proc/proc_sched.{c,h}`** — ready-queue (round-robin), per-PCB POSIX ucontext coroutine, `proc_yield` / `proc_exit` / `proc_sched_block_current_on_port` / `proc_sched_wake_one_on_port`. Single-threaded, cooperative, no pre-emption (deferred to M2). Deadlock detection returns `PROC_SCHED_ERR_DEADLOCK` instead of hanging when every live PCB is BLOCKED.
- **`kernel/ipc/ipc_port.{c,h}`** — `ipc_port_wait_token()` exposes a stable opaque equality token so the scheduler can match block/wake without ever dereferencing the slot.
- **`kernel/ipc/ipc_ops.c`** — `ipc_stage_blocking` / `ipc_consume_blocking` wrappers around `ipc_port_stage` / `ipc_port_consume`. When `proc_sched_is_active()` is **false** they preserve the v0 `IPC_ERR_PEER_GONE` semantics byte-for-byte, so `ipc_sync_v0` / `ipc_handle_gate` / `ipc_port_lifecycle` stay green without changes. When the scheduler **is** active, send on a full slot or recv on an empty slot suspends the running PCB, and the matching peer's op wakes one waiter on the same port token.
- **`tests/proc_sched_test.c` + `build/scripts/test_proc_sched.sh`** — five deterministic `TEST:PASS:` markers:
  - `proc_sched_single_dispatch` — register → run → entry runs exactly once, `exit_code` recorded
  - `proc_sched_round_robin` — two yielding PCBs interleave 1·2·3·4·5
  - `proc_sched_recv_blocks_until_send` — receiver blocks; sender observes `blocked_count==1`; payload + kernel-stamped `sender_subject` reach the receiver
  - `proc_sched_send_blocks_on_full` — sender blocks on occupied slot; receiver drains; sender re-stages; both drained envelopes match
  - `proc_sched_deadlock_detected` — single PCB blocked on a port nobody will send to → `PROC_SCHED_ERR_DEADLOCK` (no hang)
- **`build/scripts/test.sh` / `test.ps1` / `validate_bundle.sh`** — `proc_sched` target wired into the harness and the green-bundle list.

### Validation

```text
test.sh proc_sched               PASS
test.sh process_table            PASS (unchanged)
test.sh ipc_sync_v0              PASS (unchanged)
test.sh ipc_port_lifecycle       PASS (unchanged)
test.sh ipc_handle_gate          PASS (unchanged)
test.sh scheduler                PASS (unchanged)
test.sh aspace_carve             PASS (unchanged)
test.sh cap_handle_repr          PASS (unchanged)
test.sh capability_audit         PASS (unchanged)
test.sh cap_deny_marker_shape    PASS (unchanged)
validate_bundle.sh               proc_sched bundled and green
```

The pre-existing QEMU/disk-image targets (`hello_boot*`, `kernel_console`, `kernel_filedemo`, `kernel_persistence`) flag the same VALIDATION_FAIL they do on `main` in this environment — they are not touched by this PR.

### Follow-ups

- Unblocks **#251** (cap_id wiring on the block/wake path).
- Kernel-side freestanding port: `proc_sched.c` uses `<ucontext.h>` for the host coroutine. Any freestanding kernel build will need to supply a target-specific swap-context shim behind the same API. Out of scope for #250; will be a sibling slice in the M1 → M2 transition.
- Wake policy is FIFO over the entry table (first matching BLOCKED PCB). A formal port-local wait queue is a #251 follow-up.