### PR TITLE
docs(abi): bump stale 'Last verified against commit' stamps (fixes #257)

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -36,4 +36,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -174,4 +174,4 @@ fixture or fail this test loudly with a per-line diff. Updating the
 fixture is allowed only under an explicit audit-ABI bump per
 BUILD_ROADMAP §7.
 
-Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -268,4 +268,4 @@ implementation work begins under #180 / #185. Implementation issues that
 must conform to this surface are enumerated in the M1 plan referenced
 above.
 
-Last verified against commit: c7f777d502b02e1f9e2542f42ff5650b8efce1d6
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -177,4 +177,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6

--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -139,5 +139,5 @@ unused"). The reservation is purely an ABI-shape anchor.
 4. Add an allow-path and a deny-path test under `build/scripts/test_*.sh`.
 5. Update this table and bump the verification line below.
 
-Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6
 

--- a/docs/abi/versioning.md
+++ b/docs/abi/versioning.md
@@ -86,4 +86,4 @@ Decode with `(v >> 16) & 0xFFFF` and `v & 0xFFFF`.
 3. `os_get_abi_version()` returns the same value the header advertises
    (catches stale runtime stubs after a bump).
 
-Last verified against commit: 9f4f7ccbb19c9ffb28ee4b6de2f3e93c35e65785
+Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6


### PR DESCRIPTION
Closes #257.

## What

Bumps the `Last verified against commit:` provenance line on six `docs/abi/` files from their stale prior SHAs to `9b2089b` (current `main` at the time of authoring).

| File | Old SHA | New SHA |
|---|---|---|
| README.md          | 9f4f7cc | 9b2089b |
| syscalls.md        | 9f4f7cc | 9b2089b |
| capabilities.md    | 9f4f7cc | 9b2089b |
| manifest.md        | 9f4f7cc | 9b2089b |
| versioning.md      | 9f4f7cc | 9b2089b |
| ipc-wire.md        | c7f777d | 9b2089b |

`capability-registry.md` is intentionally excluded (its stamp is "regenerated on each touch" and CI-validated per #236).

## Why

Per `docs/abi/README.md` §Provenance and `docs/abi/versioning.md` §"How to update" step 3, this stamp must be bumped in the same PR that touches the underlying surface. Several recent merges (#208, #229, #235, #236, #237, #240, #242, #244, #245) landed surface edits without bumping the stamps; this PR catches them up in one mechanical pass.

## Validation

- `git diff` is one-line-per-file — purely the SHA value.
- Re-read each doc against the current implementation while bumping; no prose changes were needed (each file's normative content still matches the in-tree code/headers — capabilities.md still describes the 32-bit handle layout from #237, syscalls.md still matches the entry stub from #235, ipc-wire.md still matches the M1 IPC primitive, etc.).
- No code touched, no CI surface broadened.

## Follow-up (out of scope)

#257's body suggests a future CI check that fails when any `docs/abi/*.md` stamp predates the file's own last-modifying commit. That regression-prevention work is deliberately deferred to a separate issue to keep this PR narrow.

_— secureos-hourly-issue-work cron, run e4c62e32, 2026-05-23 12:42 UTC_