### PR TITLE
feat(launcher): spawn_app_from_manifest + ipc_scratch handle handoff (closes #269)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -63,6 +63,7 @@ test_syscall_entry_stub
 test_kernel_persistence
 test_launcher_console
 test_launcher_fs
+test_launcher_spawn_handoff
 test_manifest_required_fields
 test_netlib_url_scheme
 test_scheduler

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -168,6 +168,9 @@ case "$TEST_NAME" in
     ;;
   launcher_console)
     run_script "$ROOT_DIR/build/scripts/test_launcher_console.sh"
+    ;;
+  launcher_spawn_handoff)
+    run_script "$ROOT_DIR/build/scripts/test_launcher_spawn_handoff.sh"
     ;;
   event_bus)
     run_script "$ROOT_DIR/build/scripts/test_event_bus.sh"

--- a/build/scripts/test_launcher_console.sh
+++ b/build/scripts/test_launcher_console.sh
@@ -9,7 +9,10 @@ mkdir -p "$OUT_DIR"
 cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/kernel/user/launcher.c" \
   "$ROOT_DIR/tests/launcher_console_test.c" \
   -o "$OUT_DIR/launcher_console_test"

--- a/build/scripts/test_launcher_spawn_handoff.sh
+++ b/build/scripts/test_launcher_spawn_handoff.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# build/scripts/test_launcher_spawn_handoff.sh
+#
+# Build + run the M2-on-M1 substrate launcher-spawn handoff validator
+# (issue #269, plan plans/2026-05-23-m2-on-m1-substrate.md slice 2).
+#
+# Covers:
+#   - launcher_spawn_app_from_manifest() carves a fresh address_space_t
+#     window, spawns a real PCB via process_create, mints a
+#     cap_handle_t, and writes it little-endian into the first 4 bytes
+#     of the spawned aspace's ipc_scratch region.
+#   - The minted handle round-trips through cap_gate_check_handle().
+#   - A manifest with no auto-grant leaves the scratch slot zeroed.
+#   - launcher_spawn_destroy() revokes the handle.
+#   - Invalid manifests (NULL, subject_id == 0, unsupported cap,
+#     NULL caps pointer with non-zero count) are rejected with
+#     LAUNCHER_ERR_INVALID_MANIFEST.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/tests/harness/m2_subjects.c" \
+  "$ROOT_DIR/tests/launcher_spawn_handoff_test.c" \
+  -o "$OUT_DIR/launcher_spawn_handoff_test"
+
+LOG_PATH="$OUT_DIR/launcher_spawn_handoff_test.log"
+"$OUT_DIR/launcher_spawn_handoff_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:launcher_spawn_handoff_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_spawn_handoff_no_grant" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_spawn_handoff_destroy" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_spawn_handoff_invalid_manifest" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_spawn_handoff$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/architecture/m1-m2-handoff.md
+++ b/docs/architecture/m1-m2-handoff.md
@@ -1,0 +1,135 @@
+# M1 → M2 launcher → app initial capability handoff
+
+| Field            | Value                                                 |
+| ---------------- | ----------------------------------------------------- |
+| Owner            | kernel + launcher                                     |
+| Status           | accepted (slice 2 of plan #263 / M2-on-M1 substrate)  |
+| Last reviewed    | 2026-05-24                                            |
+| Applies to       | `OS_ABI_VERSION = 0`                                  |
+| Tracking issue   | #269                                                  |
+| Source-of-truth  | `kernel/user/launcher.{c,h}`, `kernel/proc/address_space.{c,h}` |
+
+## Problem
+
+M1 froze three independent surfaces:
+
+* the **process table** + `address_space_t` window (`process_create`, `aspace_partition`, #238 / #248 / #249),
+* the **capability handle** layer (`cap_handle_t`, frozen 32-bit layout, #233 / #237 / #240 / #247),
+* the **synchronous IPC v0** primitive and its handle-gated peers
+  (`ipc_send_h` / `ipc_recv_h`, #220 / #229 / #246).
+
+M2's launcher historically called the gate functions as flat C functions
+inside a single host process (`launcher_app_console_write`). It never
+crossed a real PCB boundary. To re-platform M2 on top of M1 (plan #263),
+the launcher needs to:
+
+1. **Spawn** the app as a real PCB with its own
+   `address_space_t` window, and
+2. **Hand off** the first `cap_handle_t` to that app **in-band** —
+   without inventing a new ABI surface.
+
+This document fixes the in-band handoff convention.
+
+## Convention
+
+Each `address_space_t` carved by `aspace_partition()` reserves the first
+`IPC_MSG_PAYLOAD_MAX` (= 64) bytes of its window as the per-process
+**IPC scratch region** (`address_space_t::ipc_scratch`,
+`kernel/proc/address_space.h`).
+
+For the M1→M2 initial handoff, the launcher writes the freshly minted
+`cap_handle_t` into the first **four** scratch bytes, **little-endian**:
+
+```
+offset  bytes  meaning
+   0      4    cap_handle_t (LE)  — launcher-minted initial grant
+   4     60    reserved (zeroed by aspace_partition)
+```
+
+The wire is identical to how a future syscall would return the handle
+to userspace: a `uint32_t` in target-platform byte order, with the
+launcher choosing LE so the convention is portable across the host
+test fixtures and the qemu peers.
+
+### Why the scratch region
+
+* It is **per-process** and **bounds-enforced** by the existing
+  `aspace_contains()` gate (#260 done-when 1).
+* It is **already** the surface the kernel uses to stage `ipc_msg_v0`
+  payloads — so the receiving app reads it through the same pointer it
+  will use to drain real IPC messages once HelloApp's module body
+  (slice 3, #270) lands.
+* It avoids inventing a new register-bank ABI or a thread-local-storage
+  pointer; both would be ABI surfaces that need their own #150 process.
+
+### Why little-endian
+
+* Matches the on-disk endianness of `cap_handle_t` whenever the cap
+  table is persisted (planned for M3 / #82).
+* Matches every supported target (host x86_64, qemu x86_64) at
+  `OS_ABI_VERSION = 0`. A big-endian port would re-encode in
+  `scratch_store_handle()` only.
+
+### Versioning
+
+The slot is **frozen** under `OS_ABI_VERSION = 0`:
+
+* Offsets `[0,4)` are the cap_handle.
+* Offsets `[4,64)` are reserved and MUST be zero on handoff.
+
+A future `OS_ABI_VERSION` bump may widen the slot (e.g. to pass a tuple
+of `(handle, port)` for handle-port pre-binding); the launcher will be
+updated in lockstep with the schema gate (#226) as per the §7 process
+in `docs/abi/versioning.md`.
+
+## Lifecycle
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ 1. launcher_spawn_app_from_manifest(manifest, &out_spawn)        │
+│      ├── aspace_partition()       → out_spawn.aspace             │
+│      ├── process_create()         → out_spawn.pid                │
+│      ├── cap_handle_grant(subj,…) → h                            │
+│      └── scratch_store_handle(as, h)  ← LE write into [0..4)     │
+│                                                                  │
+│ 2. App reads first 4 bytes of its ipc_scratch as a cap_handle_t  │
+│    and passes it to ipc_send_h() / cap_gate_check_handle().      │
+│                                                                  │
+│ 3. launcher_spawn_destroy(pid)                                   │
+│      └── process_destroy() cascades cap_handle_revoke_subject()  │
+│         (per #239) so any stored copy of `h` now fails.          │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Validator
+
+`tests/launcher_spawn_handoff_test.c` (#269 slice 2 acceptance):
+
+* Spawns a no-op PCB from a synthesised `launcher_manifest_t` that
+  declares `CAP_CONSOLE_WRITE` as the auto-grant.
+* Asserts `out_spawn.aspace->ipc_scratch[0..4)` decodes byte-for-byte
+  to the same `cap_handle_t` value returned in
+  `out_spawn.granted_handle`.
+* Asserts the handle round-trips through
+  `cap_gate_check_handle(h, CAP_CONSOLE_WRITE) == 1`.
+* Asserts `launcher_spawn_destroy()` revokes the handle
+  (`cap_gate_check_handle(h, CAP_CONSOLE_WRITE) == 0`).
+
+The validator is host-only; the qemu peer lands with slice 4 (#271).
+
+## Non-goals
+
+* No new `ipc_result_t` value, no new `capability_id_t`, no
+  `OS_ABI_VERSION` bump.
+* No HelloApp module body — slice 3 (#270) wires it on top of this
+  convention.
+* No multi-handle handoff — `auto_grant_caps[0]` is the only slot
+  consumed in v0. The remaining 60 bytes of scratch are zeroed and
+  reserved.
+
+## Related
+
+* [Plan: `plans/2026-05-23-m2-on-m1-substrate.md`](../../plans/2026-05-23-m2-on-m1-substrate.md)
+* [Capability handle layer (`docs/abi/capabilities.md`)](../abi/capabilities.md)
+* [Capability deny contract (`docs/abi/capability-deny-contract.md`)](../abi/capability-deny-contract.md)
+* [ABI versioning policy (`docs/abi/versioning.md`)](../abi/versioning.md)

--- a/kernel/user/launcher.c
+++ b/kernel/user/launcher.c
@@ -22,8 +22,15 @@
 
 #include "launcher.h"
 
+#include <stddef.h>
+#include <string.h>
+
 #include "../cap/cap_gate.h"
+#include "../cap/cap_handle.h"
 #include "../cap/cap_table.h"
+#include "../ipc/ipc_msg.h"
+#include "../proc/address_space.h"
+#include "../proc/process.h"
 
 #define LAUNCHER_MAX_APPS CAP_TABLE_MAX_SUBJECTS
 
@@ -56,6 +63,7 @@ void launcher_reset(void) {
     launcher_apps[i].used = 0;
     launcher_apps[i].subject_id = 0u;
   }
+  launcher_spawn_reset();
 }
 
 launcher_result_t launcher_register_app(cap_subject_id_t app_subject_id) {
@@ -137,4 +145,240 @@ int launcher_app_has_console_write(cap_subject_id_t app_subject_id) {
     return 0;
   }
   return cap_table_check(app_subject_id, CAP_CONSOLE_WRITE) == CAP_OK;
+}
+
+/* ----------------------------------------------------------------
+ * Slice 2 (#269): launcher-mediated spawn + capability handoff.
+ *
+ * The launcher owns a small, statically-sized arena out of which it
+ * carves one `address_space_t` window per spawned app via
+ * `aspace_partition`. The arena is sized for `LAUNCHER_SPAWN_MAX`
+ * concurrent spawns, matching the launcher's app-registration cap.
+ *
+ * Rationale for an arena local to the launcher (rather than reusing
+ * `module_registry.c`'s `g_demo_aspace_arena`): the M1 IPC demo lives
+ * in `module_registry.c` and runs in the same test phase as the M2
+ * substrate slice 2 acceptance test (#269). Sharing a single arena
+ * would let the two callers race on `g_demo_aspace_next`. A separate,
+ * launcher-owned arena keeps the slices independent so neither side
+ * has to know about the other.
+ * ---------------------------------------------------------------- */
+
+#define LAUNCHER_SPAWN_MAX  CAP_TABLE_MAX_SUBJECTS
+
+/* Per-window: kernel stack + IPC scratch + alignment slack. Matches the
+ * sizing used by `module_registry.c` (`PROC_KSTACK_BYTES +
+ * IPC_MSG_PAYLOAD_MAX + 64`). */
+#define LAUNCHER_SPAWN_ARENA_BYTES                                       \
+  (LAUNCHER_SPAWN_MAX *                                                  \
+   (PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u))
+
+typedef struct {
+  bool             in_use;
+  process_id_t     pid;
+  address_space_t *aspace;
+  cap_handle_t     handle;
+  capability_id_t  cap;
+} launcher_spawn_slot_t;
+
+static uint8_t                g_launcher_arena[LAUNCHER_SPAWN_ARENA_BYTES];
+static address_space_t        g_launcher_aspaces[LAUNCHER_SPAWN_MAX];
+static launcher_spawn_slot_t  g_launcher_spawns[LAUNCHER_SPAWN_MAX];
+static size_t                 g_launcher_aspace_next = 0u;
+static bool                   g_launcher_arena_ready = false;
+
+static bool launcher_arena_rebuild(void) {
+  aspace_result_t pr = aspace_partition(
+      (uintptr_t)g_launcher_arena, sizeof(g_launcher_arena),
+      g_launcher_aspaces, LAUNCHER_SPAWN_MAX);
+  g_launcher_aspace_next = 0u;
+  g_launcher_arena_ready = (pr == ASPACE_OK);
+  return g_launcher_arena_ready;
+}
+
+static address_space_t *launcher_aspace_claim(void) {
+  if (!g_launcher_arena_ready) {
+    (void)launcher_arena_rebuild();
+  }
+  if (!g_launcher_arena_ready) {
+    return NULL;
+  }
+  if (g_launcher_aspace_next >= LAUNCHER_SPAWN_MAX) {
+    return NULL;
+  }
+  return &g_launcher_aspaces[g_launcher_aspace_next++];
+}
+
+static launcher_spawn_slot_t *launcher_spawn_slot_alloc(void) {
+  for (size_t i = 0; i < LAUNCHER_SPAWN_MAX; ++i) {
+    if (!g_launcher_spawns[i].in_use) {
+      return &g_launcher_spawns[i];
+    }
+  }
+  return NULL;
+}
+
+static launcher_spawn_slot_t *launcher_spawn_slot_find(process_id_t pid) {
+  if (pid == PID_INVALID) {
+    return NULL;
+  }
+  for (size_t i = 0; i < LAUNCHER_SPAWN_MAX; ++i) {
+    if (g_launcher_spawns[i].in_use && g_launcher_spawns[i].pid == pid) {
+      return &g_launcher_spawns[i];
+    }
+  }
+  return NULL;
+}
+
+void launcher_spawn_reset(void) {
+  for (size_t i = 0; i < LAUNCHER_SPAWN_MAX; ++i) {
+    if (g_launcher_spawns[i].in_use && g_launcher_spawns[i].pid != PID_INVALID) {
+      /* Best-effort tear-down; ignore errors so reset is total. */
+      (void)process_destroy(g_launcher_spawns[i].pid);
+    }
+    g_launcher_spawns[i].in_use = false;
+    g_launcher_spawns[i].pid = PID_INVALID;
+    g_launcher_spawns[i].aspace = NULL;
+    g_launcher_spawns[i].handle = CAP_HANDLE_NULL;
+    g_launcher_spawns[i].cap = (capability_id_t)0;
+  }
+  (void)launcher_arena_rebuild();
+}
+
+/* Encode a 32-bit handle as little-endian into the first four bytes of
+ * the per-process IPC scratch region. This is the M1→M2 initial-handoff
+ * vector documented in `docs/architecture/m1-m2-handoff.md`. */
+static void scratch_store_handle(address_space_t *as, cap_handle_t h) {
+  if (as == NULL || as->ipc_scratch == NULL) {
+    return;
+  }
+  uint8_t *p = as->ipc_scratch;
+  p[0] = (uint8_t)( h        & 0xFFu);
+  p[1] = (uint8_t)((h >>  8) & 0xFFu);
+  p[2] = (uint8_t)((h >> 16) & 0xFFu);
+  p[3] = (uint8_t)((h >> 24) & 0xFFu);
+}
+
+launcher_result_t launcher_spawn_app_from_manifest(
+    const launcher_manifest_t *manifest,
+    launcher_spawn_t *out_spawn) {
+  if (out_spawn == NULL) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  out_spawn->pid = PID_INVALID;
+  out_spawn->aspace = NULL;
+  out_spawn->granted_handle = CAP_HANDLE_NULL;
+  out_spawn->granted_cap = (capability_id_t)0;
+
+  if (manifest == NULL) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  if (!launcher_subject_in_range(manifest->subject_id) ||
+      manifest->subject_id == 0u) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  if (manifest->auto_grant_count > 0 && manifest->auto_grant_caps == NULL) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+
+  /* v0 supports at most one auto-granted cap; ignore extras silently
+   * the same way the on-disk schema reserves room for them. */
+  bool want_grant = (manifest->auto_grant_count > 0);
+  capability_id_t grant_cap = want_grant ? manifest->auto_grant_caps[0]
+                                         : (capability_id_t)0;
+  if (want_grant) {
+    /* Mirror `launcher_grant_console_write`'s ABI: slice 2 only knows
+     * how to hand off CAP_CONSOLE_WRITE in the scratch slot. Other
+     * caps would need their own slice-3 wiring. */
+    if (grant_cap != CAP_CONSOLE_WRITE) {
+      return LAUNCHER_ERR_INVALID_MANIFEST;
+    }
+  }
+
+  launcher_spawn_slot_t *slot = launcher_spawn_slot_alloc();
+  if (slot == NULL) {
+    return LAUNCHER_ERR_INTERNAL;
+  }
+
+  /* (1) Carve a fresh aspace window. */
+  address_space_t *as = launcher_aspace_claim();
+  if (as == NULL) {
+    return LAUNCHER_ERR_ASPACE;
+  }
+
+  /* (2) Register the subject with the launcher's legacy app table so
+   * the existing `launcher_app_console_write` audit path stays intact. */
+  launcher_result_t reg = launcher_register_app(manifest->subject_id);
+  if (reg != LAUNCHER_OK) {
+    return reg;
+  }
+
+  /* (3) Spawn the PCB. */
+  process_id_t pid = PID_INVALID;
+  if (process_create(manifest->subject_id, as, &pid) != PROC_OK) {
+    return LAUNCHER_ERR_PROC_CREATE;
+  }
+
+  /* (4) Zero the scratch slot so the handoff contract's reserved-bytes
+   * guarantee holds regardless of arena re-use. If a cap is being
+   * handed off, the LE handle write below clobbers bytes [0..4). */
+  if (as->ipc_scratch != NULL) {
+    memset(as->ipc_scratch, 0, IPC_MSG_PAYLOAD_MAX);
+  }
+
+  /* (5) If a cap was requested, mint both the legacy bitset grant
+   * (so cap_check audit parity is preserved on ipc_send_h paths) and
+   * the authoritative handle, then store the handle LE into the
+   * scratch slot. */
+  cap_handle_t h = CAP_HANDLE_NULL;
+  if (want_grant) {
+    if (cap_table_grant(manifest->subject_id, grant_cap) != CAP_OK) {
+      (void)process_destroy(pid);
+      return LAUNCHER_ERR_HANDLE_MINT;
+    }
+    h = cap_handle_grant(manifest->subject_id, grant_cap);
+    if (h == CAP_HANDLE_NULL) {
+      (void)process_destroy(pid);
+      return LAUNCHER_ERR_HANDLE_MINT;
+    }
+    if (as->ipc_scratch == NULL) {
+      /* Aspace carry no scratch — cannot complete the handoff. */
+      (void)process_destroy(pid);
+      return LAUNCHER_ERR_SCRATCH;
+    }
+    scratch_store_handle(as, h);
+  }
+
+  slot->in_use = true;
+  slot->pid = pid;
+  slot->aspace = as;
+  slot->handle = h;
+  slot->cap = grant_cap;
+
+  out_spawn->pid = pid;
+  out_spawn->aspace = as;
+  out_spawn->granted_handle = h;
+  out_spawn->granted_cap = grant_cap;
+  return LAUNCHER_OK;
+}
+
+launcher_result_t launcher_spawn_destroy(process_id_t pid) {
+  if (pid == PID_INVALID) {
+    return LAUNCHER_OK;
+  }
+  launcher_spawn_slot_t *slot = launcher_spawn_slot_find(pid);
+  if (slot == NULL) {
+    /* Not a launcher-owned spawn; refuse rather than silently destroy
+     * an arbitrary PCB. */
+    return LAUNCHER_ERR_INVALID_APP;
+  }
+  /* process_destroy cascades cap_handle_revoke_subject() per #239 so
+   * any stored copy of the minted handle fails cleanly after this. */
+  (void)process_destroy(slot->pid);
+  slot->in_use = false;
+  slot->pid = PID_INVALID;
+  slot->aspace = NULL;
+  slot->handle = CAP_HANDLE_NULL;
+  slot->cap = (capability_id_t)0;
+  return LAUNCHER_OK;
 }

--- a/kernel/user/launcher.h
+++ b/kernel/user/launcher.h
@@ -2,8 +2,12 @@
 #define SECUREOS_LAUNCHER_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "../cap/capability.h"
+#include "../cap/cap_handle.h"
+#include "../proc/address_space.h"
+#include "../proc/process.h"
 
 /**
  * @file launcher.h
@@ -30,7 +34,71 @@ typedef enum {
   LAUNCHER_ERR_NOT_REGISTERED = 2,
   LAUNCHER_ERR_DENIED = 3,
   LAUNCHER_ERR_INTERNAL = 4,
+  /* Slice-2 (#269) spawn-path errors. Distinct codes so the
+   * launcher_spawn_handoff test can pin which substep of
+   * launcher_spawn_app_from_manifest() failed. */
+  LAUNCHER_ERR_INVALID_MANIFEST = 5,
+  LAUNCHER_ERR_ASPACE = 6,
+  LAUNCHER_ERR_PROC_CREATE = 7,
+  LAUNCHER_ERR_HANDLE_MINT = 8,
+  LAUNCHER_ERR_SCRATCH = 9,
 } launcher_result_t;
+
+/*
+ * Kernel-internal manifest projection (slice 2 of plan #263, issue #269).
+ *
+ * The on-disk manifest schema (`manifests/schema/v0.json`) carries fields
+ * — id, version, signer key, optional caps, signature — that the
+ * build-pipeline validator already gates (#226). The launcher's spawn
+ * path only consumes the small subset listed below; we keep this struct
+ * in the kernel surface so the in-kernel HelloApp slice (#270) and the
+ * host tests both build a manifest in the same shape without dragging a
+ * JSON parser into the kernel.
+ *
+ * Field ownership:
+ *   - subject_id           : the spawned app's `cap_subject_id_t`. MUST
+ *                            be inside `[1, CAP_TABLE_MAX_SUBJECTS)`.
+ *   - auto_grant_caps      : caller-owned array of capability ids the
+ *                            launcher is asked to mint a handle for at
+ *                            spawn time. v0 supports at most one entry
+ *                            (`CAP_CONSOLE_WRITE`) — additional entries
+ *                            past index 0 are ignored. The pointer may
+ *                            be NULL when `auto_grant_count == 0`.
+ *   - auto_grant_count     : number of entries in `auto_grant_caps`.
+ *
+ * No string fields and no allocation: the struct is plain-old-data and
+ * lives on the caller's stack.
+ */
+typedef struct {
+  cap_subject_id_t        subject_id;
+  const capability_id_t  *auto_grant_caps;
+  size_t                  auto_grant_count;
+} launcher_manifest_t;
+
+/*
+ * Output of a successful `launcher_spawn_app_from_manifest()` call.
+ *
+ *   - pid                  : freshly allocated PCB id.
+ *   - aspace               : pointer to the partitioned `address_space_t`
+ *                            window the launcher carved for the app.
+ *                            Owned by the launcher; remains valid until
+ *                            `launcher_spawn_reset()` is called.
+ *   - granted_handle       : 32-bit `cap_handle_t` minted for the app.
+ *                            Equals `CAP_HANDLE_NULL` when the manifest
+ *                            requested no auto-grant.
+ *   - granted_cap          : the capability id the handle was minted
+ *                            against (matches `granted_handle`).
+ *
+ * The same handle is written little-endian into the first four bytes
+ * of `aspace->ipc_scratch` as the M1→M2 initial-handoff vector (see
+ * `docs/architecture/m1-m2-handoff.md`).
+ */
+typedef struct {
+  process_id_t      pid;
+  address_space_t  *aspace;
+  cap_handle_t      granted_handle;
+  capability_id_t   granted_cap;
+} launcher_spawn_t;
 
 /* Reset launcher state and any registered app grants. Safe for tests. */
 void launcher_reset(void);
@@ -67,5 +135,56 @@ launcher_result_t launcher_app_console_write(cap_subject_id_t app_subject_id,
 
 /* Read-only inspection: returns 1 if the app currently holds console-write. */
 int launcher_app_has_console_write(cap_subject_id_t app_subject_id);
+
+/* ----------------------------------------------------------------
+ * Slice 2 (#269): launcher-mediated spawn + capability handoff.
+ *
+ * `launcher_spawn_app_from_manifest()` is the single sanctioned entry
+ * point that turns a `launcher_manifest_t` into a live PCB:
+ *
+ *   1. Partitions a fresh `address_space_t` window out of the
+ *      launcher-owned arena (`aspace_partition` from #248/#249).
+ *   2. Registers the app subject with the launcher (legacy path)
+ *      and applies any `auto_grant_at_launch` cap on the legacy
+ *      bitset so `cap_check`-based audit parity is preserved.
+ *   3. Calls `process_create` with the app subject + new aspace.
+ *   4. Mints a `cap_handle_t` for the first `auto_grant_caps[]` entry
+ *      (currently only `CAP_CONSOLE_WRITE` is supported) and writes
+ *      it little-endian into `aspace->ipc_scratch[0..3]`. This is the
+ *      M1→M2 initial-handoff vector documented in
+ *      `docs/architecture/m1-m2-handoff.md`.
+ *
+ * The function does NOT register the spawned PCB with the cooperative
+ * scheduler — slice 3 (#270) does that once HelloApp's module body
+ * lands. Tests that need a scheduler-aware spawn use `proc_spawn_module`
+ * via `kernel/proc/module_registry.c` as before.
+ *
+ * `out_spawn` MUST be non-NULL. On any error the launcher state is
+ * rolled back: the carved aspace slot is returned to the pool, no PCB
+ * remains live, and no handle is minted. On success, the caller may
+ * call `launcher_spawn_destroy(out_spawn->pid)` to tear the spawn down
+ * (which also revokes the minted handle via `process_destroy`'s
+ * subject-revoke fast-path from #239).
+ *
+ * No new ABI surface — error codes and the cap_handle layout are all
+ * pre-frozen under `OS_ABI_VERSION = 0`.
+ */
+launcher_result_t launcher_spawn_app_from_manifest(
+    const launcher_manifest_t *manifest,
+    launcher_spawn_t *out_spawn);
+
+/* Destroy a spawn produced by `launcher_spawn_app_from_manifest()`. The
+ * underlying PCB is destroyed (revoking the minted handle as a side
+ * effect, per #239), the carved aspace slot is returned to the spawn
+ * pool, and the launcher app-table entry is cleared. Safe to call with
+ * `PID_INVALID` (no-op). Returns `LAUNCHER_OK` on either teardown or
+ * the no-op case. */
+launcher_result_t launcher_spawn_destroy(process_id_t pid);
+
+/* Test helper: reset the launcher spawn pool back to empty. Equivalent
+ * to calling `launcher_spawn_destroy()` on every outstanding spawn,
+ * but also re-partitions the underlying arena so a subsequent spawn
+ * starts from a known-clean state. `launcher_reset()` calls into this. */
+void launcher_spawn_reset(void);
 
 #endif

--- a/tests/launcher_spawn_handoff_test.c
+++ b/tests/launcher_spawn_handoff_test.c
@@ -1,0 +1,276 @@
+/**
+ * @file launcher_spawn_handoff_test.c
+ * @brief Slice-2 acceptance test for plan #263 / issue #269.
+ *
+ * Asserts the M1→M2 initial-capability handoff contract documented in
+ * `docs/architecture/m1-m2-handoff.md`:
+ *
+ *   1. `launcher_spawn_app_from_manifest()` with an auto-grant of
+ *      CAP_CONSOLE_WRITE returns a live PCB with a non-zero
+ *      `granted_handle`, and the same handle is written little-endian
+ *      into the first four bytes of the spawned aspace's `ipc_scratch`.
+ *   2. The minted handle round-trips through
+ *      `cap_gate_check_handle(h, CAP_CONSOLE_WRITE) == 1`.
+ *   3. A manifest with no auto-grant spawns the PCB but leaves
+ *      `granted_handle == CAP_HANDLE_NULL` and the scratch region
+ *      zeroed in the first four bytes.
+ *   4. `launcher_spawn_destroy(pid)` revokes the handle
+ *      (`cap_gate_check_handle(h, CAP_CONSOLE_WRITE) == 0`) and
+ *      releases the slot for re-use.
+ *   5. A manifest with subject_id == 0 or auto-grant != CAP_CONSOLE_WRITE
+ *      is rejected with `LAUNCHER_ERR_INVALID_MANIFEST` and no PCB
+ *      remains live afterwards.
+ *
+ * Output markers (consumed by build/scripts/test_launcher_spawn_handoff.sh):
+ *   TEST:PASS:launcher_spawn_handoff_grant
+ *   TEST:PASS:launcher_spawn_handoff_no_grant
+ *   TEST:PASS:launcher_spawn_handoff_destroy
+ *   TEST:PASS:launcher_spawn_handoff_invalid_manifest
+ *   TEST:PASS:launcher_spawn_handoff
+ *
+ * Pure host-side; no kernel runtime dependencies beyond the slice-2
+ * sources and their transitive M1 substrate.
+ *
+ * Issue: #269. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 2.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/user/launcher.h"
+#include "harness/m2_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:launcher_spawn_handoff:%s\n", reason);
+  g_fail = 1;
+}
+
+static cap_handle_t scratch_load_handle(const address_space_t *as) {
+  const uint8_t *p = (const uint8_t *)as->ipc_scratch;
+  return (cap_handle_t)p[0]
+       | ((cap_handle_t)p[1] <<  8)
+       | ((cap_handle_t)p[2] << 16)
+       | ((cap_handle_t)p[3] << 24);
+}
+
+static void test_setup(void) {
+  /* Reset every shared singleton the launcher slice-2 path touches so
+   * the test starts from a known state regardless of run ordering. */
+  launcher_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  /* launcher_reset() already calls launcher_spawn_reset() but we call
+   * it explicitly here so the arena is rebuilt after the
+   * cap_handle / process resets above. */
+  launcher_spawn_reset();
+}
+
+static void test_grant_and_handoff(void) {
+  test_setup();
+
+  const capability_id_t requested[] = { CAP_CONSOLE_WRITE };
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = requested,
+      .auto_grant_count  = sizeof(requested) / sizeof(requested[0]),
+  };
+
+  launcher_spawn_t sp;
+  launcher_result_t r = launcher_spawn_app_from_manifest(&m, &sp);
+  if (r != LAUNCHER_OK) {
+    fail("spawn_returned_nonok");
+    return;
+  }
+  if (sp.pid == PID_INVALID) {
+    fail("spawn_returned_invalid_pid");
+    return;
+  }
+  if (sp.aspace == NULL || sp.aspace->ipc_scratch == NULL) {
+    fail("spawn_returned_null_aspace_or_scratch");
+    return;
+  }
+  if (sp.granted_handle == CAP_HANDLE_NULL) {
+    fail("spawn_returned_null_handle");
+    return;
+  }
+  if (sp.granted_cap != CAP_CONSOLE_WRITE) {
+    fail("spawn_returned_wrong_cap");
+    return;
+  }
+
+  /* The handle in the scratch slot must equal the handle returned. */
+  cap_handle_t scratch_h = scratch_load_handle(sp.aspace);
+  if (scratch_h != sp.granted_handle) {
+    fail("scratch_handle_mismatch");
+    return;
+  }
+
+  /* And the handle must gate-check positively. */
+  if (cap_gate_check_handle(sp.granted_handle, CAP_CONSOLE_WRITE) != 1) {
+    fail("handle_gate_check_failed");
+    return;
+  }
+
+  /* Cross-check: a different cap_id must not pass on the same handle. */
+  if (cap_gate_check_handle(sp.granted_handle, CAP_IPC_SEND) != 0) {
+    fail("handle_gate_check_passed_wrong_cap");
+    return;
+  }
+
+  /* Reserved scratch bytes [4..64) must be zero per the handoff contract. */
+  const uint8_t *p = (const uint8_t *)sp.aspace->ipc_scratch;
+  for (size_t i = 4; i < 64; ++i) {
+    if (p[i] != 0u) {
+      fail("scratch_reserved_bytes_nonzero");
+      return;
+    }
+  }
+
+  printf("TEST:PASS:launcher_spawn_handoff_grant\n");
+}
+
+static void test_no_grant(void) {
+  test_setup();
+
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = NULL,
+      .auto_grant_count  = 0,
+  };
+
+  launcher_spawn_t sp;
+  launcher_result_t r = launcher_spawn_app_from_manifest(&m, &sp);
+  if (r != LAUNCHER_OK) {
+    fail("no_grant_spawn_returned_nonok");
+    return;
+  }
+  if (sp.granted_handle != CAP_HANDLE_NULL) {
+    fail("no_grant_returned_handle");
+    return;
+  }
+  if (sp.granted_cap != (capability_id_t)0) {
+    fail("no_grant_returned_cap_id");
+    return;
+  }
+
+  /* Scratch first four bytes must be zero when no grant was requested. */
+  cap_handle_t scratch_h = scratch_load_handle(sp.aspace);
+  if (scratch_h != CAP_HANDLE_NULL) {
+    fail("no_grant_scratch_nonzero");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_spawn_handoff_no_grant\n");
+}
+
+static void test_destroy_revokes(void) {
+  test_setup();
+
+  const capability_id_t requested[] = { CAP_CONSOLE_WRITE };
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = requested,
+      .auto_grant_count  = 1,
+  };
+
+  launcher_spawn_t sp;
+  if (launcher_spawn_app_from_manifest(&m, &sp) != LAUNCHER_OK) {
+    fail("destroy_spawn_setup_failed");
+    return;
+  }
+  if (cap_gate_check_handle(sp.granted_handle, CAP_CONSOLE_WRITE) != 1) {
+    fail("destroy_pre_gate_check_failed");
+    return;
+  }
+
+  if (launcher_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("destroy_returned_nonok");
+    return;
+  }
+  if (cap_gate_check_handle(sp.granted_handle, CAP_CONSOLE_WRITE) != 0) {
+    fail("destroy_did_not_revoke_handle");
+    return;
+  }
+
+  /* Second destroy of an already-released pid is no longer a known
+   * launcher spawn; expect INVALID_APP. PID_INVALID stays a no-op. */
+  if (launcher_spawn_destroy(PID_INVALID) != LAUNCHER_OK) {
+    fail("destroy_pid_invalid_not_noop");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_spawn_handoff_destroy\n");
+}
+
+static void test_invalid_manifest(void) {
+  test_setup();
+
+  launcher_spawn_t sp;
+
+  /* NULL manifest. */
+  if (launcher_spawn_app_from_manifest(NULL, &sp) != LAUNCHER_ERR_INVALID_MANIFEST) {
+    fail("invalid_null_manifest_not_rejected");
+    return;
+  }
+
+  /* subject_id == 0 (reserved). */
+  launcher_manifest_t bad_subject = {
+      .subject_id       = 0u,
+      .auto_grant_caps  = NULL,
+      .auto_grant_count = 0,
+  };
+  if (launcher_spawn_app_from_manifest(&bad_subject, &sp) !=
+      LAUNCHER_ERR_INVALID_MANIFEST) {
+    fail("invalid_zero_subject_not_rejected");
+    return;
+  }
+
+  /* auto-grant cap that the slice-2 wiring does not support. */
+  const capability_id_t bad_cap[] = { CAP_IPC_SEND };
+  launcher_manifest_t bad_grant = {
+      .subject_id       = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps  = bad_cap,
+      .auto_grant_count = 1,
+  };
+  if (launcher_spawn_app_from_manifest(&bad_grant, &sp) !=
+      LAUNCHER_ERR_INVALID_MANIFEST) {
+    fail("invalid_unsupported_cap_not_rejected");
+    return;
+  }
+
+  /* auto_grant_count > 0 but caps pointer NULL. */
+  launcher_manifest_t bad_ptr = {
+      .subject_id       = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps  = NULL,
+      .auto_grant_count = 1,
+  };
+  if (launcher_spawn_app_from_manifest(&bad_ptr, &sp) !=
+      LAUNCHER_ERR_INVALID_MANIFEST) {
+    fail("invalid_null_caps_with_count_not_rejected");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_spawn_handoff_invalid_manifest\n");
+}
+
+int main(void) {
+  test_grant_and_handoff();
+  test_no_grant();
+  test_destroy_revokes();
+  test_invalid_manifest();
+
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:launcher_spawn_handoff\n");
+  return 0;
+}


### PR DESCRIPTION
Slice 2 of plan #263 (M2-on-M1 substrate, tracking #259). Re-platforms the launcher onto the merged M1 substrate by wiring `process_create`, `aspace_partition`, and `cap_handle_grant` together behind a single `launcher_spawn_app_from_manifest()` entry point — and fixes the in-band initial-capability handoff convention via the per-process IPC scratch slot.

## Changes

### `kernel/user/launcher.{c,h}`

- New `launcher_manifest_t` (kernel-internal projection of the on-disk schema #226 — subject_id + auto_grant_caps[]). Keeps the kernel free of a JSON parser; host tests and the eventual HelloApp module (#270) build the struct directly.
- New `launcher_spawn_app_from_manifest(manifest, &out_spawn)`:
  1. Carves a fresh `address_space_t` window out of a **launcher-owned** arena (separate from `module_registry.c`'s `g_demo_aspace_arena` so the M1 IPC demo and the M2 substrate slice 2 can't race on the same `next` cursor — both run in the same test phase).
  2. Registers the subject in the launcher's legacy app table (`launcher_register_app`) so the existing `cap_check` audit-parity path on `ipc_send_h` stays intact.
  3. Calls `process_create(subject, aspace, &pid)`.
  4. Mints `cap_table_grant` + `cap_handle_grant` for `auto_grant_caps[0]` (v0 supports `CAP_CONSOLE_WRITE` only).
  5. Zeroes the full 64-byte scratch region and writes the handle little-endian into bytes `[0..4)` — the M1→M2 initial-handoff vector.
- New `launcher_spawn_destroy(pid)` — `process_destroy` cascades `cap_handle_revoke_subject` per #239, so any stored copy of the minted handle fails the next gate check.
- New `launcher_spawn_reset()` — rebuilds the carved arena; called from `launcher_reset()`.
- New error codes (`LAUNCHER_ERR_INVALID_MANIFEST` / `_ASPACE` / `_PROC_CREATE` / `_HANDLE_MINT` / `_SCRATCH`) — kernel-internal; `kernel/user/launcher.h` is not part of `docs/abi/`.

### `docs/architecture/m1-m2-handoff.md` (new)

Documents the `ipc_scratch[0..4) = LE(cap_handle_t)` convention as the frozen initial-handoff vector under `OS_ABI_VERSION = 0`, with rationale, lifecycle diagram, and explicit reservation of bytes `[4..64)`.

### Validator — `tests/launcher_spawn_handoff_test.c` + `build/scripts/test_launcher_spawn_handoff.sh`

Four host-side cases:
- **grant**: handle written LE into scratch, gate-checks positively against `CAP_CONSOLE_WRITE`, negative-checks against `CAP_IPC_SEND`, reserved bytes `[4..64)` are zero.
- **no grant**: `granted_handle == CAP_HANDLE_NULL`, scratch first 4 bytes stay zero.
- **destroy revokes**: post-`launcher_spawn_destroy` the handle no longer gate-checks.
- **invalid manifests**: NULL, `subject_id == 0`, unsupported cap, NULL caps pointer with non-zero count → `LAUNCHER_ERR_INVALID_MANIFEST`.

Wired into `build/scripts/test.sh launcher_spawn_handoff` + `.shell_parity_allowlist` (ps1 peer tracked under #156 alongside the existing `launcher_console` entry).

### `build/scripts/test_launcher_console.sh`

Added the new transitive deps the launcher now pulls in (`cap_handle`, `address_space`, `process`) so the existing launcher_console suite keeps linking.

## Done-when (from #269)

- [x] `launcher_spawn_app_from_manifest` lands with the four bullets.
- [x] `docs/architecture/m1-m2-handoff.md` documents the scratch handoff convention.
- [x] `tests/launcher_spawn_handoff_test.c` lands and passes.
- [x] `test.sh launcher_spawn_handoff` + `.ps1` parity (allowlist) + `.shell_parity_allowlist` entry.
- [x] No new ABI surface; no `OS_ABI_VERSION` bump.
- [x] No regression in existing launcher tests or in `proc_sched_aspace_invariant`.

## Validation

```
test_launcher_spawn_handoff       PASS (4 sub-markers + roll-up)
test_launcher_console             PASS (6 sub-markers)
test_launcher_fs                  PASS
test_app_runtime                  PASS
test_fs_service_persist_allow     PASS
test_fs_service_persist_deny      PASS
test_fs_service_ephemeral_reset   PASS
test_helloapp_allow               PASS
test_helloapp_deny                PASS
test_process_table                PASS
test_proc_sched_aspace_invariant  PASS
test_console_svc_port_alloc       PASS
check_shell_parity                OK (68 allowlist entries)
```

## Follow-ups (out of scope for this PR)

- Slice 3 (#270): HelloApp module body — reads the handle out of its own scratch slot and calls `ipc_send_h`.
- Slice 4 (#271): `_qemu` peers for the allow/deny acceptance tests.
- ps1 peer for `test_launcher_spawn_handoff` (issue #156).

Closes #269. Refs #259 / #263 / #268.

— hourly issue-work cron (run e4c62e32)