### PR TITLE
feat(svc): console_svc module — slice 1 of M2-on-M1 substrate (#268)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -57,6 +57,7 @@ test_helloapp_deny
 test_https
 test_ipc_sync_v0
 test_ipc_port_lifecycle
+test_console_svc_port_alloc
 test_ipc_handle_gate
 test_syscall_entry_stub
 test_kernel_persistence

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -129,6 +129,9 @@ case "$TEST_NAME" in
     ;;
   aspace_bounds)
     run_script "$ROOT_DIR/build/scripts/test_aspace_bounds.sh"
+    ;;
+  console_svc_port_alloc)
+    run_script "$ROOT_DIR/build/scripts/test_console_svc_port_alloc.sh"
     ;;
   aspace_invariant)
     run_script "$ROOT_DIR/build/scripts/test_aspace_invariant.sh"

--- a/build/scripts/test_console_svc_port_alloc.sh
+++ b/build/scripts/test_console_svc_port_alloc.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# build/scripts/test_console_svc_port_alloc.sh
+#
+# Build + run the M2-on-M1 substrate console-service port-allocation
+# validator (issue #268, plan plans/2026-05-23-m2-on-m1-substrate.md
+# slice 1).
+#
+# Covers:
+#   - Uninitialised state: is_initialised=false, port=IPC_PORT_INVALID.
+#   - Post-init state: handle valid, owner=SUBJECT_M2_CONSOLE_SVC,
+#     send_cap=recv_cap=CAP_CONSOLE_WRITE.
+#   - Double init returns CONSOLE_SVC_ERR_ALREADY_INIT and does not
+#     allocate a second port.
+#   - Reset clears state; subsequent init succeeds.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/svc/console_svc.c" \
+  "$ROOT_DIR/tests/harness/m2_subjects.c" \
+  "$ROOT_DIR/tests/console_svc_port_alloc_test.c" \
+  -o "$OUT_DIR/console_svc_port_alloc_test"
+
+LOG_PATH="$OUT_DIR/console_svc_port_alloc_test.log"
+"$OUT_DIR/console_svc_port_alloc_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:console_svc_port_alloc_uninit" "$LOG_PATH"
+grep -q "TEST:PASS:console_svc_port_alloc_init" "$LOG_PATH"
+grep -q "TEST:PASS:console_svc_port_alloc_double_init" "$LOG_PATH"
+grep -q "TEST:PASS:console_svc_port_alloc_reset" "$LOG_PATH"
+grep -q "TEST:PASS:console_svc_port_alloc$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/svc/console_svc.c
+++ b/kernel/svc/console_svc.c
@@ -1,0 +1,74 @@
+/**
+ * @file console_svc.c
+ * @brief M2-on-M1 console service implementation — slice 1.
+ *
+ * See `console_svc.h` for the public contract and
+ * `plans/2026-05-23-m2-on-m1-substrate.md` §"Console service module"
+ * for the design context.
+ *
+ * Slice scope (intentionally narrow — issue #268):
+ *   - Allocate one well-known port at init.
+ *   - Expose the handle for downstream slices (#269, #270, #271).
+ *   - Do NOT spin a recv loop or forward bytes to the existing
+ *     console driver yet — that lands with the HelloApp slice (#270).
+ *
+ * Boot-order edge:
+ *   `console_svc_init()` MUST run AFTER `ipc_port_table_init()` (it
+ *   calls `ipc_port_create`) and BEFORE any module-registry walk that
+ *   may try to mint a handle for the console port. In the M1 kernel
+ *   boot sequence (`kernel/core/kmain.c`) this slot is between
+ *   `ipc_port_table_init` and the module-registry init pass. In host
+ *   tests, the test driver controls ordering directly.
+ *
+ * Issue: #268. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 1.
+ */
+
+#include "console_svc.h"
+
+#include "../../tests/harness/m2_subjects.h"
+#include "../cap/capability.h"
+#include "../ipc/ipc_port.h"
+
+/*
+ * Module-private state. A single port handle plus an "initialised"
+ * latch. No dynamic allocation; no other state — the recv loop and
+ * forwarding bookkeeping land in slice 3.
+ */
+static ipc_port_t g_console_svc_port = IPC_PORT_INVALID;
+static bool g_console_svc_initialised = false;
+
+console_svc_result_t console_svc_init(void) {
+  if (g_console_svc_initialised) {
+    return CONSOLE_SVC_ERR_ALREADY_INIT;
+  }
+
+  ipc_port_t handle = IPC_PORT_INVALID;
+  ipc_result_t rc = ipc_port_create((cap_subject_id_t)SUBJECT_M2_CONSOLE_SVC,
+                                    CAP_CONSOLE_WRITE,
+                                    CAP_CONSOLE_WRITE,
+                                    &handle);
+  if (rc != IPC_OK || handle == IPC_PORT_INVALID) {
+    return CONSOLE_SVC_ERR_PORT_ALLOC;
+  }
+
+  g_console_svc_port = handle;
+  g_console_svc_initialised = true;
+  return CONSOLE_SVC_OK;
+}
+
+void console_svc_reset(void) {
+  /* Intentionally do not call ipc_port_destroy() here. Tests that want
+   * the port released use ipc_port_table_reset() in the same phase;
+   * kernel-side reset is owned by the boot sequence in a future
+   * slice (M2-SUBSTRATE-005 if needed). */
+  g_console_svc_port = IPC_PORT_INVALID;
+  g_console_svc_initialised = false;
+}
+
+ipc_port_t console_svc_port(void) {
+  return g_console_svc_port;
+}
+
+bool console_svc_is_initialised(void) {
+  return g_console_svc_initialised;
+}

