### PR TITLE
feat(proc): aspace_contains bounds-check helper (#260 step 1)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -38,6 +38,7 @@ test_cap_handle_revoke_subtree
 test_process_table
 test_proc_sched
 test_aspace_carve
+test_aspace_bounds
 test_m1_ipc_demo
 test_cert_chain
 test_codesign

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|aspace_bounds|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -123,6 +123,9 @@ case "$TEST_NAME" in
     ;;
   aspace_carve)
     run_script "$ROOT_DIR/build/scripts/test_aspace_carve.sh"
+    ;;
+  aspace_bounds)
+    run_script "$ROOT_DIR/build/scripts/test_aspace_bounds.sh"
     ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"

--- a/build/scripts/test_aspace_bounds.sh
+++ b/build/scripts/test_aspace_bounds.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# build/scripts/test_aspace_bounds.sh
+#
+# Build + run the M1 address-space bounds-check unit test (issue #260,
+# plan plans/2026-05-20-m1-process-address-space.md slice 2).
+#
+# Covers:
+#   - In-window pointer + length passes.
+#   - One byte past base+size is rejected.
+#   - Range straddling the upper or lower boundary is rejected.
+#   - NULL aspace returns false.
+#   - Overflow-safe rejection of windows / ranges whose arithmetic
+#     would wrap past UINTPTR_MAX.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/tests/aspace_bounds_test.c" \
+  -o "$OUT_DIR/aspace_bounds_test"
+
+LOG_PATH="$OUT_DIR/aspace_bounds_test.log"
+"$OUT_DIR/aspace_bounds_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:aspace_bounds_allow" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_bounds_deny" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_bounds_straddle" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_bounds_null_aspace" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_bounds_overflow" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_bounds$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/proc/address_space.c
+++ b/kernel/proc/address_space.c
@@ -85,3 +85,35 @@ aspace_result_t aspace_partition(uintptr_t arena_base,
 
   return ASPACE_OK;
 }
+
+bool aspace_contains(const address_space_t *as,
+                     const void *ptr,
+                     size_t len) {
+  if (as == NULL) {
+    return false;
+  }
+
+  /* Reject malformed window: base + size must not overflow. */
+  uintptr_t base = as->base;
+  size_t size = as->size;
+  if (size > (size_t)(UINTPTR_MAX - base)) {
+    return false;
+  }
+  uintptr_t end = base + (uintptr_t)size; /* exclusive upper bound */
+
+  uintptr_t p = (uintptr_t)ptr;
+
+  /* ptr itself must be inside the half-open window [base, end). */
+  if (p < base || p >= end) {
+    return false;
+  }
+
+  /* Overflow-safe upper-end check. With p inside the window, the
+   * largest `len` we accept is `end - p`, computed without wrapping. */
+  size_t headroom = (size_t)(end - p);
+  if (len > headroom) {
+    return false;
+  }
+
+  return true;
+}

--- a/kernel/proc/address_space.h
+++ b/kernel/proc/address_space.h
@@ -47,6 +47,7 @@
 #ifndef SECUREOS_KERNEL_PROC_ADDRESS_SPACE_H
 #define SECUREOS_KERNEL_PROC_ADDRESS_SPACE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -123,6 +124,32 @@ aspace_result_t aspace_partition(uintptr_t arena_base,
                                  size_t arena_size,
                                  address_space_t *out,
                                  size_t count);
+
+/*
+ * Bounds predicate for the M1 flat-with-bounds enforcement check
+ * (issue #260). Returns `true` iff the entire byte range
+ * `[ptr, ptr + len)` is contained inside `[as->base, as->base + as->size)`.
+ *
+ * Contract:
+ *   - `as == NULL` returns `false` (no window, nothing is contained).
+ *   - `len == 0` returns `true` iff `ptr` itself is in the half-open
+ *     window. The empty range at the boundary `ptr == base + size` is
+ *     rejected; an empty range exactly at `base` is accepted.
+ *   - Pointer arithmetic on `ptr + len` is performed in `uintptr_t`
+ *     with overflow rejection: any `(uintptr_t)ptr + len` that wraps
+ *     past `UINTPTR_MAX` returns `false`. Likewise any window whose
+ *     own `base + size` would overflow is treated as not containing
+ *     anything (rejects the malformed window rather than the caller).
+ *
+ * This is the M1 substitute for page-table enforcement; the plan
+ * (`plans/2026-05-20-m1-process-address-space.md` slice 2) commits
+ * the kernel to consulting this predicate before trusting any
+ * user-supplied pointer that names a region inside an
+ * `address_space_t` window.
+ */
+bool aspace_contains(const address_space_t *as,
+                     const void *ptr,
+                     size_t len);
 
 #ifdef __cplusplus
 }

