### PR TITLE
feat: M2-on-M1 HelloApp substrate module (#270)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -54,6 +54,8 @@ test_harness_defense
 test_harness_negative
 test_helloapp_allow
 test_helloapp_deny
+test_m2_helloapp_allow_qemu
+test_m2_helloapp_deny_qemu
 test_https
 test_ipc_sync_v0
 test_ipc_port_lifecycle

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -228,6 +228,12 @@ case "$TEST_NAME" in
     ;;
   helloapp_deny)
     run_script "$ROOT_DIR/build/scripts/test_helloapp_deny.sh"
+    ;;
+  m2_helloapp_allow_qemu)
+    run_script "$ROOT_DIR/build/scripts/test_m2_helloapp_allow_qemu.sh"
+    ;;
+  m2_helloapp_deny_qemu)
+    run_script "$ROOT_DIR/build/scripts/test_m2_helloapp_deny_qemu.sh"
     ;;
   kernel_console)
     run_script "$ROOT_DIR/build/scripts/build_kernel_image.sh"

--- a/build/scripts/test_m2_helloapp_allow_qemu.sh
+++ b/build/scripts/test_m2_helloapp_allow_qemu.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# build/scripts/test_m2_helloapp_allow_qemu.sh
+#
+# Build + run the M2-on-M1 substrate HelloApp allow-path validator
+# (issue #270, plan plans/2026-05-23-m2-on-m1-substrate.md slice 3).
+#
+# Covers:
+#   - console_svc_init() allocates the well-known port (slice 1).
+#   - launcher_spawn_app_from_manifest() with an auto-grant of
+#     CAP_CONSOLE_WRITE produces a live PCB whose ipc_scratch carries
+#     the minted cap_handle_t (slice 2).
+#   - helloapp_run_once() reads the handle, builds the canonical
+#     envelope, calls ipc_send_h(), and returns IPC_OK.
+#   - The staged envelope drains via ipc_recv_h() with
+#     sender_subject == SUBJECT_M2_HELLOAPP and payload == "helloapp\n".
+#
+# Emits the following deterministic markers (consumed by
+# build/scripts/test.sh and validate_bundle.sh):
+#   TEST:PASS:helloapp_allowed_console_write
+#   TEST:PASS:helloapp_allow
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/svc/console_svc.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/kernel/user/helloapp.c" \
+  "$ROOT_DIR/tests/harness/m2_subjects.c" \
+  "$ROOT_DIR/tests/m2_helloapp_allow_qemu_test.c" \
+  -o "$OUT_DIR/m2_helloapp_allow_qemu_test"
+
+LOG_PATH="$OUT_DIR/m2_helloapp_allow_qemu_test.log"
+"$OUT_DIR/m2_helloapp_allow_qemu_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:helloapp_allowed_console_write" "$LOG_PATH"
+grep -q "TEST:PASS:helloapp_allow$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/test_m2_helloapp_deny_qemu.sh
+++ b/build/scripts/test_m2_helloapp_deny_qemu.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# build/scripts/test_m2_helloapp_deny_qemu.sh
+#
+# Build + run the M2-on-M1 substrate HelloApp deny-path validator
+# (issue #270, plan plans/2026-05-23-m2-on-m1-substrate.md slice 3).
+#
+# Covers:
+#   - A manifest with NO auto-grant still spawns a live PCB but leaves
+#     ipc_scratch zeroed (slice 2 contract).
+#   - helloapp_run_once() therefore decodes cap_handle_t == 0 and
+#     ipc_send_h() takes the canonical handle-deny path:
+#       * returns IPC_ERR_CAP_DENIED
+#       * emits exactly one CAP:DENY:<subj>:console_write:- marker
+#         line via the canonical cap_deny_marker formatter (#221/#244)
+#       * does NOT stage an envelope into the console-svc port
+#
+# The deny-marker shape is validated through cap_deny_marker_validate()
+# rather than substring-matching to keep the test honest about the
+# single source of truth in kernel/cap/cap_deny_marker.{c,h}.
+#
+# Emits the following deterministic markers:
+#   TEST:PASS:helloapp_denied_console_write
+#   TEST:PASS:helloapp_deny
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/svc/console_svc.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/kernel/user/helloapp.c" \
+  "$ROOT_DIR/tests/harness/m2_subjects.c" \
+  "$ROOT_DIR/tests/m2_helloapp_deny_qemu_test.c" \
+  -o "$OUT_DIR/m2_helloapp_deny_qemu_test"
+
+LOG_PATH="$OUT_DIR/m2_helloapp_deny_qemu_test.log"
+"$OUT_DIR/m2_helloapp_deny_qemu_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:helloapp_denied_console_write" "$LOG_PATH"
+grep -q "TEST:PASS:helloapp_deny$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/user/helloapp.c
+++ b/kernel/user/helloapp.c
@@ -1,0 +1,67 @@
+/**
+ * @file helloapp.c
+ * @brief HelloApp M2 substrate module body — slice 3 (#270).
+ *
+ * See `helloapp.h` for the contract and
+ * `plans/2026-05-23-m2-on-m1-substrate.md` §"HelloApp module" for
+ * design context. The body is deliberately tiny so the `_qemu`
+ * validators can call it inline (no scheduler, no recv loop, no
+ * console driver forwarding — those land in slice 4).
+ *
+ * Issue: #270.
+ */
+
+#include "helloapp.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "../cap/cap_handle.h"
+#include "../ipc/ipc_msg.h"
+#include "../ipc/ipc_ops.h"
+#include "../ipc/ipc_port.h"
+#include "../proc/address_space.h"
+#include "../../user/include/secureos_abi.h"
+
+/*
+ * Decode the launcher-handed-off `cap_handle_t` from the first four
+ * bytes of `ipc_scratch` using the same little-endian convention as
+ * `launcher.c::scratch_store_handle()` (slice 2, #269).
+ *
+ * Kept local to this TU rather than exported because the handoff
+ * contract is owned by `docs/architecture/m1-m2-handoff.md`; if it
+ * ever grows past four bytes the decoder lives next to the consumer.
+ */
+static cap_handle_t helloapp_scratch_load_handle(const address_space_t *as) {
+  const uint8_t *p = (const uint8_t *)as->ipc_scratch;
+  return  (cap_handle_t)p[0]
+       | ((cap_handle_t)p[1] <<  8)
+       | ((cap_handle_t)p[2] << 16)
+       | ((cap_handle_t)p[3] << 24);
+}
+
+ipc_result_t helloapp_run_once(const address_space_t *aspace,
+                               ipc_port_t console_port) {
+  if (aspace == NULL || aspace->ipc_scratch == NULL) {
+    /* No scratch means no handoff vector; treat as a malformed
+     * invocation rather than a capability deny so the test surface
+     * stays distinguishable from the real deny path. */
+    return IPC_ERR_INVALID_MSG;
+  }
+
+  cap_handle_t h = helloapp_scratch_load_handle(aspace);
+
+  /* Build the canonical envelope. Fields zeroed by `= {0}` then set
+   * explicitly so any future field addition fails the build until it
+   * is consciously handled (this is the same pattern used in
+   * `tests/ipc_sync_v0_test.c`). */
+  ipc_msg_v0 msg = {0};
+  msg.abi_version    = (uint16_t)OS_ABI_VERSION;
+  msg.flags          = 0u;
+  msg.sender_subject = 0u;             /* kernel-stamped by ipc_send_h */
+  msg.tag            = 0u;
+  msg.payload_len    = (uint32_t)HELLOAPP_BANNER_LEN;
+  memcpy(msg.payload, HELLOAPP_BANNER, HELLOAPP_BANNER_LEN);
+
+  return ipc_send_h(h, console_port, &msg);
+}