--- a/kernel/svc/console_svc.h
+++ b/kernel/svc/console_svc.h
@@ -1,0 +1,112 @@
+/**
+ * @file console_svc.h
+ * @brief M2-on-M1 console service: kernel-side IPC endpoint module.
+ *
+ * Purpose:
+ *   Allocates one well-known IPC port via `kernel/ipc/ipc_port.c` at
+ *   subsystem init time. The port is owned by the canonical console
+ *   subject (`SUBJECT_M2_CONSOLE_SVC`, see `tests/harness/m2_subjects.h`)
+ *   and is gated by `CAP_CONSOLE_WRITE` for both directions in the v0
+ *   slice — the recv side is additionally gated by the port-owner check
+ *   in `ipc_recv`, so no new capability id is introduced.
+ *
+ *   This is **slice 1 of plan #263 (M2-on-M1 substrate, issue #259)**.
+ *   Subsequent slices wire HelloApp (#270), launcher manifest handoff
+ *   (#269), and the `_qemu` peers (#271) on top of this module.
+ *
+ *   Out of scope for slice 1:
+ *     - Driving an actual recv loop / forwarding bytes to the existing
+ *       console driver (`kernel/core/console.c`) — slice 3 / #270.
+ *     - PCB allocation for the service itself (`process_create` call)
+ *       — slice 4 (`_qemu` peers) once the boot sequence is wired in.
+ *     - Any user-visible ABI surface — see "ABI" below.
+ *
+ * ABI:
+ *   Internal-only. This header is not part of the frozen `docs/abi/`
+ *   surface; the module exposes its port handle to in-kernel callers
+ *   (launcher, registry walkers) only. The on-wire envelope continues
+ *   to be the canonical `ipc_msg_v0` defined by `kernel/ipc/ipc_msg.h`.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_port.{c,h}: port table; this module is one client.
+ *   - kernel/cap/capability.h: `CAP_CONSOLE_WRITE` send/recv gate.
+ *   - tests/harness/m2_subjects.h: canonical subject ids.
+ *
+ * Launched by:
+ *   `console_svc_init()` is called by `kernel/core/kmain.c` at boot
+ *   between `ipc_port_table_init()` and `proc_init()` (boot-order edge
+ *   documented in the implementation). In host tests, the test driver
+ *   calls it directly after `ipc_port_table_reset()`.
+ *
+ * Issue: #268. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 1.
+ */
+
+#ifndef SECUREOS_KERNEL_SVC_CONSOLE_SVC_H
+#define SECUREOS_KERNEL_SVC_CONSOLE_SVC_H
+
+#include <stdbool.h>
+
+#include "../cap/capability.h"
+#include "../ipc/ipc_port.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Result vocabulary for the slice-1 init entry point. Distinct from
+ * `ipc_result_t` so callers can tell module-level wiring failures
+ * (already initialised, port table full) apart from IPC-level errors.
+ */
+typedef enum {
+  CONSOLE_SVC_OK = 0,
+  CONSOLE_SVC_ERR_PORT_ALLOC = 1,
+  CONSOLE_SVC_ERR_ALREADY_INIT = 2,
+} console_svc_result_t;
+
+/*
+ * Allocate the well-known console-service port. Idempotent-by-error:
+ * a second call before `console_svc_reset()` returns
+ * `CONSOLE_SVC_ERR_ALREADY_INIT` and does not allocate a second port.
+ *
+ * On success, the allocated port:
+ *   - is owned by `SUBJECT_M2_CONSOLE_SVC`,
+ *   - has `send_cap = CAP_CONSOLE_WRITE`,
+ *   - has `recv_cap = CAP_CONSOLE_WRITE` (recv-side gated by owner
+ *     check; see the plan §"Console service module" for rationale).
+ *
+ * The port handle is retrievable via `console_svc_port()` until reset.
+ */
+console_svc_result_t console_svc_init(void);
+
+/*
+ * Tear down the in-memory state. Does NOT call `ipc_port_destroy()` on
+ * the underlying handle — callers that want the port released must
+ * either `ipc_port_table_reset()` (test harness) or land slice 4's
+ * destroy wiring. Always safe to call; no-op when not initialised.
+ *
+ * Provided so test setup/teardown can run in any order without leaking
+ * state across phases.
+ */
+void console_svc_reset(void);
+
+/*
+ * Return the port handle allocated by `console_svc_init()`. Returns
+ * `IPC_PORT_INVALID` when the service has not been initialised. The
+ * launcher (slice 2, #269) calls this when minting handles for a
+ * spawned app.
+ */
+ipc_port_t console_svc_port(void);
+
+/*
+ * Return true iff `console_svc_init()` has been called and not yet
+ * reset. Exposed so the validator test can assert exact init/teardown
+ * lifecycle.
+ */
+bool console_svc_is_initialised(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_SVC_CONSOLE_SVC_H */

--- a/tests/console_svc_port_alloc_test.c
+++ b/tests/console_svc_port_alloc_test.c
@@ -1,0 +1,189 @@
+/**
+ * @file console_svc_port_alloc_test.c
+ * @brief Validator for slice 1 of plan #263 (issue #268).
+ *
+ * Asserts the contract documented in `kernel/svc/console_svc.h`:
+ *
+ *   1. Before init: console_svc_is_initialised() is false and
+ *      console_svc_port() returns IPC_PORT_INVALID.
+ *   2. After init: console_svc_is_initialised() is true,
+ *      console_svc_port() returns a non-zero handle, the handle is
+ *      owned by SUBJECT_M2_CONSOLE_SVC, and both its send_cap and
+ *      recv_cap are CAP_CONSOLE_WRITE (the slice-1 convention — recv
+ *      side gated by the owner check; see plan §"Console service
+ *      module" for rationale).
+ *   3. A second init without reset returns CONSOLE_SVC_ERR_ALREADY_INIT
+ *      and does NOT allocate a second port (handle is unchanged).
+ *   4. After console_svc_reset(): port is IPC_PORT_INVALID and
+ *      is_initialised is false. A subsequent init succeeds and yields
+ *      a fresh handle (post-reset, the previous handle's generation
+ *      has been bumped by ipc_port_table_reset() so any stored copy
+ *      now fails — covered by the IPC port lifecycle suite, not
+ *      re-asserted here).
+ *
+ * Output markers (consumed by build/scripts/test_console_svc_port_alloc.sh):
+ *   TEST:PASS:console_svc_port_alloc_uninit
+ *   TEST:PASS:console_svc_port_alloc_init
+ *   TEST:PASS:console_svc_port_alloc_double_init
+ *   TEST:PASS:console_svc_port_alloc_reset
+ *   TEST:PASS:console_svc_port_alloc
+ *
+ * Pure host-side, no kernel runtime dependencies beyond the slice-1
+ * source files.
+ *
+ * Issue: #268. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 1.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/svc/console_svc.h"
+#include "harness/m2_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:console_svc_port_alloc:%s\n", reason);
+  g_fail = 1;
+}
+
+static void reset_world(void) {
+  console_svc_reset();
+  ipc_port_table_reset();
+}
+
+static void test_uninit(void) {
+  reset_world();
+  if (console_svc_is_initialised()) {
+    fail("uninit_is_initialised_true");
+    return;
+  }
+  if (console_svc_port() != IPC_PORT_INVALID) {
+    fail("uninit_port_not_invalid");
+    return;
+  }
+  printf("TEST:PASS:console_svc_port_alloc_uninit\n");
+}
+
+static void test_init(void) {
+  reset_world();
+  console_svc_result_t rc = console_svc_init();
+  if (rc != CONSOLE_SVC_OK) {
+    fail("init_not_ok");
+    return;
+  }
+  if (!console_svc_is_initialised()) {
+    fail("init_flag_not_set");
+    return;
+  }
+  ipc_port_t handle = console_svc_port();
+  if (handle == IPC_PORT_INVALID) {
+    fail("init_port_invalid");
+    return;
+  }
+
+  cap_subject_id_t owner = 0u;
+  if (ipc_port_owner(handle, &owner) != IPC_OK) {
+    fail("init_owner_query_failed");
+    return;
+  }
+  if (owner != (cap_subject_id_t)SUBJECT_M2_CONSOLE_SVC) {
+    fail("init_owner_mismatch");
+    return;
+  }
+
+  capability_id_t send_cap = 0;
+  if (ipc_port_send_cap(handle, &send_cap) != IPC_OK) {
+    fail("init_send_cap_query_failed");
+    return;
+  }
+  if (send_cap != CAP_CONSOLE_WRITE) {
+    fail("init_send_cap_mismatch");
+    return;
+  }
+
+  capability_id_t recv_cap = 0;
+  if (ipc_port_recv_cap(handle, &recv_cap) != IPC_OK) {
+    fail("init_recv_cap_query_failed");
+    return;
+  }
+  if (recv_cap != CAP_CONSOLE_WRITE) {
+    fail("init_recv_cap_mismatch");
+    return;
+  }
+
+  printf("TEST:PASS:console_svc_port_alloc_init\n");
+}
+
+static void test_double_init(void) {
+  reset_world();
+  if (console_svc_init() != CONSOLE_SVC_OK) {
+    fail("double_first_init_failed");
+    return;
+  }
+  ipc_port_t first = console_svc_port();
+  if (first == IPC_PORT_INVALID) {
+    fail("double_first_handle_invalid");
+    return;
+  }
+
+  console_svc_result_t second = console_svc_init();
+  if (second != CONSOLE_SVC_ERR_ALREADY_INIT) {
+    fail("double_second_init_did_not_reject");
+    return;
+  }
+  if (console_svc_port() != first) {
+    fail("double_handle_changed_on_second_init");
+    return;
+  }
+  printf("TEST:PASS:console_svc_port_alloc_double_init\n");
+}
+
+static void test_reset(void) {
+  reset_world();
+  if (console_svc_init() != CONSOLE_SVC_OK) {
+    fail("reset_init_failed");
+    return;
+  }
+  console_svc_reset();
+  if (console_svc_is_initialised()) {
+    fail("reset_flag_still_true");
+    return;
+  }
+  if (console_svc_port() != IPC_PORT_INVALID) {
+    fail("reset_port_not_invalid");
+    return;
+  }
+
+  /* Fresh init after reset must succeed and produce a valid handle.
+   * (We don't assert handle inequality vs. the pre-reset value: the
+   * ipc_port_table_reset() above invalidates the prior generation, but
+   * the handle's numeric value may legitimately repeat — the
+   * staleness guarantee is the port table's job, not this module's.) */
+  ipc_port_table_reset();
+  if (console_svc_init() != CONSOLE_SVC_OK) {
+    fail("reset_reinit_failed");
+    return;
+  }
+  if (console_svc_port() == IPC_PORT_INVALID) {
+    fail("reset_reinit_port_invalid");
+    return;
+  }
+  printf("TEST:PASS:console_svc_port_alloc_reset\n");
+}
+
+int main(void) {
+  test_uninit();
+  test_init();
+  test_double_init();
+  test_reset();
+
+  if (g_fail) {
+    fprintf(stderr, "TEST:FAIL:console_svc_port_alloc\n");
+    return 1;
+  }
+  printf("TEST:PASS:console_svc_port_alloc\n");
+  return 0;
+}