--- a/tests/aspace_bounds_test.c
+++ b/tests/aspace_bounds_test.c
@@ -1,0 +1,179 @@
+/**
+ * @file aspace_bounds_test.c
+ * @brief Host-side unit tests for the M1 `aspace_contains` runtime
+ *        bounds-check helper (issue #260, plan
+ *        plans/2026-05-20-m1-process-address-space.md slice 2).
+ *
+ * Scope of this binary (matches the “Done when” items in issue #260
+ * that don’t require touching the frozen IPC error/marker grammar):
+ *
+ *   - Allow case: in-window pointer + length passes
+ *     (TEST:PASS:aspace_bounds_allow).
+ *   - Deny case: one byte past `base + size` is rejected
+ *     (TEST:PASS:aspace_bounds_deny).
+ *   - Deny case: a range straddling the upper or lower boundary is
+ *     rejected (TEST:PASS:aspace_bounds_straddle).
+ *   - Overflow-safety: synthetic windows where `ptr + len` or
+ *     `base + size` would wrap past `UINTPTR_MAX` are rejected without
+ *     UB (TEST:PASS:aspace_bounds_overflow).
+ *   - NULL aspace returns false (TEST:PASS:aspace_bounds_null_aspace).
+ *
+ * Out of scope (per #260 follow-up — needs a maintainer design call,
+ * see the issue thread): wiring the helper into `ipc_send` / `ipc_recv`
+ * and the scheduler block/wake paths. The frozen `ipc_result_t` enum
+ * (docs/abi/ipc-wire.md §6) and the canonical CAP:DENY grammar
+ * (docs/abi/capability-deny-contract.md §4) both forbid the literal
+ * `IPC_ERR_BOUNDS` value and `CAP:DENY:<aspace>:ipc_send:bounds`
+ * marker the issue body suggests without an ABI / grammar change.
+ *
+ * Launched by:
+ *   build/scripts/test_aspace_bounds.sh (dispatched via
+ *   build/scripts/test.sh aspace_bounds).
+ *
+ * Issue: #260.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/proc/address_space.h"
+#include "../kernel/ipc/ipc_msg.h"
+
+static int g_fail = 0;
+
+#define CHECK(cond, name) do { \
+  if (!(cond)) { \
+    fprintf(stderr, "TEST:FAIL:%s\n", (name)); \
+    g_fail = 1; \
+  } \
+} while (0)
+
+/* A small page-aligned-ish backing arena lives in BSS; the helper
+ * only ever does pointer arithmetic on the descriptor fields, it
+ * never dereferences `ipc_scratch`, so a host buffer is fine. */
+static uint8_t g_arena[1u * 1024u * 1024u];
+
+static const address_space_t *partition_one_window(address_space_t *spaces, size_t count) {
+  aspace_result_t r = aspace_partition((uintptr_t)g_arena,
+                                       sizeof(g_arena),
+                                       spaces,
+                                       count);
+  CHECK(r == ASPACE_OK, "aspace_bounds_setup_partition_ok");
+  return &spaces[0];
+}
+
+static void test_in_window_allow(void) {
+  address_space_t spaces[2];
+  const address_space_t *as = partition_one_window(spaces, 2u);
+  uint8_t *base = (uint8_t *)as->base;
+
+  /* base, one byte: inside. */
+  CHECK(aspace_contains(as, base, 1u), "aspace_bounds_base_onebyte");
+  /* full window: inside. */
+  CHECK(aspace_contains(as, base, as->size), "aspace_bounds_full_window");
+  /* mid-window range: inside. */
+  CHECK(aspace_contains(as, base + 16u, 32u), "aspace_bounds_midwindow");
+  /* last byte: inside. */
+  CHECK(aspace_contains(as, base + as->size - 1u, 1u),
+        "aspace_bounds_lastbyte");
+  /* zero-len at base: inside. */
+  CHECK(aspace_contains(as, base, 0u), "aspace_bounds_base_zerolen");
+  /* IPC scratch range: inside (this is the M1 contract — the per-
+   * process scratch buffer is always carved inside its own window). */
+  CHECK(aspace_contains(as, as->ipc_scratch, IPC_MSG_PAYLOAD_MAX),
+        "aspace_bounds_ipc_scratch_in_window");
+
+  printf("TEST:PASS:aspace_bounds_allow\n");
+}
+
+static void test_out_of_window_deny(void) {
+  address_space_t spaces[2];
+  const address_space_t *as = partition_one_window(spaces, 2u);
+  uint8_t *base = (uint8_t *)as->base;
+
+  /* One byte past the exclusive end: OUT. */
+  CHECK(!aspace_contains(as, base + as->size, 1u),
+        "aspace_bounds_one_past_end");
+  /* Zero-len at the exclusive end: OUT (boundary point not contained). */
+  CHECK(!aspace_contains(as, base + as->size, 0u),
+        "aspace_bounds_zerolen_at_end");
+  /* One byte before the window start: OUT. */
+  CHECK(!aspace_contains(as, base - 1u, 1u),
+        "aspace_bounds_one_before_base");
+  /* len == window_size + 1 starting at base: OUT. */
+  CHECK(!aspace_contains(as, base, as->size + 1u),
+        "aspace_bounds_len_overruns");
+
+  printf("TEST:PASS:aspace_bounds_deny\n");
+}
+
+static void test_straddle_deny(void) {
+  address_space_t spaces[2];
+  const address_space_t *as = partition_one_window(spaces, 2u);
+  uint8_t *base = (uint8_t *)as->base;
+
+  /* Upper boundary straddle: starts in-window, ends past it. */
+  CHECK(!aspace_contains(as, base + as->size - 4u, 8u),
+        "aspace_bounds_straddle_upper");
+  /* Lower boundary straddle: starts below base, extends into window. */
+  CHECK(!aspace_contains(as, base - 4u, 8u),
+        "aspace_bounds_straddle_lower");
+
+  printf("TEST:PASS:aspace_bounds_straddle\n");
+}
+
+static void test_null_aspace_deny(void) {
+  CHECK(!aspace_contains(NULL, g_arena, 1u),
+        "aspace_bounds_null_aspace_rejects");
+  CHECK(!aspace_contains(NULL, NULL, 0u),
+        "aspace_bounds_null_aspace_zerolen_rejects");
+  printf("TEST:PASS:aspace_bounds_null_aspace\n");
+}
+
+static void test_overflow_safe(void) {
+  /* Synthetic aspace whose `p + len` would wrap past UINTPTR_MAX. */
+  address_space_t as = {
+      .base = (uintptr_t)1u,
+      .size = (size_t)(UINTPTR_MAX - 1u), /* end == UINTPTR_MAX */
+      .stack_top = 0,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  void *p = (void *)(uintptr_t)(UINTPTR_MAX - 4u);
+  CHECK(!aspace_contains(&as, p, (size_t)16u),
+        "aspace_bounds_p_plus_len_overflow_rejects");
+
+  /* Window whose own base + size would overflow: not containing
+   * anything. We treat the malformed window itself as deny-by-default
+   * rather than punishing the caller. */
+  address_space_t bad = {
+      .base = (uintptr_t)16u,
+      .size = (size_t)UINTPTR_MAX, /* base + size wraps */
+      .stack_top = 0,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_contains(&bad, (void *)(uintptr_t)32u, 1u),
+        "aspace_bounds_window_overflow_rejects");
+
+  printf("TEST:PASS:aspace_bounds_overflow\n");
+}
+
+int main(void) {
+  test_in_window_allow();
+  test_out_of_window_deny();
+  test_straddle_deny();
+  test_null_aspace_deny();
+  test_overflow_safe();
+
+  if (g_fail) {
+    fprintf(stderr, "TEST:FAIL:aspace_bounds\n");
+    return EXIT_FAILURE;
+  }
+  printf("TEST:PASS:aspace_bounds\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Lands the overflow-safe `aspace_contains(as, ptr, len)` predicate the M1 flat-with-bounds plan (slice 2 of `plans/2026-05-20-m1-process-address-space.md`) committed to, plus a dedicated host-side test. This is step 1 of #260 — the pure helper + tests, which is the unambiguous slice of the issue's done-when list.

## Spec conflict on the IPC / scheduler wiring (deferred to a follow-up)

Wiring the helper into `ipc_send` / `ipc_recv` and the scheduler block/wake path is **deferred** because the issue body asks for two ABI-surface items that conflict with already-frozen contracts (same class of conflict as #261):

1. **`IPC_ERR_BOUNDS` new error code** — `ipc_result_t` is explicitly frozen for v0 in `docs/abi/ipc-wire.md` §6: *"Adding new entries to `ipc_result_t` is **not** additive — the enum is frozen for v0."* So a new `IPC_ERR_BOUNDS` value requires either an `OS_ABI_VERSION` bump (which the issue forbids) or reusing an existing class (most likely `IPC_ERR_INVALID_MSG`, the §5.1 malformed-envelope class).
2. **`CAP:DENY:<aspace>:ipc_send:bounds` marker** — the canonical marker grammar in `docs/abi/capability-deny-contract.md` §4 fixes the shape as `CAP:DENY:<actor_subject_id:decimal>:<capability_id:registered_name>:<resource>`. Putting `aspace` in the actor slot fails `actor_not_decimal`; `bounds` is fine for the resource slot. So the deny line for an out-of-window send would naturally be something like `CAP:DENY:<sender_subject>:ipc_send:bounds` to stay inside the conformance-tested grammar (#211 / #221).

A detailed comment with these options has been posted on #260; happy to land the wiring on the next cron run once the design call is made.

## What lands in this PR

- `kernel/proc/address_space.h`: declares `bool aspace_contains(const address_space_t *, const void *, size_t)` with documented contract (NULL aspace, zero-length boundary handling, overflow-safe arithmetic).
- `kernel/proc/address_space.c`: implementation rejecting any window where `base + size` would wrap and any range where `p + len` would wrap; half-open `[base, base+size)` semantics.
- `tests/aspace_bounds_test.c`: allow / deny / straddle / null-aspace / overflow cases emitting deterministic `TEST:PASS:` markers (`aspace_bounds_allow`, `aspace_bounds_deny`, `aspace_bounds_straddle`, `aspace_bounds_null_aspace`, `aspace_bounds_overflow`).
- `build/scripts/test_aspace_bounds.sh` + dispatcher entry in `build/scripts/test.sh` + `.shell_parity_allowlist` entry per #156.

## Validation (local)

```
bash build/scripts/test.sh aspace_bounds   # PASS (5/5 + aggregate)
bash build/scripts/test.sh aspace_carve    # PASS (unchanged)
bash build/scripts/test.sh ipc_sync_v0     # PASS (unchanged)
bash build/scripts/test.sh process_table   # PASS (unchanged)
bash build/scripts/test.sh proc_sched      # PASS (unchanged)
bash build/scripts/check_shell_parity.sh   # PARITY:OK
```

## ABI

No new ABI surface. No `OS_ABI_VERSION` bump. The helper is a kernel-internal predicate.

## Follow-ups (separate PR after design call)

- Wire `aspace_contains` into `ipc_send` / `ipc_recv` and `ipc_send_h` / `ipc_recv_h` against the caller's address space; reject with `IPC_ERR_INVALID_MSG` (matching the §5.1 malformed-envelope class) and emit the canonical `CAP:DENY:<subject>:ipc_send:bounds` marker.
- Add the scheduler-side kernel-internal invariant check on `stack_top` at block/wake (panic on violation, since that's a kernel bug not a user error).

Refs #260.