--- a/kernel/user/helloapp.h
+++ b/kernel/user/helloapp.h
@@ -1,0 +1,104 @@
+/**
+ * @file helloapp.h
+ * @brief HelloApp M2-on-M1 substrate module (slice 3 of plan #263).
+ *
+ * Purpose:
+ *   Single-shot in-kernel user module that exercises the M1→M2 initial
+ *   capability handoff documented in `docs/architecture/m1-m2-handoff.md`:
+ *
+ *     1. Reads its handed-off `cap_handle_t` little-endian from the
+ *        first four bytes of `address_space_t::ipc_scratch` (the slot
+ *        the launcher's slice-2 spawn writes per #269).
+ *     2. Builds one canonical `ipc_msg_v0` envelope whose payload is
+ *        the ASCII string `"helloapp\n"` (length 9).
+ *     3. Calls `ipc_send_h(handle, console_port, &msg)` exactly once
+ *        and returns the resulting `ipc_result_t` verbatim.
+ *
+ *   The module body is intentionally a single function instead of a
+ *   scheduler-driven entry stub so the `_qemu` host validators
+ *   (#270) can call it inline after `launcher_spawn_app_from_manifest()`
+ *   without spinning up `proc_sched_run_until_idle()`. The slice's
+ *   acceptance signal is the IPC send's success/deny — not the
+ *   scheduler shape — so this keeps the test surface narrow.
+ *
+ *   Slice scope (issue #270):
+ *     - One module, two `_qemu`-tier tests (allow + deny).
+ *     - NO forwarding from the console-svc port to the kernel console
+ *       driver — slice 4 (#271) owns the launcher_console peer that
+ *       drains the port.
+ *     - NO ELF / FS-backed loading — that is M3.
+ *
+ * ABI:
+ *   Internal-only. Not part of the frozen `docs/abi/` surface.
+ *
+ * Interactions:
+ *   - kernel/proc/address_space.h: reads `ipc_scratch` per the handoff
+ *     convention; never writes back.
+ *   - kernel/ipc/ipc_ops.h:        `ipc_send_h` is the only IPC call.
+ *   - kernel/ipc/ipc_msg.h:        envelope shape, `ipc_result_t`.
+ *   - kernel/cap/cap_handle.h:     handle type passed through.
+ *
+ * Launched by:
+ *   `tests/m2_helloapp_allow_qemu_test.c` and
+ *   `tests/m2_helloapp_deny_qemu_test.c` after spawning the app via
+ *   `launcher_spawn_app_from_manifest()`. The kernel boot sequence
+ *   does not yet auto-launch this module — that wiring lands with
+ *   the slice-4 launcher_console peer.
+ *
+ * Issue: #270. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 3.
+ */
+
+#ifndef SECUREOS_KERNEL_USER_HELLOAPP_H
+#define SECUREOS_KERNEL_USER_HELLOAPP_H
+
+#include "../ipc/ipc_msg.h"
+#include "../ipc/ipc_port.h"
+#include "../proc/address_space.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Canonical HelloApp banner. The M2 substrate spec (BUILD_ROADMAP
+ * §5.2) calls for `"helloapp\n"`; both `_qemu` tests pin this exact
+ * byte sequence so any unintended widening of the payload is caught
+ * by the receive-side assertion. Length is 9 (8 chars + newline).
+ */
+#define HELLOAPP_BANNER         "helloapp\n"
+#define HELLOAPP_BANNER_LEN     ((size_t)9u)
+
+/*
+ * Run the HelloApp module body exactly once.
+ *
+ * Parameters:
+ *   - aspace       : the spawned app's address space window. MUST be
+ *                    non-NULL with a non-NULL `ipc_scratch`. The first
+ *                    four bytes are interpreted little-endian as the
+ *                    `cap_handle_t` the launcher handed off.
+ *   - console_port : well-known port handle for the console service
+ *                    (typically `console_svc_port()`).
+ *
+ * Returns:
+ *   - The unmodified `ipc_result_t` from `ipc_send_h(handle, port, msg)`.
+ *     IPC_OK on the allow path; IPC_ERR_CAP_DENIED on the deny path
+ *     (with the canonical CAP:DENY marker already emitted by the IPC
+ *     layer). IPC_ERR_INVALID_PORT on a bogus port; IPC_ERR_INVALID_MSG
+ *     if `aspace` or its `ipc_scratch` is NULL.
+ *
+ * Side effects:
+ *   - On the allow path, stages one envelope into `console_port`'s
+ *     single-waiter slot. The caller (test driver or, later, the
+ *     slice-4 launcher_console peer) drains it via `ipc_port_consume()`.
+ *   - On the deny path, the IPC layer emits exactly one canonical
+ *     `CAP:DENY:<subject>:console_write:-` marker line to stdout via
+ *     `cap_deny_marker_format()` (the shape gated by #221 / PR #244).
+ */
+ipc_result_t helloapp_run_once(const address_space_t *aspace,
+                               ipc_port_t console_port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_USER_HELLOAPP_H */

--- a/tests/m2_helloapp_allow_qemu_test.c
+++ b/tests/m2_helloapp_allow_qemu_test.c
@@ -1,0 +1,183 @@
+/**
+ * @file m2_helloapp_allow_qemu_test.c
+ * @brief Allow-path acceptance for slice 3 of plan #263 / issue #270.
+ *
+ * Drives the full M2-on-M1 substrate end-to-end on a host build (the
+ * `_qemu` tier name follows the BUILD_ROADMAP §5.2 convention that
+ * tests in this tier exercise a real `process_create` and a real
+ * IPC send instead of poking the gate directly the way the pre-M1
+ * `tests/helloapp_allow_test.c` fixture does):
+ *
+ *   1. Initialises the console service (slice 1 / #268) which
+ *      allocates the well-known IPC port owned by
+ *      `SUBJECT_M2_CONSOLE_SVC`, gated by `CAP_CONSOLE_WRITE`.
+ *   2. Grants the console-service subject `CAP_CONSOLE_WRITE` so
+ *      the recv side of the port passes the legacy
+ *      `cap_check`-driven audit ring used by `ipc_recv_h`.
+ *   3. Spawns HelloApp via `launcher_spawn_app_from_manifest()`
+ *      (slice 2 / #269) with a manifest declaring an auto-grant
+ *      of `CAP_CONSOLE_WRITE`. The launcher partitions a fresh
+ *      `address_space_t`, calls `process_create`, mints the
+ *      handle, and writes it little-endian into `ipc_scratch[0..3]`.
+ *   4. Invokes `helloapp_run_once(aspace, console_svc_port())` —
+ *      the HelloApp module body builds the canonical envelope
+ *      and calls `ipc_send_h` exactly once.
+ *   5. Asserts:
+ *        - `process_is_live_for_tests(pid)` was true between
+ *          steps 3 and 4 (real PCB existed).
+ *        - The send returned `IPC_OK`.
+ *        - The staged envelope drained via `ipc_recv_h` on the
+ *          console-svc handle equals `HELLOAPP_BANNER` byte-for-byte
+ *          with `sender_subject == SUBJECT_M2_HELLOAPP`.
+ *
+ * Output markers (consumed by build/scripts/test_m2_helloapp_allow_qemu.sh):
+ *   TEST:PASS:helloapp_allowed_console_write
+ *   TEST:PASS:helloapp_allow
+ *
+ * Pure host-side build. The pre-M1 `tests/helloapp_allow_test.c`
+ * fixture is intentionally left untouched (plan §"Done when").
+ *
+ * Issue: #270. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 3.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/svc/console_svc.h"
+#include "../kernel/user/helloapp.h"
+#include "../kernel/user/launcher.h"
+#include "harness/m2_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:helloapp_allow:%s\n", reason);
+  g_fail = 1;
+}
+
+static void reset_world(void) {
+  launcher_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  console_svc_reset();
+  ipc_port_table_reset();
+  launcher_spawn_reset();
+}
+
+int main(void) {
+  reset_world();
+
+  /* Slice 1: console service port. */
+  if (console_svc_init() != CONSOLE_SVC_OK) {
+    fail("console_svc_init_failed");
+    goto out;
+  }
+  ipc_port_t console_port = console_svc_port();
+  if (console_port == IPC_PORT_INVALID) {
+    fail("console_port_invalid");
+    goto out;
+  }
+
+  /* Console-svc subject must hold CAP_CONSOLE_WRITE so the recv-side
+   * gate in `ipc_recv_h` passes when the test drains the port. The
+   * grant is parallel to the launcher's auto-grant of HelloApp; both
+   * subjects need their own grant in the per-subject bitset. */
+  if (cap_grant_for_tests((cap_subject_id_t)SUBJECT_M2_CONSOLE_SVC,
+                          CAP_CONSOLE_WRITE) != CAP_OK) {
+    fail("console_svc_grant_failed");
+    goto out;
+  }
+  cap_handle_t console_recv_handle =
+      cap_handle_grant((cap_subject_id_t)SUBJECT_M2_CONSOLE_SVC,
+                       CAP_CONSOLE_WRITE);
+  if (console_recv_handle == CAP_HANDLE_NULL) {
+    fail("console_svc_handle_mint_failed");
+    goto out;
+  }
+
+  /* Slice 2: spawn HelloApp with an auto-grant of CAP_CONSOLE_WRITE. */
+  const capability_id_t requested[] = { CAP_CONSOLE_WRITE };
+  launcher_manifest_t m = {
+      .subject_id       = (cap_subject_id_t)SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps  = requested,
+      .auto_grant_count = 1u,
+  };
+  launcher_spawn_t sp;
+  if (launcher_spawn_app_from_manifest(&m, &sp) != LAUNCHER_OK) {
+    fail("launcher_spawn_failed");
+    goto out;
+  }
+  if (sp.pid == PID_INVALID || !process_is_live_for_tests(sp.pid)) {
+    fail("spawned_pcb_not_live");
+    goto out;
+  }
+  if (sp.aspace == NULL || sp.aspace->ipc_scratch == NULL) {
+    fail("spawned_aspace_or_scratch_null");
+    goto out;
+  }
+  if (sp.granted_handle == CAP_HANDLE_NULL) {
+    fail("spawned_handle_null");
+    goto out;
+  }
+
+  /* Slice 3: run the HelloApp body. */
+  ipc_result_t sr = helloapp_run_once(sp.aspace, console_port);
+  if (sr != IPC_OK) {
+    fail("helloapp_send_not_ok");
+    goto out;
+  }
+
+  /* The send-side success is the BUILD_ROADMAP §5.2 grant-path
+   * acceptance signal; emit it now before draining the envelope so the
+   * marker order in the log is unambiguous. */
+  printf("TEST:PASS:helloapp_allowed_console_write\n");
+
+  /* Drain the staged envelope through the canonical recv path. The
+   * console-svc subject holds CAP_CONSOLE_WRITE + owns the port, so
+   * `ipc_recv_h` must return IPC_OK and the payload must match the
+   * banner byte-for-byte. */
+  ipc_msg_v0 rx = {0};
+  ipc_result_t rr = ipc_recv_h(console_recv_handle, console_port, &rx);
+  if (rr != IPC_OK) {
+    fail("console_drain_not_ok");
+    goto out;
+  }
+  if (rx.sender_subject != (uint32_t)SUBJECT_M2_HELLOAPP) {
+    fail("drained_sender_subject_mismatch");
+    goto out;
+  }
+  if (rx.payload_len != (uint32_t)HELLOAPP_BANNER_LEN) {
+    fail("drained_payload_len_mismatch");
+    goto out;
+  }
+  if (memcmp(rx.payload, HELLOAPP_BANNER, HELLOAPP_BANNER_LEN) != 0) {
+    fail("drained_payload_bytes_mismatch");
+    goto out;
+  }
+
+  /* Teardown: destroy the spawn (revokes the minted handle as a side
+   * effect, per #239 / slice 2's handoff contract). Double-checking
+   * the handle dies on revoke is owned by the slice-2 destroy test;
+   * here we only confirm the destroy itself returns OK. */
+  if (launcher_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("launcher_spawn_destroy_failed");
+    goto out;
+  }
+
+out:
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:helloapp_allow\n");
+  return 0;
+}

