### PR TITLE
issue #260: add aspace_invariant_ok() layout predicate + host test

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -39,6 +39,7 @@ test_process_table
 test_proc_sched
 test_aspace_carve
 test_aspace_bounds
+test_aspace_invariant
 test_m1_ipc_demo
 test_cert_chain
 test_codesign

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|aspace_bounds|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -126,6 +126,9 @@ case "$TEST_NAME" in
     ;;
   aspace_bounds)
     run_script "$ROOT_DIR/build/scripts/test_aspace_bounds.sh"
+    ;;
+  aspace_invariant)
+    run_script "$ROOT_DIR/build/scripts/test_aspace_invariant.sh"
     ;;
   capability_gate)
     run_script "$ROOT_DIR/build/scripts/test_capability_gate.sh"

--- a/build/scripts/test_aspace_invariant.sh
+++ b/build/scripts/test_aspace_invariant.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# build/scripts/test_aspace_invariant.sh
+#
+# Build + run the M1 address-space layout-invariant unit test
+# (issue #260, scheduler block/wake half — the kernel-internal
+# panic predicate `aspace_invariant_ok()`).
+#
+# Covers:
+#   - Allow: every window produced by aspace_partition() passes.
+#   - Allow: hand-built window with NULL ipc_scratch passes.
+#   - Deny: NULL, zero-size, base+size overflow, stack_top below
+#     base, stack_top past window end.
+#   - Deny: ipc_scratch outside the window or whose IPC_MSG_PAYLOAD_MAX
+#     span straddles the upper boundary.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/tests/aspace_invariant_test.c" \
+  -o "$OUT_DIR/aspace_invariant_test"
+
+LOG_PATH="$OUT_DIR/aspace_invariant_test.log"
+"$OUT_DIR/aspace_invariant_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:aspace_invariant_allow_partitioned" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_invariant_allow_no_scratch" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_invariant_deny_layout" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_invariant_deny_scratch_escapes" "$LOG_PATH"
+grep -q "TEST:PASS:aspace_invariant$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/proc/address_space.c
+++ b/kernel/proc/address_space.c
@@ -117,3 +117,43 @@ bool aspace_contains(const address_space_t *as,
 
   return true;
 }
