### PR TITLE
docs(roadmap): wire M2 acceptance bullets to existing TEST:PASS markers (#82)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -231,8 +231,24 @@ Deliver:
 
 Validate:
 
-- grant path: HelloApp prints
-- deny path: HelloApp cannot print and receives defined error/fallback
+- grant path: HelloApp prints — satisfied by
+  `TEST:PASS:helloapp_allowed_console_write` + `TEST:PASS:helloapp_allow`
+  (see `tests/helloapp_allow_test.c`, run via
+  `build/scripts/test.sh helloapp_allow`; plan
+  `plans/2026-04-14-console-service-launcher-helloapp.md`, umbrella issue
+  #82).
+- deny path: HelloApp cannot print and receives defined error/fallback —
+  satisfied by `TEST:PASS:helloapp_denied_console_write` +
+  `TEST:PASS:helloapp_deny` (see `tests/helloapp_deny_test.c`, run via
+  `build/scripts/test.sh helloapp_deny`; same plan / issue #82).
+- launcher-mediation regression: direct console writes without an explicit
+  launcher-issued grant remain denied, and revoke restores the deny path —
+  satisfied by `TEST:PASS:launcher_console_deny_without_grant`,
+  `TEST:PASS:launcher_console_allow_after_grant`,
+  `TEST:PASS:launcher_console_regression_bypass_denied`, and
+  `TEST:PASS:launcher_console_revoke_restores_deny` (see
+  `tests/launcher_console_test.c`, run via
+  `build/scripts/test.sh launcher_console`).
 
 ## 5.3 M3: Filesystem service + faux FS
 


### PR DESCRIPTION
## Summary

BUILD_ROADMAP §5.1 (M1) names the concrete `TEST:PASS:*` markers that satisfy each acceptance bullet (e.g. `TEST:PASS:m1_ipc_allow`, `TEST:PASS:m1_ipc_deny`). §5.2 (M2 — console + launcher + HelloApp) listed acceptance in prose only, even though the harness targets already exist and pass on main. This PR mirrors the §5.1 pattern for §5.2 so milestone closure is grep-able and tied to specific harness entry points.

Closes nothing on its own — umbrella issue #82 still belongs to the maintainer to close once they're satisfied the M2 slice is done. This PR strengthens that closure rationale.

## Change

Single doc edit in `BUILD_ROADMAP.md` §5.2:

- **grant path** → `tests/helloapp_allow_test.c` (`TEST:PASS:helloapp_allowed_console_write` + `TEST:PASS:helloapp_allow`)
- **deny path** → `tests/helloapp_deny_test.c` (`TEST:PASS:helloapp_denied_console_write` + `TEST:PASS:helloapp_deny`)
- **launcher-mediation regression** → `tests/launcher_console_test.c` (`deny_without_grant` / `allow_after_grant` / `regression_bypass_denied` / `revoke_restores_deny`)

No code changes. No new tests. The plan file (`plans/2026-04-14-console-service-launcher-helloapp.md`) is referenced inline.

## Validation

All three named harness targets pass on this branch (clean main + docs-only diff):

```
$ bash build/scripts/test.sh helloapp_allow
TEST:PASS:helloapp_allowed_console_write
TEST:PASS:helloapp_allow

$ bash build/scripts/test.sh helloapp_deny
TEST:PASS:helloapp_denied_console_write
TEST:PASS:helloapp_deny

$ bash build/scripts/test.sh launcher_console
TEST:PASS:launcher_console_deny_without_grant
TEST:PASS:launcher_console_allow_after_grant
TEST:PASS:launcher_console_regression_bypass_denied
TEST:PASS:launcher_console_revoke_restores_deny
TEST:PASS:launcher_console_invalid_app
TEST:PASS:launcher_console_reset_clears_state

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 63 entries)
```

## Follow-ups

- Maintainer can close #82 once they're satisfied this rationale matches their bar (every bulleted exit criterion now points at a specific PASS marker).
- Same pattern can be applied to §5.3/§5.4/§5.5/§5.6 in future cron runs as those slices' acceptance harnesses land.

_— secureos-hourly-issue-work cron, run e4c62e32_