### PR TITLE
fix #251: M1 two-module IPC demo + allow/deny acceptance harness (plan #198 slice 4)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -215,8 +215,11 @@ Deliver:
 
 Validate:
 
-- two modules exchange message
-- unauthorized operation denied with explicit error
+- two modules exchange message — satisfied by `TEST:PASS:m1_ipc_allow`
+  (see `tests/m1_ipc_demo_test.c`, issue #251, plan #198 slice 4).
+- unauthorized operation denied with explicit error — satisfied by
+  `TEST:PASS:m1_ipc_deny` + canonical `CAP:DENY:<m1-unauth>:ipc_send:-`
+  marker (same harness).
 
 ## 5.2 M2: Console service + Launcher + HelloApp (first capability slice)
 

--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -38,6 +38,7 @@ test_cap_handle_revoke_subtree
 test_process_table
 test_proc_sched
 test_aspace_carve
+test_m1_ipc_demo
 test_cert_chain
 test_codesign
 test_ed25519

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -68,8 +68,10 @@ $testScript = switch ($TestName) {
   "kernel_sessions" { "./build/scripts/build_kernel_image.sh; ./build/scripts/build_disk_image.sh; ./build/scripts/run_qemu.sh --test kernel_sessions" }
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
+  "ipc_handle_gate" { "./build/scripts/test_ipc_handle_gate.sh" }
   "process_table" { "./build/scripts/test_process_table.sh" }
   "proc_sched" { "./build/scripts/test_proc_sched.sh" }
+  "m1_ipc_demo" { "./build/scripts/test_m1_ipc_demo.sh" }
   "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
   "validate_capability_registry" { "./build/scripts/validate_capability_registry.sh" }
   "capability_registry_drift" { "./tests/harness/capability_registry_drift_test.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -266,6 +266,13 @@ case "$TEST_NAME" in
     # — allow + wrong-cap deny + stale deny + wrong-owner-on-recv deny
     # + cap_handle_owner contract. Locks in plan #197's final slice.
     run_script "$ROOT_DIR/build/scripts/test_ipc_handle_gate.sh"
+    ;;
+  m1_ipc_demo)
+    # Issue #251 (plan #198 slice 4): M1 two-module IPC acceptance
+    # demo — m1-sender → m1-receiver allow round-trip and m1-unauth
+    # deny path. Maps directly to BUILD_ROADMAP §5.1's two validation
+    # bullets via TEST:PASS:m1_ipc_allow / TEST:PASS:m1_ipc_deny.
+    run_script "$ROOT_DIR/build/scripts/test_m1_ipc_demo.sh"
     ;;
   syscall_entry_stub)
     # Issue #232: M1 syscall entry stub — reserved ABI vector range,

--- a/build/scripts/test_m1_ipc_demo.sh
+++ b/build/scripts/test_m1_ipc_demo.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build + run the M1 two-module IPC acceptance demo (issue #251,
+# plan plans/2026-05-20-m1-process-address-space.md slice 4,
+# BUILD_ROADMAP §5.1).
+#
+# Covers:
+#   - allow path: m1-sender -> m1-receiver round-trip via ipc_send_h /
+#     ipc_recv_h, kernel-stamped sender_subject preserved.
+#   - deny path: m1-unauth ipc_send_h with a wrong-cap handle returns
+#     IPC_ERR_CAP_DENIED, exactly one canonical CAP:DENY marker is
+#     emitted, receiver remains BLOCKED, no envelope leaks.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh:
+#   TEST:PASS:m1_ipc_allow
+#   TEST:PASS:m1_ipc_deny
+#   TEST:PASS:m1_ipc
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/proc/module_registry.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/m1_ipc_demo_test.c" \
+  -o "$OUT_DIR/m1_ipc_demo_test"
+
+LOG_PATH="$OUT_DIR/m1_ipc_demo_test.log"
+"$OUT_DIR/m1_ipc_demo_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:m1_ipc_allow" "$LOG_PATH"
+grep -q "TEST:PASS:m1_ipc_deny"  "$LOG_PATH"
+grep -q "TEST:PASS:m1_ipc$"      "$LOG_PATH"
+# Canonical deny marker per docs/abi/capability-deny-contract.md §4.
+# SUBJECT_M1_UNAUTH = 7 (see kernel/proc/module_registry.h).
+grep -Eq "^CAP:DENY:7:ipc_send:-$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -46,6 +46,7 @@ TEST_TARGETS=(
     ipc_port_lifecycle
     ipc_handle_gate
     proc_sched
+    m1_ipc_demo
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/docs/architecture/kernel-module-boundaries.md
+++ b/docs/architecture/kernel-module-boundaries.md
@@ -226,6 +226,20 @@ same PR so the "is" matches the "ought."
 
 ## 6. Cross-references
 
+### M1 acceptance demo
+
+The BUILD_ROADMAP §5.1 "two modules exchange message" and "unauthorized
+operation denied with explicit error" bullets are realised by the
+in-tree demo registered in `kernel/proc/module_registry.{c,h}` and
+driven by `tests/m1_ipc_demo_test.c` (build/scripts/test_m1_ipc_demo.sh,
+issue #251, plan #198 slice 4). Three compile-time modules—`m1-sender`,
+`m1-receiver`, `m1-unauth`—are spawned via `proc_spawn_module` (which
+chains `process_create` + `cap_table_grant` + `cap_handle_grant` +
+`proc_sched_register`) and exchange a single envelope through the
+handle-gated `ipc_send_h` / `ipc_recv_h` entry points. Allow path emits
+`TEST:PASS:m1_ipc_allow`; deny path emits `TEST:PASS:m1_ipc_deny` plus
+the canonical `CAP:DENY:<m1-unauth>:ipc_send:-` marker exactly once.
+
 - `AGENTS.md` — project intent.
 - `BUILD_ROADMAP.md` §2.2, §8 item 13 — aspirational tree and the requirement
   for this doc.

--- a/kernel/proc/module_registry.c
+++ b/kernel/proc/module_registry.c
@@ -1,0 +1,263 @@
+/**
+ * @file module_registry.c
+ * @brief Implementation of the M1 acceptance-demo module registry
+ *        (issue #251, plan #198 slice 4).
+ *
+ * See module_registry.h for the contract. This file owns the
+ * compile-time module table and the three entry stubs that produce the
+ * deterministic side-effects asserted by tests/m1_ipc_demo_test.c.
+ *
+ * Issue: #251.
+ */
+
+#include "module_registry.h"
+
+#include <string.h>
+
+#include "../cap/cap_handle.h"
+#include "../cap/cap_table.h"
+#include "../cap/capability.h"
+#include "../ipc/ipc_msg.h"
+#include "../ipc/ipc_ops.h"
+#include "../ipc/ipc_port.h"
+#include "process.h"
+#include "proc_sched.h"
+#include "../../user/include/secureos_abi.h"
+
+/* Canonical demo payload. Pinned so tests can byte-compare. */
+#define M1_DEMO_PAYLOAD "PING"
+#define M1_DEMO_PAYLOAD_LEN 4u
+#define M1_DEMO_TAG 0xC0DEu
+
+/* --------------------------------------------------------------------
+ * Transient demo state (port + per-subject handle map).
+ * ------------------------------------------------------------------ */
+
+#define M1_DEMO_MAX_SUBJECTS 8u
+
+typedef struct {
+  cap_subject_id_t subject;
+  cap_handle_t     handle;
+  bool             in_use;
+} demo_handle_slot_t;
+
+static ipc_port_t          g_demo_port = IPC_PORT_INVALID;
+static demo_handle_slot_t  g_demo_handles[M1_DEMO_MAX_SUBJECTS];
+static m1_demo_observations_t g_demo_obs;
+
+static void demo_handle_record(cap_subject_id_t subject, cap_handle_t h) {
+  /* Replace existing entry for the same subject if present. */
+  for (uint32_t i = 0u; i < M1_DEMO_MAX_SUBJECTS; ++i) {
+    if (g_demo_handles[i].in_use && g_demo_handles[i].subject == subject) {
+      g_demo_handles[i].handle = h;
+      return;
+    }
+  }
+  for (uint32_t i = 0u; i < M1_DEMO_MAX_SUBJECTS; ++i) {
+    if (!g_demo_handles[i].in_use) {
+      g_demo_handles[i].in_use = true;
+      g_demo_handles[i].subject = subject;
+      g_demo_handles[i].handle = h;
+      return;
+    }
+  }
+  /* Silently drop — the demo never registers more than 3 subjects so
+   * overflow indicates a test-harness bug. */
+}
+
+void m1_demo_reset(void) {
+  g_demo_port = IPC_PORT_INVALID;
+  memset(g_demo_handles, 0, sizeof(g_demo_handles));
+  memset(&g_demo_obs, 0, sizeof(g_demo_obs));
+}
+
+bool m1_demo_set_port(ipc_port_t port) {
+  if (port == IPC_PORT_INVALID) {
+    return false;
+  }
+  g_demo_port = port;
+  return true;
+}
+
+cap_handle_t m1_demo_get_handle_for(cap_subject_id_t subject) {
+  for (uint32_t i = 0u; i < M1_DEMO_MAX_SUBJECTS; ++i) {
+    if (g_demo_handles[i].in_use && g_demo_handles[i].subject == subject) {
+      return g_demo_handles[i].handle;
+    }
+  }
+  return CAP_HANDLE_NULL;
+}
+
+const m1_demo_observations_t *m1_demo_observations_for_tests(void) {
+  return &g_demo_obs;
+}
+
+/* --------------------------------------------------------------------
+ * Per-module entry stubs.
+ *
+ * Each stub runs inside a scheduled PCB (proc_sched_register sets up
+ * the ucontext stack). They MUST NOT return — proc_exit() never
+ * returns to its caller. The stubs record their observable behaviour
+ * into g_demo_obs and emit the per-marker TEST:PASS lines that the
+ * acceptance harness scrapes.
+ * ------------------------------------------------------------------ */
+
+static void entry_m1_receiver(void) {
+  /* Look up our handle (issued at spawn time). */
+  cap_handle_t recv_h = m1_demo_get_handle_for(SUBJECT_M1_RECEIVER);
+  if (recv_h == CAP_HANDLE_NULL || g_demo_port == IPC_PORT_INVALID) {
+    (void)proc_exit(901u);
+  }
+
+  ipc_msg_v0 in;
+  memset(&in, 0xAA, sizeof(in));
+  ipc_result_t r = ipc_recv_h(recv_h, g_demo_port, &in);
+  if (r != IPC_OK) {
+    (void)proc_exit(902u);
+  }
+
+  g_demo_obs.recv_ok++;
+  g_demo_obs.recv_sender_subject = in.sender_subject;
+
+  if (in.tag == M1_DEMO_TAG
+      && in.payload_len == M1_DEMO_PAYLOAD_LEN
+      && memcmp(in.payload, M1_DEMO_PAYLOAD, M1_DEMO_PAYLOAD_LEN) == 0
+      && in.sender_subject == SUBJECT_M1_SENDER) {
+    g_demo_obs.recv_payload_ok = 1u;
+  }
+  (void)proc_exit(0u);
+}
+
+static void demo_make_msg(ipc_msg_v0 *m) {
+  memset(m, 0, sizeof(*m));
+  m->abi_version = (uint16_t)OS_ABI_VERSION;
+  m->flags = 0u;
+  /* Deliberately set sender_subject to garbage so the test confirms
+   * the handle-gated path overwrites it with the handle's owner. */
+  m->sender_subject = 0xFEEDFACEu;
+  m->tag = M1_DEMO_TAG;
+  m->payload_len = M1_DEMO_PAYLOAD_LEN;
+  memcpy(m->payload, M1_DEMO_PAYLOAD, M1_DEMO_PAYLOAD_LEN);
+}
+
+static void entry_m1_sender(void) {
+  cap_handle_t send_h = m1_demo_get_handle_for(SUBJECT_M1_SENDER);
+  if (send_h == CAP_HANDLE_NULL || g_demo_port == IPC_PORT_INVALID) {
+    (void)proc_exit(801u);
+  }
+
+  ipc_msg_v0 m;
+  demo_make_msg(&m);
+
+  ipc_result_t r = ipc_send_h(send_h, g_demo_port, &m);
+  if (r != IPC_OK) {
+    (void)proc_exit(802u);
+  }
+  g_demo_obs.send_allow_ok = 1u;
+  (void)proc_exit(0u);
+}
+
+static void entry_m1_unauth(void) {
+  /* SUBJECT_M1_UNAUTH was spawned with a handle for the WRONG cap
+   * (CAP_CONSOLE_WRITE — see g_modules below). The handle resolves
+   * with owner == SUBJECT_M1_UNAUTH, but its cap_id mismatches the
+   * port's required CAP_IPC_SEND, so cap_gate_check_handle_result
+   * returns CAP_ERR_MISSING and ipc_send_h emits the canonical
+   *   CAP:DENY:<SUBJECT_M1_UNAUTH>:ipc_send:-
+   * marker (subject id is the kernel-trusted handle owner, so the
+   * marker carries 259 — SUBJECT_M1_UNAUTH — not 0).
+   *
+   * The test also asserts the receiver remains BLOCKED when the unauth
+   * module runs in isolation (no sender, no other waker). */
+  if (g_demo_port == IPC_PORT_INVALID) {
+    (void)proc_exit(701u);
+  }
+  cap_handle_t bad_h = m1_demo_get_handle_for(SUBJECT_M1_UNAUTH);
+  if (bad_h == CAP_HANDLE_NULL) {
+    (void)proc_exit(702u);
+  }
+
+  ipc_msg_v0 m;
+  demo_make_msg(&m);
+
+  ipc_result_t r = ipc_send_h(bad_h, g_demo_port, &m);
+  if (r == IPC_ERR_CAP_DENIED) {
+    g_demo_obs.send_deny_cap_denied = 1u;
+  }
+  (void)proc_exit(0u);
+}
+
+/* --------------------------------------------------------------------
+ * Module registry table.
+ * ------------------------------------------------------------------ */
+
+typedef struct {
+  const char       *name;
+  cap_subject_id_t  subject;
+  proc_entry_fn_t   entry;
+  /* `declared_cap == 0` means "no cap granted at spawn time". The
+   * capability_id_t enum starts at 1 so 0 is a safe sentinel. */
+  capability_id_t   declared_cap;
+} module_descriptor_t;
+
+static const module_descriptor_t g_modules[] = {
+  { "m1-sender",   SUBJECT_M1_SENDER,   entry_m1_sender,   CAP_IPC_SEND },
+  { "m1-receiver", SUBJECT_M1_RECEIVER, entry_m1_receiver, CAP_IPC_RECV },
+  /* m1-unauth gets a deliberately wrong cap (CAP_CONSOLE_WRITE) so the
+   * deny marker emitted by ipc_send_h carries SUBJECT_M1_UNAUTH as the
+   * authenticated handle owner — matching the plan's expectation of
+   * a deny marker scoped to m1-unauth's identity, not subject 0. */
+  { "m1-unauth",   SUBJECT_M1_UNAUTH,   entry_m1_unauth,   CAP_CONSOLE_WRITE },
+};
+
+#define M1_MODULE_COUNT (sizeof(g_modules) / sizeof(g_modules[0]))
+
+static const module_descriptor_t *lookup_module(const char *name) {
+  if (name == NULL) {
+    return NULL;
+  }
+  for (uint32_t i = 0u; i < M1_MODULE_COUNT; ++i) {
+    if (strcmp(g_modules[i].name, name) == 0) {
+      return &g_modules[i];
+    }
+  }
+  return NULL;
+}
+
+module_spawn_result_t proc_spawn_module(const char *name,
+                                        process_id_t *out_pid) {
+  if (out_pid == NULL) {
+    return MODULE_SPAWN_ERR_INVALID_ARG;
+  }
+  const module_descriptor_t *m = lookup_module(name);
+  if (m == NULL) {
+    return MODULE_SPAWN_ERR_UNKNOWN_NAME;
+  }
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(m->subject, NULL, &pid) != PROC_OK) {
+    return MODULE_SPAWN_ERR_PROC_CREATE;
+  }
+
+  if (m->declared_cap != (capability_id_t)0) {
+    /* Grant via the legacy bitset so the cap_check audit-ring path in
+     * ipc_send_h / ipc_recv_h sees a matching grant (ipc_ops.c calls
+     * cap_check for audit parity on both allow and deny paths). */
+    if (cap_table_grant(m->subject, m->declared_cap) != CAP_OK) {
+      return MODULE_SPAWN_ERR_CAP_GRANT;
+    }
+    /* Authoritative handle for the handle-gated decision. */
+    cap_handle_t h = cap_handle_grant(m->subject, m->declared_cap);
+    if (h == CAP_HANDLE_NULL) {
+      return MODULE_SPAWN_ERR_CAP_GRANT;
+    }
+    demo_handle_record(m->subject, h);
+  }
+
+  if (proc_sched_register(pid, m->entry) != PROC_SCHED_OK) {
+    return MODULE_SPAWN_ERR_SCHED_REGISTER;
+  }
+
+  *out_pid = pid;
+  return MODULE_SPAWN_OK;
+}

--- a/kernel/proc/module_registry.h
+++ b/kernel/proc/module_registry.h
@@ -1,0 +1,162 @@
+/**
+ * @file module_registry.h
+ * @brief M1 acceptance-demo module registry (issue #251, plan #198 slice 4).
+ *
+ * Purpose:
+ *   Static, compile-time table of the three "modules" used by the M1
+ *   two-module IPC acceptance demo (BUILD_ROADMAP §5.1):
+ *
+ *     name           subject                 declared cap        role
+ *     m1-sender      SUBJECT_M1_SENDER       CAP_IPC_SEND        allow-path send
+ *     m1-receiver    SUBJECT_M1_RECEIVER     CAP_IPC_RECV        port owner / recv
+ *     m1-unauth      SUBJECT_M1_UNAUTH       (none)              deny-path send
+ *
+ *   `proc_spawn_module(name, out_pid)` looks up the entry by name,
+ *   creates a PCB bound to the registered subject, grants the declared
+ *   capability via BOTH `cap_table_grant` (for the audit-ring path the
+ *   handle-gated IPC ops still drive) and `cap_handle_grant` (for the
+ *   authoritative handle-keyed decision), and registers a kernel-stack
+ *   entry stub with the cooperative scheduler.
+ *
+ *   The IPC port used by the demo is owned by the test harness and
+ *   announced to the registry via `m1_demo_set_port` before any module
+ *   is spawned. The registry's per-module entry stubs route through
+ *   `ipc_send_h` / `ipc_recv_h` using the handle issued at spawn time
+ *   (looked up by subject id via `m1_demo_get_handle_for`).
+ *
+ * Out of scope (per issue #251):
+ *   - No new syscall surface, no ABI bump.
+ *   - No filesystem-backed module load (M3).
+ *   - No dynamic grants — the cap set per module is fixed at compile
+ *     time so the demo is deterministic.
+ *
+ * Interactions:
+ *   - kernel/proc/process.{c,h}: process_create + PCB lifecycle.
+ *   - kernel/proc/proc_sched.{c,h}: proc_sched_register.
+ *   - kernel/cap/cap_table.h:  cap_table_grant for audit-ring parity.
+ *   - kernel/cap/cap_handle.h: cap_handle_grant for the handle-gated
+ *     IPC decision.
+ *   - kernel/ipc/ipc_ops.h:    ipc_send_h / ipc_recv_h.
+ *
+ * Launched by:
+ *   tests/m1_ipc_demo_test.c (host build), dispatched via
+ *   build/scripts/test_m1_ipc_demo.sh.
+ *
+ * Issue: #251. Plan: plans/2026-05-20-m1-process-address-space.md slice 4.
+ */
+
+#ifndef SECUREOS_KERNEL_PROC_MODULE_REGISTRY_H
+#define SECUREOS_KERNEL_PROC_MODULE_REGISTRY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../cap/cap_handle.h"
+#include "../cap/capability.h"
+#include "../ipc/ipc_port.h"
+#include "process.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Stable subject ids for the three M1 demo modules. Frozen under
+ * OS_ABI_VERSION = 0 — tests pin the exact values so a regression in
+ * the registry is caught immediately.
+ */
+/*
+ * NOTE: subject ids are kept under CAP_TABLE_MAX_SUBJECTS (8 in v0)
+ * because the audit-ring parity hit in ipc_send_h / ipc_recv_h still
+ * threads through cap_table_check, which rejects out-of-range subject
+ * ids with CAP_ERR_SUBJECT_INVALID. Growing the bitset table is
+ * tracked separately under the M1-CAPTBL umbrella.
+ */
+#define SUBJECT_M1_SENDER   ((cap_subject_id_t)5u)
+#define SUBJECT_M1_RECEIVER ((cap_subject_id_t)6u)
+#define SUBJECT_M1_UNAUTH   ((cap_subject_id_t)7u)
+
+/*
+ * Result vocabulary for proc_spawn_module. Distinct from proc_result_t
+ * and proc_sched_result_t so callers can tell registry-level failures
+ * (unknown name, demo state not initialised) from PCB-table or
+ * scheduler-level failures.
+ */
+typedef enum {
+  MODULE_SPAWN_OK = 0,
+  MODULE_SPAWN_ERR_UNKNOWN_NAME = 1,
+  MODULE_SPAWN_ERR_INVALID_ARG = 2,
+  MODULE_SPAWN_ERR_PROC_CREATE = 3,
+  MODULE_SPAWN_ERR_SCHED_REGISTER = 4,
+  MODULE_SPAWN_ERR_CAP_GRANT = 5,
+  MODULE_SPAWN_ERR_DEMO_UNINITIALISED = 6,
+} module_spawn_result_t;
+
+/*
+ * Reset the demo's transient state (the announced port and the
+ * per-subject handle map). Always call at the start of a test phase
+ * alongside process_table_reset / proc_sched_reset / cap_*_reset.
+ */
+void m1_demo_reset(void);
+
+/*
+ * Announce the IPC port the demo will exchange over. The port MUST be
+ * owned by SUBJECT_M1_RECEIVER and configured with send_cap=CAP_IPC_SEND
+ * / recv_cap=CAP_IPC_RECV; the registry does not enforce this beyond
+ * storing the handle, but the demo entry stubs assume it.
+ *
+ * Returns false if `port` equals IPC_PORT_INVALID; otherwise true.
+ */
+bool m1_demo_set_port(ipc_port_t port);
+
+/*
+ * Look up the cap_handle_t most recently issued to `subject` by a
+ * spawn call. Returns CAP_HANDLE_NULL if no spawn issued one (e.g.
+ * SUBJECT_M1_UNAUTH — its registered cap set is empty so no handle is
+ * granted at spawn time).
+ */
+cap_handle_t m1_demo_get_handle_for(cap_subject_id_t subject);
+
+/*
+ * Spawn a module by registered name. Equivalent to:
+ *   1. process_create(module.subject, NULL, &pid)
+ *   2. cap_table_grant + cap_handle_grant for the module's declared cap
+ *      (no-op if the module declares no cap, i.e. m1-unauth)
+ *   3. proc_sched_register(pid, module.entry)
+ *
+ * On success writes the new PID to `*out_pid`. On failure leaves
+ * `*out_pid` untouched. `name` MUST be one of "m1-sender",
+ * "m1-receiver", or "m1-unauth"; any other value returns
+ * MODULE_SPAWN_ERR_UNKNOWN_NAME.
+ *
+ * The function is intentionally idempotent-free: calling it twice with
+ * the same name within one test phase creates two distinct PCBs
+ * sharing the same subject id (which is fine — subjects in v0 are not
+ * required to be unique across PCBs).
+ */
+module_spawn_result_t proc_spawn_module(const char *name,
+                                        process_id_t *out_pid);
+
+/* ---------------- test-only inspectors (issue #251) --------------- */
+
+/*
+ * The demo entry stubs record their observable side effects into the
+ * counters below so the test can assert exact behaviour without
+ * peeking at scheduler / IPC internals. All counters are zeroed by
+ * m1_demo_reset().
+ */
+typedef struct {
+  uint32_t recv_ok;                /* receiver completed ipc_recv_h with OK */
+  uint32_t recv_payload_ok;        /* receiver saw expected payload + sender */
+  uint32_t recv_sender_subject;    /* sender_subject stamped by kernel */
+  uint32_t send_allow_ok;          /* sender's ipc_send_h returned IPC_OK */
+  uint32_t send_deny_cap_denied;   /* unauth ipc_send_h returned CAP_DENIED */
+} m1_demo_observations_t;
+
+const m1_demo_observations_t *m1_demo_observations_for_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_PROC_MODULE_REGISTRY_H */

--- a/tests/m1_ipc_demo_test.c
+++ b/tests/m1_ipc_demo_test.c
@@ -1,0 +1,265 @@
+/**
+ * @file m1_ipc_demo_test.c
+ * @brief Acceptance harness for the M1 two-module IPC demo
+ *        (issue #251, plan #198 slice 4, BUILD_ROADMAP §5.1).
+ *
+ * Covers the two §5.1 acceptance bullets:
+ *
+ *   1. "two modules exchange message" — m1-sender → m1-receiver
+ *      round-trip via ipc_send_h / ipc_recv_h across two PCBs.
+ *      The kernel-stamped sender_subject reaches the receiver as
+ *      SUBJECT_M1_SENDER (not the attacker-supplied 0xFEEDFACE).
+ *      Emits TEST:PASS:m1_ipc_allow.
+ *
+ *   2. "unauthorized operation denied with explicit error" —
+ *      m1-unauth attempts ipc_send_h with a wrong-cap handle
+ *      (CAP_CONSOLE_WRITE) and is denied. ipc_send_h returns
+ *      IPC_ERR_CAP_DENIED, exactly one
+ *      CAP:DENY:<SUBJECT_M1_UNAUTH>:ipc_send:- marker is emitted,
+ *      and the receiver remains BLOCKED with no envelope delivered.
+ *      Emits TEST:PASS:m1_ipc_deny.
+ *
+ *   Aggregate marker TEST:PASS:m1_ipc is the harness rollup.
+ *
+ * Launched by:
+ *   build/scripts/test_m1_ipc_demo.sh (dispatched via test.sh and
+ *   validate_bundle.sh).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/module_registry.h"
+#include "../kernel/proc/proc_sched.h"
+#include "../kernel/proc/process.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:m1_ipc:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  m1_demo_reset();
+  proc_sched_reset();
+  process_table_reset();
+  ipc_port_table_reset();
+  cap_reset_for_tests();
+  cap_table_reset();
+  cap_handle_table_reset();
+  cap_audit_reset_for_tests();
+}
+
+/* ------------------------------------------------------------------ */
+/* (1) Allow path                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_allow(void) {
+  reset_world();
+
+  /* Receiver must hold CAP_IPC_RECV before the port is created — the
+   * scheduler hasn't run yet so the spawn-time grant ordering matters.
+   * Spawn the receiver first so its handle is recorded before we make
+   * the port (the port's owner field references SUBJECT_M1_RECEIVER). */
+  process_id_t pr = PID_INVALID;
+  if (proc_spawn_module("m1-receiver", &pr) != MODULE_SPAWN_OK) {
+    die("spawn_receiver");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(SUBJECT_M1_RECEIVER, CAP_IPC_SEND, CAP_IPC_RECV, &port)
+        != IPC_OK
+      || port == IPC_PORT_INVALID) {
+    die("port_create");
+  }
+  if (!m1_demo_set_port(port)) {
+    die("set_port");
+  }
+
+  process_id_t ps = PID_INVALID;
+  if (proc_spawn_module("m1-sender", &ps) != MODULE_SPAWN_OK) {
+    die("spawn_sender");
+  }
+
+  if (proc_sched_run() != PROC_SCHED_OK) {
+    die("sched_run_allow");
+  }
+
+  const m1_demo_observations_t *obs = m1_demo_observations_for_tests();
+  if (!obs->send_allow_ok)       die("send_did_not_succeed");
+  if (!obs->recv_ok)             die("recv_did_not_complete");
+  if (!obs->recv_payload_ok)     die("recv_payload_mismatch");
+  if (obs->recv_sender_subject != SUBJECT_M1_SENDER) {
+    die("sender_subject_not_kernel_stamped");
+  }
+
+  process_t snap;
+  if (process_lookup(pr, &snap) != PROC_OK
+      || snap.state != PROC_STATE_EXITED
+      || snap.exit_code != 0u) {
+    die("receiver_bad_terminal");
+  }
+  if (process_lookup(ps, &snap) != PROC_OK
+      || snap.state != PROC_STATE_EXITED
+      || snap.exit_code != 0u) {
+    die("sender_bad_terminal");
+  }
+
+  printf("TEST:PASS:m1_ipc_allow\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (2) Deny path                                                       */
+/* ------------------------------------------------------------------ */
+
+/* We need to capture the CAP:DENY: line emitted by ipc_send_h on the
+ * deny path so the test can pin: (a) marker present, (b) marker
+ * appears exactly once. We re-route stdout through a pipe for the
+ * duration of the scheduler run, then drain it and re-emit so the
+ * outer log keeps the line visible to the test_*.sh grep.
+ */
+#include <fcntl.h>
+#include <unistd.h>
+
+static char g_deny_capture[8192];
+static size_t g_deny_capture_len = 0u;
+
+static int dup_stdout_fd = -1;
+static int pipe_fds[2] = {-1, -1};
+
+static void capture_begin(void) {
+  fflush(stdout);
+  if (pipe(pipe_fds) != 0) die("pipe");
+  /* Make the read end non-blocking so capture_end's drain loop
+   * terminates after the writer is restored. */
+  int flags = fcntl(pipe_fds[0], F_GETFL, 0);
+  (void)fcntl(pipe_fds[0], F_SETFL, flags | O_NONBLOCK);
+
+  dup_stdout_fd = dup(STDOUT_FILENO);
+  if (dup_stdout_fd < 0) die("dup_stdout");
+  if (dup2(pipe_fds[1], STDOUT_FILENO) < 0) die("dup2_pipe");
+  close(pipe_fds[1]);
+  pipe_fds[1] = -1;
+  g_deny_capture_len = 0u;
+  g_deny_capture[0] = '\0';
+}
+
+static void capture_end(void) {
+  fflush(stdout);
+  /* Restore stdout BEFORE draining so any newly-printed bytes go to
+   * the real stdout, not the pipe. */
+  if (dup2(dup_stdout_fd, STDOUT_FILENO) < 0) die("dup2_restore");
+  close(dup_stdout_fd);
+  dup_stdout_fd = -1;
+
+  for (;;) {
+    char buf[1024];
+    ssize_t n = read(pipe_fds[0], buf, sizeof(buf));
+    if (n <= 0) break;
+    size_t room = sizeof(g_deny_capture) - 1u - g_deny_capture_len;
+    size_t take = ((size_t)n < room) ? (size_t)n : room;
+    memcpy(g_deny_capture + g_deny_capture_len, buf, take);
+    g_deny_capture_len += take;
+    g_deny_capture[g_deny_capture_len] = '\0';
+  }
+  close(pipe_fds[0]);
+  pipe_fds[0] = -1;
+
+  /* Re-emit captured bytes so the outer log retains visibility. */
+  fwrite(g_deny_capture, 1, g_deny_capture_len, stdout);
+  fflush(stdout);
+}
+
+static size_t count_substr(const char *hay, const char *needle) {
+  size_t n = 0u;
+  size_t nl = strlen(needle);
+  if (nl == 0u) return 0u;
+  const char *p = hay;
+  while ((p = strstr(p, needle)) != NULL) {
+    n++;
+    p += nl;
+  }
+  return n;
+}
+
+static void test_deny(void) {
+  reset_world();
+
+  /* Receiver first so it blocks on the port and we can observe it. */
+  process_id_t pr = PID_INVALID;
+  if (proc_spawn_module("m1-receiver", &pr) != MODULE_SPAWN_OK) {
+    die("spawn_receiver_deny");
+  }
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  if (ipc_port_create(SUBJECT_M1_RECEIVER, CAP_IPC_SEND, CAP_IPC_RECV, &port)
+        != IPC_OK
+      || port == IPC_PORT_INVALID) {
+    die("port_create_deny");
+  }
+  if (!m1_demo_set_port(port)) die("set_port_deny");
+
+  process_id_t pu = PID_INVALID;
+  if (proc_spawn_module("m1-unauth", &pu) != MODULE_SPAWN_OK) {
+    die("spawn_unauth");
+  }
+
+  capture_begin();
+  proc_sched_result_t rr = proc_sched_run();
+  capture_end();
+
+  /* Receiver remains blocked (no envelope), unauth exits cleanly, so
+   * the scheduler must classify this as a deadlock (one PCB BLOCKED,
+   * no possible waker). */
+  if (rr != PROC_SCHED_ERR_DEADLOCK) {
+    die("deny_did_not_deadlock");
+  }
+
+  const m1_demo_observations_t *obs = m1_demo_observations_for_tests();
+  if (!obs->send_deny_cap_denied) die("unauth_send_not_denied");
+  if (obs->recv_ok)               die("recv_completed_on_deny");
+  if (obs->send_allow_ok)         die("allow_path_ran_on_deny");
+
+  /* Deny marker shape per docs/abi/capability-deny-contract.md §4 and
+   * ipc_ops.c's ipc_emit_deny_marker: "CAP:DENY:<subject>:ipc_send:-".
+   */
+  char expected[64];
+  snprintf(expected, sizeof(expected),
+           "CAP:DENY:%u:ipc_send:-\n", (unsigned)SUBJECT_M1_UNAUTH);
+  size_t hits = count_substr(g_deny_capture, expected);
+  if (hits == 0u) die("deny_marker_missing");
+  if (hits > 1u)  die("deny_marker_emitted_more_than_once");
+
+  /* Envelope must not have leaked into the port slot. */
+  if (ipc_port_has_pending_for_tests(port)) {
+    die("envelope_leaked_on_deny");
+  }
+
+  /* Receiver PCB must still be BLOCKED on the port (never woken). */
+  process_t snap;
+  if (process_lookup(pr, &snap) != PROC_OK) die("lookup_receiver");
+  if (snap.state != PROC_STATE_BLOCKED) die("receiver_not_blocked_after_deny");
+
+  /* Unauth PCB exited cleanly with exit_code 0 (the entry returns
+   * proc_exit(0) on the denied-as-expected branch). */
+  if (process_lookup(pu, &snap) != PROC_OK
+      || snap.state != PROC_STATE_EXITED
+      || snap.exit_code != 0u) {
+    die("unauth_bad_terminal");
+  }
+
+  printf("TEST:PASS:m1_ipc_deny\n");
+}
+
+int main(void) {
+  test_allow();
+  test_deny();
+  printf("TEST:PASS:m1_ipc\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #251. Executes slice 4 (final code slice) of plan #198 (`plans/2026-05-20-m1-process-address-space.md`), wiring the canonical two-module IPC demo and satisfying BUILD_ROADMAP §5.1's two validation bullets.

## Summary

- **`kernel/proc/module_registry.{c,h}`** — compile-time table of three M1 demo modules with declared subjects, caps, and entry stubs:
  - `m1-sender` (subject 5) — `CAP_IPC_SEND`
  - `m1-receiver` (subject 6) — `CAP_IPC_RECV`, owns the demo port
  - `m1-unauth` (subject 7) — deliberately granted `CAP_CONSOLE_WRITE` (wrong cap) so the deny path is scoped to its identity (not subject 0)
  - `proc_spawn_module(name, &pid)` chains `process_create` + `cap_table_grant` + `cap_handle_grant` + `proc_sched_register`. No dynamic grants at runtime — fully deterministic per the plan.
- **`tests/m1_ipc_demo_test.c`** — host-side acceptance harness:
  - **Allow path**: kernel-stamped `sender_subject` reaches the receiver as `SUBJECT_M1_SENDER` (not the attacker-supplied `0xFEEDFACE` planted in the outbound envelope); round-trip uses `ipc_send_h` / `ipc_recv_h`; both PCBs reach `EXITED` with `exit_code 0`.
  - **Deny path**: `m1-unauth`'s `ipc_send_h` with a wrong-cap handle returns `IPC_ERR_CAP_DENIED`, exactly one canonical `CAP:DENY:7:ipc_send:-` marker is emitted (captured via a stdout pipe so we can pin the count to 1), no envelope leaks into the port slot, the receiver remains `BLOCKED`, and `proc_sched_run` returns `PROC_SCHED_ERR_DEADLOCK` (rather than hanging) because the leftover blocked PCB has no possible waker.
- **`build/scripts/test_m1_ipc_demo.sh`** + wiring into `test.sh` / `test.ps1` / `validate_bundle.sh` / `.shell_parity_allowlist` (parity per #156).
- **Docs**: BUILD_ROADMAP §5.1 acceptance bullets now cross-link the marker names; `docs/architecture/kernel-module-boundaries.md` gains a one-paragraph "M1 acceptance demo" pointer.

## Markers

```
TEST:PASS:m1_ipc_allow
TEST:PASS:m1_ipc_deny
TEST:PASS:m1_ipc
CAP:DENY:7:ipc_send:-
```

## Validation

All green locally:

```
bash build/scripts/test.sh m1_ipc_demo
bash build/scripts/test.sh proc_sched
bash build/scripts/test.sh ipc_handle_gate
bash build/scripts/test.sh ipc_sync_v0
bash build/scripts/test.sh validate_capability_registry
bash build/scripts/check_shell_parity.sh
```

## Implementation notes / deviations

- **Subject ids land at 5/6/7** (below `CAP_TABLE_MAX_SUBJECTS=8`) rather than the plan's `0x0101/0x0102/0x0103`, because the legacy `cap_table` bitset that `ipc_send_h` / `ipc_recv_h` still drive for audit-ring parity (#243) rejects out-of-range subject ids with `CAP_ERR_SUBJECT_INVALID`. Growing the bitset table is its own M1-CAPTBL follow-up.
- **`m1-unauth` is granted a wrong cap, not nothing**, so the deny marker scopes to `SUBJECT_M1_UNAUTH` (handle-owner of a stale-or-wrong-cap handle would otherwise be 0). This matches the plan's wording that the marker is `m1-unauth`'s identity.

## Follow-ups (out of scope here, intentionally)

- Validator JSON report `acceptance.m1_kernel` field flip from `pending` to `pass`: the current schema (`docs/test-plans/validator-report.schema.json`) has no `acceptance` block yet; that's a separate schema-extension PR. The two new markers are now part of `TEST_TARGETS` in `validate_bundle.sh`, so the report's `targets[]` already covers them.
- `EXPECTED_FAIL_TARGETS` negative-path canary per #213 — the `canary_must_fail` slot already covers harness-defense; a per-demo negative canary can land alongside the schema extension above.

Cross-references: plan #198, slice 3 PR #254, slice 2 PR #249, handle-gate PR #247, plan-parity #156.