--- a/tests/harness/m2_subjects.c
+++ b/tests/harness/m2_subjects.c
@@ -1,0 +1,52 @@
+/**
+ * @file m2_subjects.c
+ * @brief Compile-time assertions for the canonical M2 substrate subject ids.
+ *
+ * Header-only-ish: the values themselves live in `m2_subjects.h`.
+ * This translation unit only exists to:
+ *
+ *   1. Statically assert the ids are in the legal cap-table range
+ *      (mirrors the SUBJECT_M1_* range guard in
+ *      `kernel/proc/module_registry.h`).
+ *   2. Assert all three ids are distinct from one another and from the
+ *      reserved `0` so a future renumbering can't silently re-alias.
+ *   3. Give the build a non-empty object file when this header is
+ *      consumed via a `.c,h` pair (per the slice-1 / issue #268 spec).
+ *
+ * No runtime function is exported. Adding behaviour here is out of
+ * scope; per-slice helpers belong in their own translation units.
+ *
+ * Issue: #268. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 1.
+ */
+
+#include "m2_subjects.h"
+
+/* CAP_TABLE_MAX_SUBJECTS is 8 in v0 (see comment in
+ * kernel/proc/module_registry.h on the same constraint). Subject ids
+ * must be strictly less than that bound; the actual constant lives in
+ * kernel/cap/cap_table.h. Replicating it here would create a second
+ * source of truth, so the static_assert below uses the literal `8u`
+ * with a NOTE: if cap_table grows past 8, update this guard in the
+ * same PR that updates `kernel/cap/cap_table.h`. */
+_Static_assert(SUBJECT_M2_LAUNCHER < 8u,
+               "SUBJECT_M2_LAUNCHER must fit under CAP_TABLE_MAX_SUBJECTS");
+_Static_assert(SUBJECT_M2_CONSOLE_SVC < 8u,
+               "SUBJECT_M2_CONSOLE_SVC must fit under CAP_TABLE_MAX_SUBJECTS");
+_Static_assert(SUBJECT_M2_HELLOAPP < 8u,
+               "SUBJECT_M2_HELLOAPP must fit under CAP_TABLE_MAX_SUBJECTS");
+
+_Static_assert(SUBJECT_M2_LAUNCHER != 0u
+               && SUBJECT_M2_CONSOLE_SVC != 0u
+               && SUBJECT_M2_HELLOAPP != 0u,
+               "M2 substrate subject ids must not collide with the "
+               "reserved 0 used by ipc_msg_v0 to signal "
+               "unstamped/invalid sender_subject");
+
+_Static_assert(SUBJECT_M2_LAUNCHER != SUBJECT_M2_CONSOLE_SVC
+               && SUBJECT_M2_LAUNCHER != SUBJECT_M2_HELLOAPP
+               && SUBJECT_M2_CONSOLE_SVC != SUBJECT_M2_HELLOAPP,
+               "M2 substrate subject ids must be pairwise distinct");
+
+/* Keep at least one external symbol in the .o so linkers that strip
+ * empty TUs don't drop the static_asserts above on an LTO build. */
+const unsigned int m2_subjects_compile_marker = 0xC0DEC0DEu;