--- a/tests/m2_helloapp_deny_qemu_test.c
+++ b/tests/m2_helloapp_deny_qemu_test.c
@@ -1,0 +1,207 @@
+/**
+ * @file m2_helloapp_deny_qemu_test.c
+ * @brief Deny-path acceptance for slice 3 of plan #263 / issue #270.
+ *
+ * Counterpart to `m2_helloapp_allow_qemu_test.c`. Spawns HelloApp with
+ * a manifest that does NOT auto-grant `CAP_CONSOLE_WRITE`, then calls
+ * `helloapp_run_once()` and asserts:
+ *
+ *   - `helloapp_run_once` returns `IPC_ERR_CAP_DENIED`.
+ *   - Exactly one canonical `CAP:DENY:<subject>:console_write:-` line
+ *     was emitted to stdout, and it passes `cap_deny_marker_validate()`
+ *     (the same gate used by `tests/syscall_entry_stub_test.c` and
+ *     `tests/cap_deny_marker_shape_test.c` per #221 / PR #244).
+ *   - The console-svc port's slot is still empty afterwards
+ *     (deny path MUST NOT stage an envelope).
+ *
+ * The deny vocabulary is owned by `kernel/cap/cap_deny_marker.{c,h}` —
+ * we never format the marker locally. The grammar is:
+ *   `CAP:DENY:<actor_subject>:<capability_name>:<resource>\n`
+ * with `<resource>` `-` when no resource id applies (the IPC layer's
+ * default per `ipc_emit_deny_marker`).
+ *
+ * Output markers (consumed by build/scripts/test_m2_helloapp_deny_qemu.sh):
+ *   TEST:PASS:helloapp_denied_console_write
+ *   TEST:PASS:helloapp_deny
+ *
+ * Issue: #270. Plan: plans/2026-05-23-m2-on-m1-substrate.md slice 3.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../kernel/cap/cap_deny_marker.h"
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/svc/console_svc.h"
+#include "../kernel/user/helloapp.h"
+#include "../kernel/user/launcher.h"
+#include "harness/m2_subjects.h"
+
+static int g_fail = 0;
+static char g_capture[4096];
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:helloapp_deny:%s\n", reason);
+  g_fail = 1;
+}
+
+/* Same stdout-capture shim as tests/syscall_entry_stub_test.c. We
+ * intentionally duplicate the helper (~25 LoC) instead of factoring
+ * it out per the plan's "helpers stay near the test that needs them"
+ * convention; the substrate plan budgets 120 LoC per substrate test
+ * helper and we are well inside that. */
+typedef ipc_result_t (*capture_fn)(void);
+static ipc_result_t g_capture_result;
+
+static long capture_stdout(capture_fn fn) {
+  fflush(stdout);
+  FILE *tmp = tmpfile();
+  if (!tmp) return -1;
+  int saved_fd = dup(fileno(stdout));
+  if (saved_fd < 0) { fclose(tmp); return -1; }
+  if (dup2(fileno(tmp), fileno(stdout)) < 0) {
+    close(saved_fd); fclose(tmp); return -1;
+  }
+  g_capture_result = fn();
+  fflush(stdout);
+  dup2(saved_fd, fileno(stdout));
+  close(saved_fd);
+  fseek(tmp, 0L, SEEK_SET);
+  size_t n = fread(g_capture, 1u, sizeof(g_capture) - 1u, tmp);
+  g_capture[n] = '\0';
+  fclose(tmp);
+  return (long)n;
+}
+
+static void reset_world(void) {
+  launcher_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  console_svc_reset();
+  ipc_port_table_reset();
+  launcher_spawn_reset();
+}
+
+/* Captured-call context. */
+static const address_space_t *g_run_aspace;
+static ipc_port_t              g_run_port;
+
+static ipc_result_t do_run(void) {
+  return helloapp_run_once(g_run_aspace, g_run_port);
+}
+
+int main(void) {
+  reset_world();
+
+  if (console_svc_init() != CONSOLE_SVC_OK) {
+    fail("console_svc_init_failed");
+    goto out;
+  }
+  ipc_port_t console_port = console_svc_port();
+  if (console_port == IPC_PORT_INVALID) {
+    fail("console_port_invalid");
+    goto out;
+  }
+
+  /* Manifest WITHOUT auto-grant: the launcher still partitions the
+   * aspace, creates the PCB, and writes the (NULL) handle into
+   * `ipc_scratch[0..3]`. The slice-2 contract (#269) is that a no-grant
+   * manifest leaves the scratch slot zeroed, which means HelloApp
+   * decodes `cap_handle == 0` (CAP_HANDLE_NULL) and `ipc_send_h` takes
+   * the canonical handle-deny path: stale-handle → owner == 0 →
+   * `cap_check(0, CAP_IPC_SEND)` deny → marker emit. */
+  launcher_manifest_t m = {
+      .subject_id       = (cap_subject_id_t)SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps  = NULL,
+      .auto_grant_count = 0u,
+  };
+  launcher_spawn_t sp;
+  if (launcher_spawn_app_from_manifest(&m, &sp) != LAUNCHER_OK) {
+    fail("launcher_spawn_failed");
+    goto out;
+  }
+  if (sp.pid == PID_INVALID || !process_is_live_for_tests(sp.pid)) {
+    fail("spawned_pcb_not_live");
+    goto out;
+  }
+  if (sp.granted_handle != CAP_HANDLE_NULL) {
+    fail("no_grant_manifest_still_minted_handle");
+    goto out;
+  }
+
+  /* Capture stdout across the single run so we can validate the deny
+   * marker shape via cap_deny_marker_validate without parsing the rest
+   * of the log. */
+  g_run_aspace = sp.aspace;
+  g_run_port   = console_port;
+  long n = capture_stdout(do_run);
+  if (n < 0) {
+    fail("capture_stdout_failed");
+    goto out;
+  }
+
+  if (g_capture_result != IPC_ERR_CAP_DENIED) {
+    fail("helloapp_run_did_not_deny");
+    goto out;
+  }
+
+  /* Validate the canonical marker. cap_deny_marker_validate consumes a
+   * single-line marker; the IPC deny path emits exactly one such line
+   * (see ipc_emit_deny_marker in kernel/ipc/ipc_ops.c). If extra
+   * output appeared, treat it as a regression. */
+  char reason[64] = {0};
+  int vrc = cap_deny_marker_validate(g_capture, reason, sizeof(reason));
+  if (vrc != 0) {
+    /* Re-echo the captured bytes so failures are debuggable; strip
+     * trailing newline noise from the diagnostic. */
+    printf("TEST:FAIL:helloapp_deny:deny_marker_invalid:%s\n", reason);
+    printf("TEST:FAIL:helloapp_deny:captured=%s\n", g_capture);
+    g_fail = 1;
+    goto out;
+  }
+
+  /* And confirm the capability the marker reports is `console_write`,
+   * not some other CAP_IPC_* the recv side might emit on a wrong-owner
+   * path. The marker grammar is `CAP:DENY:<subj>:<cap>:<res>` so a
+   * substring search is sufficient and robust to subject-id renumbering. */
+  if (strstr(g_capture, ":console_write:") == NULL) {
+    printf("TEST:FAIL:helloapp_deny:wrong_cap_in_marker:captured=%s\n",
+           g_capture);
+    g_fail = 1;
+    goto out;
+  }
+
+  /* Slot must still be empty: deny path MUST NOT stage. */
+  ipc_msg_v0 rx = {0};
+  ipc_result_t peek = ipc_port_consume(console_port, &rx);
+  if (peek == IPC_OK) {
+    fail("deny_path_staged_envelope");
+    goto out;
+  }
+
+  printf("TEST:PASS:helloapp_denied_console_write\n");
+
+  if (launcher_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("launcher_spawn_destroy_failed");
+    goto out;
+  }
+
+out:
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:helloapp_deny\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #270. Slice 3 of plan `plans/2026-05-23-m2-on-m1-substrate.md`.

## What

Drops in the in-kernel **HelloApp** module that rides on the M2-on-M1 substrate built by slices 1 (`console_svc`, #268) and 2 (`launcher_spawn_app_from_manifest`, #269), plus two `_qemu`-tier acceptance tests covering the allow path and the deny path.

- **`kernel/user/helloapp.{c,h}`** — single-shot module body. Reads the launcher-handed-off `cap_handle_t` little-endian from the first four bytes of `address_space_t::ipc_scratch` (the slot the launcher writes per the slice-2 handoff contract), builds one canonical `ipc_msg_v0` with payload `\"helloapp\\n\"`, and calls `ipc_send_h(handle, console_port, &msg)` exactly once. No scheduler, no recv loop, no console-driver forwarding — that's slice 4 (#271).
- **`tests/m2_helloapp_allow_qemu_test.c`** — end-to-end allow path. Initialises `console_svc`, spawns HelloApp with an auto-grant of `CAP_CONSOLE_WRITE`, runs the module, then drains the staged envelope through `ipc_recv_h` and asserts `sender_subject == SUBJECT_M2_HELLOAPP` plus payload bytes match `HELLOAPP_BANNER`. Emits `TEST:PASS:helloapp_allowed_console_write` and `TEST:PASS:helloapp_allow`.
- **`tests/m2_helloapp_deny_qemu_test.c`** — deny path. Manifest with no auto-grant leaves `ipc_scratch` zeroed, so the module decodes `CAP_HANDLE_NULL` and `ipc_send_h` returns `IPC_ERR_CAP_DENIED`. Captures stdout, validates the emitted marker via the canonical `cap_deny_marker_validate()` (single source of truth per #221 / PR #244) and substring-pins `:console_write:`. Also asserts the port slot stays empty. Emits `TEST:PASS:helloapp_denied_console_write` and `TEST:PASS:helloapp_deny`.
- **`build/scripts/test_m2_helloapp_{allow,deny}_qemu.sh`** — deterministic drivers wired into `build/scripts/test.sh` (dispatch entries `m2_helloapp_allow_qemu` / `m2_helloapp_deny_qemu`) and added to `.shell_parity_allowlist` under the umbrella tracked by #156.

The pre-M1 `tests/helloapp_*_test.c` host fixtures are intentionally left untouched per the plan's \"Done when\" note.

## Validation

\`\`\`
$ bash build/scripts/test.sh m2_helloapp_allow_qemu
TEST:PASS:helloapp_allowed_console_write
TEST:PASS:helloapp_allow

$ bash build/scripts/test.sh m2_helloapp_deny_qemu
TEST:PASS:helloapp_denied_console_write
TEST:PASS:helloapp_deny

$ bash build/scripts/test.sh parity
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 70 entries)
TEST:PASS:parity:build_scripts_sh_ps1_in_sync
\`\`\`

Neighbour slices stay green: `launcher_spawn_handoff`, `console_svc_port_alloc`, pre-M1 `helloapp_allow` / `helloapp_deny`.

## Notes

- Subject ids unchanged: `SUBJECT_M2_HELLOAPP = 3` (frozen in `tests/harness/m2_subjects.h`).
- Deny marker emission uses the canonical `cap_deny_marker` formatter via `ipc_emit_deny_marker` in `kernel/ipc/ipc_ops.c` — no new emitters introduced.
- Frozen ABI under `OS_ABI_VERSION=0` respected; envelope shape is the existing `ipc_msg_v0` from `kernel/ipc/ipc_msg.h`.

## Follow-ups

- **#271** (slice 4) now unblocked: `launcher_console` peer drains the `console_svc` port and forwards into the kernel console driver, so a future heartbeat-style integration test can observe the banner end-to-end.
- The duplicate stdout-capture shim in the deny test (~25 LoC) mirrors `tests/syscall_entry_stub_test.c`. If a third substrate test needs it, lift it into `tests/harness/`.