### PR TITLE
issue #260: wire aspace_invariant_ok() into proc_sched dispatch

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -37,6 +37,7 @@ test_cap_handle_revoke_subject
 test_cap_handle_revoke_subtree
 test_process_table
 test_proc_sched
+test_proc_sched_aspace_invariant
 test_aspace_carve
 test_aspace_bounds
 test_aspace_invariant

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -120,6 +120,9 @@ case "$TEST_NAME" in
     ;;
   proc_sched)
     run_script "$ROOT_DIR/build/scripts/test_proc_sched.sh"
+    ;;
+  proc_sched_aspace_invariant)
+    run_script "$ROOT_DIR/build/scripts/test_proc_sched_aspace_invariant.sh"
     ;;
   aspace_carve)
     run_script "$ROOT_DIR/build/scripts/test_aspace_carve.sh"

--- a/build/scripts/test_ipc_handle_gate.sh
+++ b/build/scripts/test_ipc_handle_gate.sh
@@ -24,6 +24,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \
   "$ROOT_DIR/kernel/ipc/ipc_ops.c" \

--- a/build/scripts/test_ipc_sync_v0.sh
+++ b/build/scripts/test_ipc_sync_v0.sh
@@ -25,6 +25,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \
   "$ROOT_DIR/kernel/ipc/ipc_ops.c" \

--- a/build/scripts/test_m1_ipc_demo.sh
+++ b/build/scripts/test_m1_ipc_demo.sh
@@ -29,6 +29,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/proc/module_registry.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \

--- a/build/scripts/test_proc_sched.sh
+++ b/build/scripts/test_proc_sched.sh
@@ -28,6 +28,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/kernel/proc/proc_sched.c" \
   "$ROOT_DIR/kernel/ipc/ipc_port.c" \

--- a/build/scripts/test_proc_sched_aspace_invariant.sh
+++ b/build/scripts/test_proc_sched_aspace_invariant.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# build/scripts/test_proc_sched_aspace_invariant.sh
+#
+# Build + run the M1 scheduler aspace-invariant regression test
+# (issue #260 done-when 3 — saved-stack-out-of-window panic site).
+#
+# Covers:
+#   - Clean path: well-formed partitioned aspace dispatches without
+#     invoking the panic hook.
+#   - Deny: stack_top past the window's upper bound triggers
+#     `stack_top_escapes_window` and force-exits the PCB.
+#   - Deny: NULL aspace triggers `null_aspace`.
+#   - Deny: ipc_scratch straddling the upper boundary triggers
+#     `ipc_scratch_escapes_window`.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/proc_sched_aspace_invariant_test.c" \
+  -o "$OUT_DIR/proc_sched_aspace_invariant_test"
+
+LOG_PATH="$OUT_DIR/proc_sched_aspace_invariant_test.log"
+"$OUT_DIR/proc_sched_aspace_invariant_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:proc_sched_aspace_invariant_clean" "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_aspace_invariant_stack_escape" "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_aspace_invariant_null_aspace" "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_aspace_invariant_scratch_escape" "$LOG_PATH"
+grep -q "TEST:PASS:proc_sched_aspace_invariant$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/proc/module_registry.c
+++ b/kernel/proc/module_registry.c
@@ -20,6 +20,7 @@
 #include "../ipc/ipc_msg.h"
 #include "../ipc/ipc_ops.h"
 #include "../ipc/ipc_port.h"
+#include "address_space.h"
 #include "process.h"
 #include "proc_sched.h"
 #include "../../user/include/secureos_abi.h"
@@ -65,10 +66,60 @@ static void demo_handle_record(cap_subject_id_t subject, cap_handle_t h) {
    * overflow indicates a test-harness bug. */
 }
 