+
+bool aspace_invariant_ok(const address_space_t *as) {
+  if (as == NULL) {
+    return false;
+  }
+
+  /* Non-empty window with non-wrapping arithmetic. */
+  if (as->size == 0u) {
+    return false;
+  }
+  if (as->size > (size_t)(UINTPTR_MAX - as->base)) {
+    return false;
+  }
+  uintptr_t end = as->base + (uintptr_t)as->size; /* exclusive upper bound */
+
+  /* stack_top must point strictly above base (non-empty stack) and
+   * not past the exclusive window end. Equality with end is fine
+   * because the stack grows downward from stack_top and the first
+   * push lands at end - 1, still inside the window. */
+  if (as->stack_top <= as->base) {
+    return false;
+  }
+  if (as->stack_top > end) {
+    return false;
+  }
+
+  /* ipc_scratch may legitimately be NULL on an aspace that does not
+   * carry a per-process scratch region (e.g. the boot idle PCB). When
+   * non-NULL, the full IPC_MSG_PAYLOAD_MAX span must lie inside the
+   * window — reuse the same overflow-safe arithmetic as
+   * aspace_contains() so the scheduler's invariant check matches the
+   * IPC layer's bounds check by construction. */
+  if (as->ipc_scratch != NULL) {
+    if (!aspace_contains(as, as->ipc_scratch, (size_t)IPC_MSG_PAYLOAD_MAX)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/kernel/proc/address_space.h
+++ b/kernel/proc/address_space.h
@@ -151,6 +151,34 @@ bool aspace_contains(const address_space_t *as,
                      const void *ptr,
                      size_t len);
 
+/*
+ * Kernel-internal layout-invariant predicate (issue #260, scheduler
+ * block/wake half).
+ *
+ * Returns `true` iff `as` describes a self-consistent window:
+ *   - `as != NULL`.
+ *   - `as->size > 0` and `as->base + as->size` does not overflow.
+ *   - `as->stack_top` lies strictly above `as->base` and at most at
+ *     the exclusive upper bound `as->base + as->size` — i.e. a
+ *     non-empty stack region that does not escape the window.
+ *   - `as->ipc_scratch == NULL` is permitted (an aspace may carry no
+ *     scratch region), but if non-NULL, the full `IPC_MSG_PAYLOAD_MAX`
+ *     scratch span must lie inside `[base, base + size)`.
+ *
+ * This is the M1 scheduler's substitute for a hardware page-table
+ * invariant check: every PCB whose context is about to be restored
+ * must satisfy `aspace_invariant_ok(pcb->aspace)`, otherwise the
+ * scheduler has been handed a corrupted window and continuing would
+ * silently restore an out-of-bounds stack pointer. The scheduler
+ * panics on a `false` return (issue #260 done-when 3); this predicate
+ * exists so the panic site is byte-identical to the host-side
+ * regression test asserting the same invariant.
+ *
+ * Pure function: no I/O, no globals, no allocation. Safe to call
+ * from any context.
+ */
+bool aspace_invariant_ok(const address_space_t *as);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/aspace_invariant_test.c
+++ b/tests/aspace_invariant_test.c
@@ -1,0 +1,204 @@
+/**
+ * @file aspace_invariant_test.c
+ * @brief Host-side unit tests for the M1 `aspace_invariant_ok()`
+ *        layout-invariant predicate (issue #260, scheduler block/wake
+ *        half — the kernel-internal panic site that the future
+ *        `proc_sched_*` wiring will call before restoring a PCB
+ *        context).
+ *
+ * Scope (kernel-internal only — no ABI surface, no IPC error code,
+ * no CAP:DENY marker; those remain blocked on the maintainer design
+ * call discussed in #260 / #261 thread):
+ *
+ *   - Allow: a freshly partitioned aspace (the only way the scheduler
+ *     ever obtains a window in M1) passes the invariant
+ *     (TEST:PASS:aspace_invariant_allow_partitioned).
+ *   - Allow: a hand-built window with NULL ipc_scratch passes (the
+ *     boot idle PCB legitimately carries no scratch region)
+ *     (TEST:PASS:aspace_invariant_allow_no_scratch).
+ *   - Deny: NULL aspace, zero-size window, base+size overflow,
+ *     stack_top below base, stack_top past window end
+ *     (TEST:PASS:aspace_invariant_deny_layout).
+ *   - Deny: non-NULL ipc_scratch that does not fit the full
+ *     IPC_MSG_PAYLOAD_MAX span inside the window
+ *     (TEST:PASS:aspace_invariant_deny_scratch_escapes).
+ *
+ * Why this test exists separately from aspace_bounds_test:
+ *   `aspace_contains()` is a runtime pointer/length check the IPC
+ *   layer will eventually call on every send/recv. `aspace_invariant_ok()`
+ *   is a layout audit the scheduler will eventually call exactly
+ *   once per dispatch. Their failure modes are different (per-call
+ *   deny vs. fatal panic), so the tests are kept in separate
+ *   binaries so a regression in one cannot mask the other.
+ *
+ * Launched by:
+ *   build/scripts/test_aspace_invariant.sh (dispatched via
+ *   build/scripts/test.sh aspace_invariant).
+ *
+ * Issue: #260.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/proc/address_space.h"
+#include "../kernel/ipc/ipc_msg.h"
+
+static int g_fail = 0;
+
+#define CHECK(cond, name) do { \
+  if (!(cond)) { \
+    fprintf(stderr, "TEST:FAIL:%s\n", (name)); \
+    g_fail = 1; \
+  } \
+} while (0)
+
+/* Backing arena lives in BSS. The invariant helper never dereferences
+ * any of the descriptor pointers, it only inspects the numeric
+ * fields, so a plain host buffer is sufficient. */
+static uint8_t g_arena[1u * 1024u * 1024u];
+
+static void test_allow_partitioned(void) {
+  address_space_t spaces[4];
+  aspace_result_t r = aspace_partition((uintptr_t)g_arena,
+                                       sizeof(g_arena),
+                                       spaces,
+                                       4u);
+  CHECK(r == ASPACE_OK, "aspace_invariant_setup_partition_ok");
+
+  /* Every window produced by aspace_partition() must satisfy the
+   * invariant by construction — this is the contract the scheduler
+   * relies on. */
+  for (size_t i = 0; i < 4u; ++i) {
+    CHECK(aspace_invariant_ok(&spaces[i]),
+          "aspace_invariant_partitioned_window_ok");
+  }
+
+  printf("TEST:PASS:aspace_invariant_allow_partitioned\n");
+}
+
+static void test_allow_no_scratch(void) {
+  /* Hand-built window mirroring the M1 boot idle PCB layout: a
+   * kernel-reserved arena with a usable stack but no per-process IPC
+   * scratch region. The invariant must accept this. */
+  address_space_t as = {
+      .base = (uintptr_t)g_arena,
+      .size = (size_t)4096u,
+      .stack_top = (uintptr_t)g_arena + (uintptr_t)4096u,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(aspace_invariant_ok(&as), "aspace_invariant_no_scratch_ok");
+
+  /* stack_top strictly above base but not at end is also fine. */
+  as.stack_top = (uintptr_t)g_arena + (uintptr_t)2048u;
+  CHECK(aspace_invariant_ok(&as), "aspace_invariant_stack_below_end_ok");
+
+  printf("TEST:PASS:aspace_invariant_allow_no_scratch\n");
+}
+
+static void test_deny_layout(void) {
+  /* NULL. */
+  CHECK(!aspace_invariant_ok(NULL), "aspace_invariant_null_deny");
+
+  /* Zero-size window. */
+  address_space_t zero = {
+      .base = (uintptr_t)g_arena,
+      .size = 0u,
+      .stack_top = (uintptr_t)g_arena,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&zero), "aspace_invariant_zero_size_deny");
+
+  /* base + size would wrap past UINTPTR_MAX. */
+  address_space_t wrap = {
+      .base = (uintptr_t)16u,
+      .size = (size_t)UINTPTR_MAX,
+      .stack_top = (uintptr_t)32u,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&wrap), "aspace_invariant_wrap_deny");
+
+  /* stack_top below base — corrupted layout, scheduler must refuse. */
+  address_space_t low = {
+      .base = (uintptr_t)g_arena + 1024u,
+      .size = 1024u,
+      .stack_top = (uintptr_t)g_arena, /* below base */
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&low), "aspace_invariant_stack_below_base_deny");
+
+  /* stack_top equal to base — zero-size stack, scheduler would
+   * immediately underflow on first push. Treat as invariant break. */
+  address_space_t eq = {
+      .base = (uintptr_t)g_arena,
+      .size = 1024u,
+      .stack_top = (uintptr_t)g_arena, /* equals base */
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&eq), "aspace_invariant_stack_at_base_deny");
+
+  /* stack_top one byte past the exclusive window end. */
+  address_space_t high = {
+      .base = (uintptr_t)g_arena,
+      .size = 1024u,
+      .stack_top = (uintptr_t)g_arena + 1025u,
+      .ipc_scratch = NULL,
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&high), "aspace_invariant_stack_past_end_deny");
+
+  printf("TEST:PASS:aspace_invariant_deny_layout\n");
+}
+
+static void test_deny_scratch_escapes(void) {
+  /* Window large enough to hold a stack but whose ipc_scratch is
+   * pointed outside the window. The scheduler must refuse such a
+   * PCB rather than silently restore it. */
+  address_space_t outside = {
+      .base = (uintptr_t)g_arena,
+      .size = (size_t)(PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u),
+      .stack_top = (uintptr_t)g_arena
+                   + (uintptr_t)(PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u),
+      .ipc_scratch = (uint8_t *)((uintptr_t)g_arena + (uintptr_t)sizeof(g_arena)),
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&outside),
+        "aspace_invariant_scratch_outside_deny");
+
+  /* ipc_scratch starts in-window but its IPC_MSG_PAYLOAD_MAX span
+   * runs past the window end. */
+  address_space_t straddle = {
+      .base = (uintptr_t)g_arena,
+      .size = (size_t)IPC_MSG_PAYLOAD_MAX, /* exactly one scratch worth */
+      .stack_top = (uintptr_t)g_arena + (uintptr_t)IPC_MSG_PAYLOAD_MAX,
+      /* scratch starts one byte in, so its tail is one byte past end. */
+      .ipc_scratch = (uint8_t *)((uintptr_t)g_arena + 1u),
+      .pt_reserved = NULL,
+  };
+  CHECK(!aspace_invariant_ok(&straddle),
+        "aspace_invariant_scratch_straddle_deny");
+
+  printf("TEST:PASS:aspace_invariant_deny_scratch_escapes\n");
+}
+
+int main(void) {
+  test_allow_partitioned();
+  test_allow_no_scratch();
+  test_deny_layout();
+  test_deny_scratch_escapes();
+
+  if (g_fail) {
+    fprintf(stderr, "TEST:FAIL:aspace_invariant\n");
+    return EXIT_FAILURE;
+  }
+  printf("TEST:PASS:aspace_invariant\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Adds the kernel-internal, ABI-neutral half of #260's M1 address-space bounds work — a pure layout-invariant predicate `aspace_invariant_ok()` that the cooperative scheduler will call before restoring any PCB context (#260 done-when 3: panic on saved-stack-out-of-window).

This is the second slice of #260, following PR #264 (`aspace_contains()` helper, merged). The third remaining piece — wiring this predicate into `proc_sched` dispatch — is intentionally split off (see Follow-ups).

## New API

`kernel/proc/address_space.{h,c}`:

```c
bool aspace_invariant_ok(const address_space_t *as);
```

Returns `false` when:

- `as` is NULL
- `size` is 0 or `base + size` would wrap past `UINTPTR_MAX`
- `stack_top` is at or below `base` (empty/inverted stack)
- `stack_top` is past `base + size` (escaped window)
- `ipc_scratch` is non-NULL but its `IPC_MSG_PAYLOAD_MAX` span does not fit fully inside the window — reuses `aspace_contains()` so the scheduler's invariant matches the IPC layer's bounds check by construction.

### Why a separate predicate from `aspace_contains()`

`aspace_contains()` is a per-call IPC bounds check whose failure is a per-message deny. `aspace_invariant_ok()` is a per-dispatch layout audit whose failure is fatal — the scheduler has been handed a corrupted window. Keeping the two checks in separate translation-time invariants and separate test binaries means a regression in one cannot mask the other.

## Test

New host-side binary `tests/aspace_invariant_test.c` covering:

- Allow: every window produced by `aspace_partition()` satisfies the invariant (the M1 contract the scheduler relies on)
- Allow: hand-built window with NULL `ipc_scratch` (boot idle PCB shape)
- Deny: NULL, zero size, base+size overflow, `stack_top` below base, `stack_top` at base, `stack_top` past end
- Deny: `ipc_scratch` outside window, scratch straddling upper end

Runner `build/scripts/test_aspace_invariant.sh`, wired into `build/scripts/test.sh aspace_invariant` and added to the shell-parity allowlist (issue #156 tracked).

## Validation

```
bash build/scripts/test.sh aspace_invariant -> TEST:PASS:aspace_invariant
bash build/scripts/test.sh aspace_bounds    -> PASS (no regression)
bash build/scripts/test.sh aspace_carve     -> PASS (no regression)
bash build/scripts/test.sh proc_sched       -> PASS (no regression)
bash build/scripts/check_shell_parity.sh    -> PARITY:OK (65 entries)
```

## Scope / non-scope

- **In scope:** the pure predicate + its host test. Pure additive, no behaviour change to any existing translation unit's exported semantics.
- **Not in scope (this PR):** calling `aspace_invariant_ok()` from `proc_sched.c`'s dispatch loop. That wiring requires migrating `tests/proc_sched_test.c`'s `fake_aspace()` tag-pointer fixture (which manufactures non-partitioned aspaces with bogus `stack_top`/`ipc_scratch` values purely as identity tags) to real `aspace_partition()`-derived windows; otherwise an enforcing scheduler would refuse to dispatch the existing PCBs. That fixture refactor is larger than this slice and is split off to keep this PR a clean helper landing.
- **Still blocked on maintainer call (per #260 / #261 thread):** IPC-side wiring (`ipc_send`/`ipc_recv` returning a bounds-deny). The frozen `ipc_result_t` enum and CAP:DENY marker grammar both forbid the literal codes the issue body suggests without an ABI/grammar change.

## Follow-ups

- [ ] Migrate `tests/proc_sched_test.c` `fake_aspace()` to real partitioned aspaces (prerequisite to actually invoking `aspace_invariant_ok()` from `proc_sched`).
- [ ] Wire `aspace_invariant_ok()` into `proc_sched_run` / `proc_sched_block_current_on_port` as a kernel panic-on-false (post-fixture-migration).
- [ ] Maintainer design call on the bounds error code / marker grammar (tracked in #260 thread).

Closes none. Refs #260.