--- a/tests/harness/m2_subjects.h
+++ b/tests/harness/m2_subjects.h
@@ -1,0 +1,54 @@
+/**
+ * @file m2_subjects.h
+ * @brief Canonical subject ids for the M2-on-M1 substrate test suite.
+ *
+ * Single source of truth for the three subject ids the slice-1 / -2 /
+ * -3 / -4 PRs reference (console service, launcher, HelloApp). Issuing
+ * them from one header keeps the three substrate slices from drifting
+ * into mismatched id pickers.
+ *
+ * Numeric values:
+ *   - Kept LOW (single digits) so they stay under
+ *     `CAP_TABLE_MAX_SUBJECTS` (8 in v0) — same constraint the M1
+ *     module-registry subjects already obey
+ *     (`kernel/proc/module_registry.h` SUBJECT_M1_*).
+ *   - Distinct from SUBJECT_M1_SENDER/RECEIVER/UNAUTH (5/6/7) so the
+ *     M1 IPC demo and the M2 substrate demo can coexist in the same
+ *     test phase without subject-id collisions.
+ *   - `0` is reserved (the IPC v0 spec requires kernel-stamped
+ *     `sender_subject != 0` on receive); never used here.
+ *
+ * Subject map (frozen under `OS_ABI_VERSION = 0`):
+ *   SUBJECT_M2_LAUNCHER    = 1   launcher (M2 mediation point)
+ *   SUBJECT_M2_CONSOLE_SVC = 2   in-kernel console service module
+ *   SUBJECT_M2_HELLOAPP    = 3   spawned HelloApp under launcher
+ *                                (placeholder until slice 3 lands)
+ *
+ * Issue: #268 (slice 1). Consumed by slices 2 / 3 / 4 (#269 / #270 /
+ * #271). Plan: plans/2026-05-23-m2-on-m1-substrate.md §"Risks and
+ * explicit assumptions" — shared helper to keep each new test under
+ * ~120 LoC.
+ */
+
+#ifndef SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H
+#define SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H
+
+#include "../../kernel/cap/capability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Canonical M2 substrate subject ids. Pinned by tests; do NOT
+ * renumber without updating every slice-1..4 consumer in the same PR.
+ */
+#define SUBJECT_M2_LAUNCHER    ((cap_subject_id_t)1u)
+#define SUBJECT_M2_CONSOLE_SVC ((cap_subject_id_t)2u)
+#define SUBJECT_M2_HELLOAPP    ((cap_subject_id_t)3u)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H */