+/* --------------------------------------------------------------------
+ * Per-module address-space backing (issue #260 done-when 3 follow-up).
+ *
+ * The scheduler now asserts `aspace_invariant_ok(pcb->aspace)` before
+ * restoring any PCB's context (proc_sched_run / dispatch path). A NULL
+ * aspace fails that check, so we cannot keep passing NULL into
+ * process_create() — m1-sender / m1-receiver / m1-unauth all need a
+ * real partitioned window of their own.
+ *
+ * The arena lives in BSS so its address is stable across resets. The
+ * partition is rebuilt by `m1_demo_reset()` so each test invocation
+ * sees a fresh, well-formed set of windows. One slot per module entry
+ * in `g_modules[]` is the minimum, but we size for
+ * `M1_DEMO_MAX_SUBJECTS` for symmetry with the handle map and to leave
+ * room for future demo modules.
+ *
+ * Each window is sized for `PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX +
+ * 64` bytes (slack for alignment), matching the partitioning shape
+ * used by `tests/proc_sched_test.c`.
+ * ------------------------------------------------------------------ */
+
+#define M1_DEMO_ARENA_BYTES                                          \
+  (M1_DEMO_MAX_SUBJECTS *                                            \
+   (PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u))
+
+static uint8_t          g_demo_aspace_arena[M1_DEMO_ARENA_BYTES];
+static address_space_t  g_demo_aspaces[M1_DEMO_MAX_SUBJECTS];
+static size_t           g_demo_aspace_next = 0u;
+static bool             g_demo_aspaces_ready = false;
+
+static bool demo_aspaces_rebuild(void) {
+  aspace_result_t pr = aspace_partition(
+      (uintptr_t)g_demo_aspace_arena, sizeof(g_demo_aspace_arena),
+      g_demo_aspaces, M1_DEMO_MAX_SUBJECTS);
+  g_demo_aspace_next = 0u;
+  g_demo_aspaces_ready = (pr == ASPACE_OK);
+  return g_demo_aspaces_ready;
+}
+
+static address_space_t *demo_aspace_claim(void) {
+  if (!g_demo_aspaces_ready) {
+    return NULL;
+  }
+  if (g_demo_aspace_next >= M1_DEMO_MAX_SUBJECTS) {
+    return NULL;
+  }
+  return &g_demo_aspaces[g_demo_aspace_next++];
+}
+
 void m1_demo_reset(void) {
   g_demo_port = IPC_PORT_INVALID;
   memset(g_demo_handles, 0, sizeof(g_demo_handles));
   memset(&g_demo_obs, 0, sizeof(g_demo_obs));
+  (void)demo_aspaces_rebuild();
 }
 
 bool m1_demo_set_port(ipc_port_t port) {
@@ -234,8 +285,17 @@ module_spawn_result_t proc_spawn_module(const char *name,
     return MODULE_SPAWN_ERR_UNKNOWN_NAME;
   }
 
+  /* Back the PCB with a real partitioned address-space window so the
+   * scheduler's `aspace_invariant_ok()` gate (issue #260 done-when 3)
+   * sees a valid base/size/stack_top/ipc_scratch layout. Without this
+   * the dispatch path panics with `null_aspace` on the first wake. */
+  address_space_t *as = demo_aspace_claim();
+  if (as == NULL) {
+    return MODULE_SPAWN_ERR_PROC_CREATE;
+  }
+
   process_id_t pid = PID_INVALID;
-  if (process_create(m->subject, NULL, &pid) != PROC_OK) {
+  if (process_create(m->subject, as, &pid) != PROC_OK) {
     return MODULE_SPAWN_ERR_PROC_CREATE;
   }
 

--- a/kernel/proc/proc_sched.c
+++ b/kernel/proc/proc_sched.c
@@ -30,9 +30,12 @@
 
 #include "proc_sched.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ucontext.h>
+
+#include "address_space.h"
 
 /* Per-PCB coroutine stack. 64 KiB matches the slice-2 default arena
  * stack window's lower bound (kernel/proc/address_space.h) and is more
@@ -59,6 +62,11 @@ static uint32_t g_ready_count = 0u;
 static ucontext_t g_scheduler_ctx;
 static int16_t g_current_index = -1;  /* index into g_entries, -1 = none */
 static bool g_dispatching = false;
+
+/* Panic hook for aspace-invariant violations (issue #260). NULL in the
+ * default kernel/host build; tests install a hook so they can observe
+ * the violation deterministically without aborting the test process. */
+static proc_sched_panic_fn_t g_aspace_panic_hook = NULL;
 
 /* ------------------------------------------------------------------ */
 
@@ -125,6 +133,43 @@ static void ready_drop(uint16_t entry_index) {
 }
 
 /* ------------------------------------------------------------------ */
+
+proc_sched_panic_fn_t proc_sched_set_panic_hook_for_tests(
+    proc_sched_panic_fn_t hook) {
+  proc_sched_panic_fn_t prev = g_aspace_panic_hook;
+  g_aspace_panic_hook = hook;
+  return prev;
+}
+
+/* Categorise an aspace-invariant violation into a short, deterministic
+ * reason string. Matches `aspace_invariant_ok()` semantics. */
+static const char *aspace_invariant_reason(const address_space_t *as) {
+  if (as == NULL) return "null_aspace";
+  if (as->size == 0u) return "zero_size";
+  if (as->size > (size_t)(UINTPTR_MAX - as->base)) return "window_overflow";
+  uintptr_t end = as->base + (uintptr_t)as->size;
+  if (as->stack_top <= as->base) return "stack_top_at_or_below_base";
+  if (as->stack_top > end) return "stack_top_escapes_window";
+  /* If reached, ipc_scratch must be the offender (when non-NULL). */
+  return "ipc_scratch_escapes_window";
+}
+
+/* Report an invariant violation. With a test hook installed, dispatch
+ * to the hook and let the scheduler force-exit the offending PCB.
+ * Otherwise emit a deterministic PANIC marker and abort, matching the
+ * kernel-side panic semantics. */
+static void aspace_invariant_panic(process_id_t pid,
+                                   const address_space_t *as) {
+  const char *reason = aspace_invariant_reason(as);
+  if (g_aspace_panic_hook != NULL) {
+    g_aspace_panic_hook(pid, reason);
+    return;
+  }
+  fprintf(stderr, "PANIC:proc_sched:aspace_invariant:%u:%s\n",
+          (unsigned)pid, reason);
+  fflush(stderr);
+  abort();
+}
 
 void proc_sched_reset(void) {
   for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
@@ -314,6 +359,25 @@ proc_sched_result_t proc_sched_run(void) {
       /* Stale entry — skip. */
       continue;
     }
+
+    /* Address-space invariant check (issue #260 done-when 3). Every
+     * PCB whose context is about to be restored must satisfy
+     * `aspace_invariant_ok(pcb->aspace)`; a `false` return means the
+     * scheduler has been handed a corrupted window and continuing
+     * would silently restore an out-of-bounds stack pointer. Panic
+     * (or hook into the test harness) before swapping context. */
+    if (!aspace_invariant_ok(snap.aspace)) {
+      aspace_invariant_panic(e->pid, snap.aspace);
+      /* If we reach here a test hook absorbed the violation. Force
+       * the offending PCB to EXITED with a sentinel exit_code so the
+       * dispatch loop keeps making forward progress. */
+      (void)process_set_exit_code(e->pid, UINT32_MAX);
+      (void)process_set_state(e->pid, PROC_STATE_EXITED);
+      ready_drop((uint16_t)idx);
+      g_current_index = -1;
+      continue;
+    }
+
     g_current_index = idx;
     (void)process_set_state(e->pid, PROC_STATE_RUNNING);
 

--- a/kernel/proc/proc_sched.h
+++ b/kernel/proc/proc_sched.h
@@ -167,6 +167,34 @@ uint32_t proc_sched_ready_count_for_tests(void);
 uint32_t proc_sched_blocked_count_for_tests(void);
 
 /*
+ * Address-space invariant panic hook (issue #260 done-when 3).
+ *
+ * The scheduler verifies `aspace_invariant_ok(pcb->aspace)` immediately
+ * before restoring a PCB's coroutine context. A `false` return means
+ * the scheduler has been handed a corrupted window (NULL aspace, zero
+ * size, base+size overflow, stack_top inversion/escape, or ipc_scratch
+ * outside the window) — continuing would silently restore an
+ * out-of-bounds kernel stack.
+ *
+ * In the freestanding kernel build this is a panic. The host-side
+ * test build installs a hook so the regression test can observe the
+ * violation deterministically: when a hook is installed, the
+ * violation is reported via the hook (with the offending PID and a
+ * short reason string) and the scheduler force-transitions the
+ * offending PCB to PROC_STATE_EXITED with exit_code = UINT32_MAX so
+ * the dispatch loop continues making forward progress instead of
+ * hanging. When no hook is installed, the scheduler writes a
+ * `PANIC:proc_sched:aspace_invariant:<pid>:<reason>` line to stderr
+ * and calls abort() — matching the kernel-side semantics.
+ *
+ * Pure test-only mutator; not part of the kernel ABI. Always returns
+ * the previously-installed hook so tests can chain / restore.
+ */
+typedef void (*proc_sched_panic_fn_t)(process_id_t pid, const char *reason);
+proc_sched_panic_fn_t proc_sched_set_panic_hook_for_tests(
+    proc_sched_panic_fn_t hook);
+
+/*
  * Is a scheduler dispatch currently in progress? IPC ops use this to
  * pick between the v0 single-waiter-slot semantics (no scheduler
  * running -> return IPC_ERR_PEER_GONE) and the slice-3 block/wake

--- a/tests/proc_sched_aspace_invariant_test.c
+++ b/tests/proc_sched_aspace_invariant_test.c
@@ -1,0 +1,248 @@
+/**
+ * @file proc_sched_aspace_invariant_test.c
+ * @brief Regression: cooperative scheduler panics (via test hook) when
+ *        asked to dispatch a PCB whose address_space_t fails the
+ *        kernel-internal layout invariant.
+ *
+ * Issue: #260 done-when 3 ("scheduler block/wake panics on
+ * saved-stack-out-of-window — covered by a host harness fixture that
+ * exercises the check").
+ *
+ * Why a separate test binary:
+ *   The existing proc_sched_test.c asserts the happy-path scheduler /
+ *   IPC block/wake semantics. This binary deliberately corrupts a
+ *   PCB's aspace and exercises the invariant-check path that aborts
+ *   dispatch — keeping that fixture out of the happy-path harness
+ *   keeps the two test surfaces orthogonal.
+ *
+ * What is asserted:
+ *   1. A well-formed partitioned aspace dispatches normally and the
+ *      panic hook is NEVER invoked (`TEST:PASS:proc_sched_aspace_invariant_clean`).
+ *   2. A PCB whose aspace has `stack_top` outside the window triggers
+ *      the panic hook exactly once with the expected reason string,
+ *      and the scheduler force-exits the offending PCB so the
+ *      dispatch loop terminates cleanly
+ *      (`TEST:PASS:proc_sched_aspace_invariant_stack_escape`).
+ *   3. A PCB whose aspace is NULL triggers the panic hook with
+ *      `null_aspace` and is similarly force-exited
+ *      (`TEST:PASS:proc_sched_aspace_invariant_null_aspace`).
+ *   4. A PCB whose aspace has `ipc_scratch` straddling the window's
+ *      upper boundary triggers `ipc_scratch_escapes_window`
+ *      (`TEST:PASS:proc_sched_aspace_invariant_scratch_escape`).
+ *
+ * Launched by:
+ *   build/scripts/test_proc_sched_aspace_invariant.sh
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/proc/address_space.h"
+#include "../kernel/proc/proc_sched.h"
+#include "../kernel/proc/process.h"
+#include "../user/include/secureos_abi.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:proc_sched_aspace_invariant:%s\n", reason);
+  exit(1);
+}
+
+/* Panic-hook capture. The scheduler installs the hook before
+ * dispatch; on a violation it records the offending PID + reason and
+ * lets the scheduler force-exit the PCB so the test process does not
+ * itself abort. */
+static struct {
+  int hits;
+  process_id_t last_pid;
+  char last_reason[64];
+} g_panic;
+
+static void panic_hook(process_id_t pid, const char *reason) {
+  g_panic.hits++;
+  g_panic.last_pid = pid;
+  if (reason != NULL) {
+    strncpy(g_panic.last_reason, reason, sizeof(g_panic.last_reason) - 1u);
+    g_panic.last_reason[sizeof(g_panic.last_reason) - 1u] = '\0';
+  } else {
+    g_panic.last_reason[0] = '\0';
+  }
+}
+
+static void reset_panic(void) {
+  g_panic.hits = 0;
+  g_panic.last_pid = PID_INVALID;
+  g_panic.last_reason[0] = '\0';
+}
+
+static void reset_world(void) {
+  proc_sched_reset();
+  process_table_reset();
+  cap_reset_for_tests();
+  cap_table_reset();
+  reset_panic();
+  (void)proc_sched_set_panic_hook_for_tests(panic_hook);
+}
+
+/* Real arena so happy-path aspaces are well-formed. */
+static uint8_t g_arena[4u * (PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u)];
+static address_space_t g_aspaces[4];
+
+static void rebuild_arena(void) {
+  if (aspace_partition((uintptr_t)g_arena, sizeof(g_arena),
+                       g_aspaces, 4u) != ASPACE_OK) {
+    die("partition_failed");
+  }
+}
+
+/* A trivial scheduler entry that immediately exits; only reached on
+ * the clean-path test. */
+static int g_entry_runs = 0;
+static void entry_exit_zero(void) {
+  g_entry_runs++;
+  (void)proc_exit(0u);
+}
+
+/* ------------------------------------------------------------------ */
+/* (1) Clean path: well-formed partitioned aspace — no panic.          */
+/* ------------------------------------------------------------------ */
+
+static void test_clean_path(void) {
+  reset_world();
+  rebuild_arena();
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(1u, &g_aspaces[0], &pid) != PROC_OK) die("create_clean");
+  if (proc_sched_register(pid, entry_exit_zero) != PROC_SCHED_OK) {
+    die("register_clean");
+  }
+
+  g_entry_runs = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_clean");
+  if (g_panic.hits != 0) die("clean_path_panicked");
+  if (g_entry_runs != 1) die("clean_entry_did_not_run");
+
+  printf("TEST:PASS:proc_sched_aspace_invariant_clean\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (2) stack_top escapes window.                                       */
+/* ------------------------------------------------------------------ */
+
+/* Should be unreachable: the scheduler panics before dispatching the
+ * PCB whose context owns this entry. If it runs, the test fails
+ * because the invariant gate was bypassed. */
+static int g_bad_entry_ran = 0;
+static void entry_should_not_run(void) {
+  g_bad_entry_ran = 1;
+  (void)proc_exit(0u);
+}
+
+static void test_stack_top_escapes(void) {
+  reset_world();
+  rebuild_arena();
+
+  /* Corrupt one slot: push stack_top past the window's upper bound. */
+  address_space_t corrupted = g_aspaces[0];
+  corrupted.stack_top = corrupted.base + (uintptr_t)corrupted.size + 1u;
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(1u, &corrupted, &pid) != PROC_OK) die("create_bad");
+  if (proc_sched_register(pid, entry_should_not_run) != PROC_SCHED_OK) {
+    die("register_bad");
+  }
+
+  g_bad_entry_ran = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_bad_should_drain");
+
+  if (g_panic.hits != 1) die("expected_exactly_one_panic");
+  if (g_panic.last_pid != pid) die("panic_pid_mismatch");
+  if (strcmp(g_panic.last_reason, "stack_top_escapes_window") != 0) {
+    printf("DEBUG:reason=%s\n", g_panic.last_reason);
+    die("panic_reason_mismatch");
+  }
+  if (g_bad_entry_ran) die("invariant_gate_bypassed");
+
+  /* PCB should have been force-exited with the sentinel exit code. */
+  process_t snap;
+  if (process_lookup(pid, &snap) != PROC_OK) die("lookup_after_panic");
+  if (snap.state != PROC_STATE_EXITED) die("expected_exited_after_panic");
+  if (snap.exit_code != UINT32_MAX) die("expected_sentinel_exit_code");
+
+  printf("TEST:PASS:proc_sched_aspace_invariant_stack_escape\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (3) NULL aspace.                                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_null_aspace(void) {
+  reset_world();
+  rebuild_arena();
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(1u, NULL, &pid) != PROC_OK) die("create_null");
+  if (proc_sched_register(pid, entry_should_not_run) != PROC_SCHED_OK) {
+    die("register_null");
+  }
+
+  g_bad_entry_ran = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_null_should_drain");
+
+  if (g_panic.hits != 1) die("expected_one_panic_null");
+  if (strcmp(g_panic.last_reason, "null_aspace") != 0) {
+    printf("DEBUG:reason=%s\n", g_panic.last_reason);
+    die("panic_reason_mismatch_null");
+  }
+  if (g_bad_entry_ran) die("null_invariant_gate_bypassed");
+
+  printf("TEST:PASS:proc_sched_aspace_invariant_null_aspace\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* (4) ipc_scratch escapes window.                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_scratch_escapes(void) {
+  reset_world();
+  rebuild_arena();
+
+  /* Corrupt one slot: point ipc_scratch one byte before the window's
+   * upper end so the IPC_MSG_PAYLOAD_MAX span straddles the boundary. */
+  address_space_t corrupted = g_aspaces[0];
+  uintptr_t end = corrupted.base + (uintptr_t)corrupted.size;
+  corrupted.ipc_scratch = (uint8_t *)(end - 1u);
+
+  process_id_t pid = PID_INVALID;
+  if (process_create(1u, &corrupted, &pid) != PROC_OK) die("create_scratch");
+  if (proc_sched_register(pid, entry_should_not_run) != PROC_SCHED_OK) {
+    die("register_scratch");
+  }
+
+  g_bad_entry_ran = 0;
+  if (proc_sched_run() != PROC_SCHED_OK) die("run_scratch_should_drain");
+
+  if (g_panic.hits != 1) die("expected_one_panic_scratch");
+  if (strcmp(g_panic.last_reason, "ipc_scratch_escapes_window") != 0) {
+    printf("DEBUG:reason=%s\n", g_panic.last_reason);
+    die("panic_reason_mismatch_scratch");
+  }
+  if (g_bad_entry_ran) die("scratch_invariant_gate_bypassed");
+
+  printf("TEST:PASS:proc_sched_aspace_invariant_scratch_escape\n");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+  printf("TEST:START:proc_sched_aspace_invariant\n");
+  test_clean_path();
+  test_stack_top_escapes();
+  test_null_aspace();
+  test_scratch_escapes();
+  printf("TEST:PASS:proc_sched_aspace_invariant\n");
+  return 0;
+}

--- a/tests/proc_sched_test.c
+++ b/tests/proc_sched_test.c
@@ -32,6 +32,7 @@
 #include "../kernel/ipc/ipc_msg.h"
 #include "../kernel/ipc/ipc_ops.h"
 #include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/address_space.h"
 #include "../kernel/proc/proc_sched.h"
 #include "../kernel/proc/process.h"
 #include "../user/include/secureos_abi.h"
@@ -41,17 +42,53 @@ static void die(const char *reason) {
   exit(1);
 }
 
+/* Real partitioned address-space arena (issue #260 done-when 3).
+ *
+ * The scheduler now asserts `aspace_invariant_ok(pcb->aspace)` before
+ * restoring any PCB's context. A sentinel pointer like
+ * `(address_space_t *)0x1000` fails that check immediately (it has no
+ * valid `base`/`size`/`stack_top`), so this test backs every PCB with
+ * a real partitioned slot carved out of a host-side arena. The arena
+ * lives in BSS so its address is stable across tests; the partition
+ * is rebuilt by `reset_world()` so each test gets identical inputs.
+ *
+ * Arena sized for PROC_TABLE_MAX windows so any test can claim up to
+ * the table maximum without exhausting the partition.
+ */
+static uint8_t g_test_arena[PROC_TABLE_MAX *
+                            (PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u)];
+static address_space_t g_test_aspaces[PROC_TABLE_MAX];
+static size_t g_test_aspace_next = 0u;
+
 static void reset_world(void) {
   proc_sched_reset();
   process_table_reset();
   ipc_port_table_reset();
   cap_reset_for_tests();
   cap_table_reset();
+
+  /* Rebuild the test partition every reset so each case sees a fresh,
+   * well-formed arena. PROC_TABLE_MAX slots is more than any single
+   * test consumes. */
+  aspace_result_t pr = aspace_partition(
+      (uintptr_t)g_test_arena, sizeof(g_test_arena),
+      g_test_aspaces, PROC_TABLE_MAX);
+  if (pr != ASPACE_OK) {
+    printf("TEST:FAIL:proc_sched:arena_partition_failed:%d\n", (int)pr);
+    exit(1);
+  }
+  g_test_aspace_next = 0u;
 }
 
-/* Sentinel address-space pointer; v0 treats it as opaque. */
-static address_space_t *fake_aspace(uintptr_t tag) {
-  return (address_space_t *)tag;
+/* Claim the next partitioned address-space slot. Each test PCB gets
+ * its own slot — the original `fake_aspace(tag)` sentinels are
+ * preserved as comments so the diff against #260 stays readable. */
+static address_space_t *next_aspace(void) {
+  if (g_test_aspace_next >= PROC_TABLE_MAX) {
+    printf("TEST:FAIL:proc_sched:aspace_arena_exhausted\n");
+    exit(1);
+  }
+  return &g_test_aspaces[g_test_aspace_next++];
 }
 
 /* ------------------------------------------------------------------ */
@@ -73,7 +110,7 @@ static void test_single_dispatch(void) {
   cap_table_grant(subj, CAP_IPC_RECV);
 
   process_id_t pid = PID_INVALID;
-  if (process_create(subj, fake_aspace(0x1000u), &pid) != PROC_OK) die("create_single");
+  if (process_create(subj, next_aspace(), &pid) != PROC_OK) die("create_single");
   if (proc_sched_register(pid, entry_single) != PROC_SCHED_OK) die("register_single");
 
   process_t snap;
@@ -121,8 +158,8 @@ static void test_round_robin(void) {
   reset_world();
   cap_subject_id_t sa = 2u, sb = 3u;
   process_id_t pa = PID_INVALID, pb = PID_INVALID;
-  if (process_create(sa, fake_aspace(0xA000u), &pa) != PROC_OK) die("create_a");
-  if (process_create(sb, fake_aspace(0xB000u), &pb) != PROC_OK) die("create_b");
+  if (process_create(sa, next_aspace(), &pa) != PROC_OK) die("create_a");
+  if (process_create(sb, next_aspace(), &pb) != PROC_OK) die("create_b");
   if (proc_sched_register(pa, entry_a) != PROC_SCHED_OK) die("register_a");
   if (proc_sched_register(pb, entry_b) != PROC_SCHED_OK) die("register_b");
 
@@ -202,8 +239,8 @@ static void test_recv_blocks_until_send(void) {
   }
 
   process_id_t pr = PID_INVALID, ps = PID_INVALID;
-  if (process_create(g_recv_subj, fake_aspace(0xC000u), &pr) != PROC_OK) die("create_recv");
-  if (process_create(g_send_subj, fake_aspace(0xD000u), &ps) != PROC_OK) die("create_send");
+  if (process_create(g_recv_subj, next_aspace(), &pr) != PROC_OK) die("create_recv");
+  if (process_create(g_send_subj, next_aspace(), &ps) != PROC_OK) die("create_send");
   /* Register receiver first so it runs first and is the one that blocks. */
   if (proc_sched_register(pr, entry_receiver) != PROC_SCHED_OK) die("register_recv");
   if (proc_sched_register(ps, entry_sender) != PROC_SCHED_OK) die("register_send");
@@ -281,8 +318,8 @@ static void test_send_blocks_on_full(void) {
   }
 
   process_id_t po = PID_INVALID, pb = PID_INVALID;
-  if (process_create(g_blocker_subj, fake_aspace(0xE000u), &pb) != PROC_OK) die("create_blocker");
-  if (process_create(g_owner_subj, fake_aspace(0xF000u), &po) != PROC_OK) die("create_owner");
+  if (process_create(g_blocker_subj, next_aspace(), &pb) != PROC_OK) die("create_blocker");
+  if (process_create(g_owner_subj, next_aspace(), &po) != PROC_OK) die("create_owner");
   /* Register sender first so it runs and fills the slot before the owner. */
   if (proc_sched_register(pb, entry_blocker_send) != PROC_SCHED_OK) die("register_blocker");
   if (proc_sched_register(po, entry_owner_drain) != PROC_SCHED_OK) die("register_owner");
@@ -324,7 +361,7 @@ static void test_deadlock_detection(void) {
     die("dead_port_create");
   }
   process_id_t pd = PID_INVALID;
-  if (process_create(g_dead_subj, fake_aspace(0x10000u), &pd) != PROC_OK) die("create_dead");
+  if (process_create(g_dead_subj, next_aspace(), &pd) != PROC_OK) die("create_dead");
   if (proc_sched_register(pd, entry_dead_recv) != PROC_SCHED_OK) die("register_dead");
 
   g_deadlock_recv_returned = 0;


### PR DESCRIPTION
## Summary
Closes done-when 3 of #260 — "scheduler block/wake panics on saved-stack-out-of-window, covered by a host harness fixture that exercises the check". Prior cron landed `aspace_invariant_ok()` itself (kernel/proc/address_space.{c,h}) and its unit test (tests/aspace_invariant_test.c); this PR wires the predicate into the cooperative scheduler and migrates the proc_sched fixture off integer-cast sentinels.

## Changes

### Scheduler (kernel/proc/proc_sched.{c,h})
- `proc_sched_run()` now invokes `aspace_invariant_ok(snap.aspace)` on every PCB immediately before `swapcontext()` restores its coroutine.
- On violation the scheduler emits `PANIC:proc_sched:aspace_invariant:<pid>:<reason>` to stderr and `abort()`s (kernel-side panic semantics).
- New test-only mutator `proc_sched_set_panic_hook_for_tests()` lets the host harness observe the violation deterministically: the hook absorbs the panic and the scheduler force-exits the offending PCB with `exit_code = UINT32_MAX` so the dispatch loop keeps draining instead of hanging the test process.
- Reason strings: `null_aspace`, `zero_size`, `window_overflow`, `stack_top_at_or_below_base`, `stack_top_escapes_window`, `ipc_scratch_escapes_window`.

### Test fixture migration (tests/proc_sched_test.c)
- Replaces `fake_aspace(uintptr_t tag)` (cast-to-pointer sentinels) with a real partitioned arena: `reset_world()` rebuilds a `PROC_TABLE_MAX`-window partition via `aspace_partition()` and `next_aspace()` hands each `process_create()` a well-formed slot.
- All five existing sub-tests (single dispatch, round-robin, recv-blocks-until-send, send-blocks-on-full, deadlock detection) pass under the new invariant check.
- `build/scripts/test_proc_sched.sh` now links `kernel/proc/address_space.c`.

### New regression (tests/proc_sched_aspace_invariant_test.c + script)
Four cases exercising the panic site:
1. `proc_sched_aspace_invariant_clean` — well-formed aspace dispatches normally, hook never fires.
2. `proc_sched_aspace_invariant_stack_escape` — `stack_top > base+size` triggers `stack_top_escapes_window`, PCB force-exited with sentinel code, entry never runs.
3. `proc_sched_aspace_invariant_null_aspace` — NULL `aspace` triggers `null_aspace`.
4. `proc_sched_aspace_invariant_scratch_escape` — `ipc_scratch` placed s.t. `IPC_MSG_PAYLOAD_MAX` span straddles the upper bound triggers `ipc_scratch_escapes_window`.

Wired into `build/scripts/test.sh` as `proc_sched_aspace_invariant` and added to the shell-parity allowlist (#156 follow-up).

## Validation
```
$ bash build/scripts/test.sh proc_sched
TEST:PASS:proc_sched_single_dispatch
TEST:PASS:proc_sched_round_robin
TEST:PASS:proc_sched_recv_blocks_until_send
TEST:PASS:proc_sched_send_blocks_on_full
TEST:PASS:proc_sched_deadlock_detected
TEST:PASS:proc_sched

$ bash build/scripts/test.sh proc_sched_aspace_invariant
TEST:PASS:proc_sched_aspace_invariant_clean
TEST:PASS:proc_sched_aspace_invariant_stack_escape
TEST:PASS:proc_sched_aspace_invariant_null_aspace
TEST:PASS:proc_sched_aspace_invariant_scratch_escape
TEST:PASS:proc_sched_aspace_invariant

$ bash build/scripts/test.sh aspace_invariant     # still green
TEST:PASS:aspace_invariant

$ bash build/scripts/check_shell_parity.sh
PARITY:OK
```

## Follow-ups
- The .ps1 peer of `test_proc_sched_aspace_invariant.sh` is on the parity allowlist alongside the existing `test_proc_sched` exemption (issue #156).
- Closure of #260 is gated on maintainer review of the full done-when set; this PR completes item 3.