### PR DESCRIPTION
Implements **M2-SUBSTRATE-001** — slice 1 of plan #263 (issue #259) — closing #268.

## What lands

- `kernel/svc/console_svc.{c,h}` — minimal in-kernel module that allocates one well-known IPC port owned by `SUBJECT_M2_CONSOLE_SVC` with `send_cap = recv_cap = CAP_CONSOLE_WRITE`. Idempotent-by-error init, explicit reset. No recv loop / no byte forwarding yet — those land with the HelloApp slice (#270, slice 3).
- `tests/harness/m2_subjects.{c,h}` — canonical subject-id header consumed by all three substrate slices (launcher=1, console_svc=2, helloapp=3). `_Static_assert`s pin the range + pairwise distinctness so a future renumber can't silently break the M2 acceptance suite.
- `tests/console_svc_port_alloc_test.c` — validator asserting:
  - Uninit: `is_initialised=false`, `port=IPC_PORT_INVALID`.
  - Init: handle valid, owner = `SUBJECT_M2_CONSOLE_SVC`, send/recv caps = `CAP_CONSOLE_WRITE`.
  - Double init returns `CONSOLE_SVC_ERR_ALREADY_INIT` and does not allocate a second port.
  - Reset clears state; re-init after reset succeeds.
- `build/scripts/test_console_svc_port_alloc.sh` — build+run wrapper, deterministic `TEST:PASS:console_svc_port_alloc{,_uninit,_init,_double_init,_reset}` markers.
- `build/scripts/test.sh` — `console_svc_port_alloc` dispatch (plus usage line update).
- `build/scripts/.shell_parity_allowlist` — added entry under #156 (matches every existing IPC/cap_handle/aspace test — no `.ps1` peers exist yet for the M1/M2 suite).

## Validation

```
$ bash build/scripts/test.sh console_svc_port_alloc
TEST:PASS:console_svc_port_alloc_uninit
TEST:PASS:console_svc_port_alloc_init
TEST:PASS:console_svc_port_alloc_double_init
TEST:PASS:console_svc_port_alloc_reset
TEST:PASS:console_svc_port_alloc

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 67 entries)
```

## Explicit non-goals (per issue #268 / plan §"Out of scope")

- HelloApp wiring (slice 3 / #270).
- Launcher → cap_handle handoff (slice 2 / #269).
- `_qemu`-tier acceptance peers (slices 3 / 4).
- Boot-order wire-in to `kmain.c` — module is reachable only from tests in this slice. Production boot wiring is documented in the header for slice 4 to pick up; landing the `kmain` edit here would require running the qemu boot path against an init sequence that doesn't exist yet.
- `process_create("console-svc", …)` PCB allocation — also slice 4. The plan's §"Console service module" sketch covers this; doing it here would force a circular dep with the boot-order edge above.

## ABI

No new ABI surface. No `OS_ABI_VERSION` bump. `console_svc.h` is internal-only and not listed under `docs/abi/`.

## Follow-ups

- Slice 2 (#269): launcher manifest handoff that mints `cap_handle_t` for `CAP_CONSOLE_WRITE` against `console_svc_port()`.
- Slice 3 (#270): HelloApp module + `console_svc_recv_step()` forwarding to the existing console driver.
- Slice 4 (#271): `_qemu` acceptance peers for §5.2 markers.
- Boot-order wire-in (`kmain.c` between `ipc_port_table_init` and `proc_init`) — to be landed alongside slice 4 once the production boot sequence has somewhere to send the allocated handle.

Closes #268.
