### PR TITLE
feat(svc): fs_svc in-kernel module + dual IPC port allocation (closes #278)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -61,6 +61,7 @@ test_https
 test_ipc_sync_v0
 test_ipc_port_lifecycle
 test_console_svc_port_alloc
+test_fs_svc_port_alloc
 test_ipc_handle_gate
 test_syscall_entry_stub
 test_kernel_persistence

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -132,6 +132,9 @@ case "$TEST_NAME" in
     ;;
   console_svc_port_alloc)
     run_script "$ROOT_DIR/build/scripts/test_console_svc_port_alloc.sh"
+    ;;
+  fs_svc_port_alloc)
+    run_script "$ROOT_DIR/build/scripts/test_fs_svc_port_alloc.sh"
     ;;
   aspace_invariant)
     run_script "$ROOT_DIR/build/scripts/test_aspace_invariant.sh"

--- a/build/scripts/test_fs_svc_port_alloc.sh
+++ b/build/scripts/test_fs_svc_port_alloc.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# build/scripts/test_fs_svc_port_alloc.sh
+#
+# Build + run the M3-on-M1 substrate fs-service port-allocation
+# validator (issue #278, plan plans/2026-05-24-m3-fs-on-m1-substrate.md
+# slice 1).
+#
+# Covers:
+#   - Uninitialised state: is_initialised=false, both ports=IPC_PORT_INVALID.
+#   - Post-init state: both handles valid + distinct; owner=SUBJECT_M3_FS_SVC;
+#     read port send_cap=recv_cap=CAP_FS_READ; write port send_cap=recv_cap=CAP_FS_WRITE.
+#   - Double init returns FS_SVC_ERR_ALREADY_INIT and does not allocate fresh ports.
+#   - Reset clears state; subsequent init succeeds.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/svc/fs_svc.c" \
+  "$ROOT_DIR/tests/harness/svc_subjects.c" \
+  "$ROOT_DIR/tests/fs_svc_port_alloc_test.c" \
+  -o "$OUT_DIR/fs_svc_port_alloc_test"
+
+LOG_PATH="$OUT_DIR/fs_svc_port_alloc_test.log"
+"$OUT_DIR/fs_svc_port_alloc_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:fs_svc_port_alloc_uninit" "$LOG_PATH"
+grep -q "TEST:PASS:fs_svc_port_alloc_init" "$LOG_PATH"
+grep -q "TEST:PASS:fs_svc_port_alloc_double_init" "$LOG_PATH"
+grep -q "TEST:PASS:fs_svc_port_alloc_reset" "$LOG_PATH"
+grep -q "TEST:PASS:fs_svc_port_alloc$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/svc/fs_svc.c
+++ b/kernel/svc/fs_svc.c
@@ -1,0 +1,94 @@
+/**
+ * @file fs_svc.c
+ * @brief M3-on-M1 fs service implementation — slice 1.
+ *
+ * See `fs_svc.h` for the public contract and
+ * `plans/2026-05-24-m3-fs-on-m1-substrate.md` §"Follow-up
+ * implementation issues to file" §1 for the design context.
+ *
+ * Slice scope (intentionally narrow — issue #278):
+ *   - Allocate two well-known ports at init (read + write).
+ *   - Expose the handles for downstream slices (#279, #280, #281).
+ *   - Do NOT spin a recv loop or handle fs_read/fs_write envelopes
+ *     yet — that lands with the persist tests in #280.
+ *
+ * Boot-order edge:
+ *   `fs_svc_init()` MUST run AFTER `ipc_port_table_init()` (it calls
+ *   `ipc_port_create` twice) and AFTER `console_svc_init()` so the
+ *   well-known port indexes stay deterministic across boots (read +
+ *   write are slots 2 and 3 in a fresh port table, with console at
+ *   slot 1). It must run BEFORE any module-registry walk that mints
+ *   handles for the fs ports. In host tests, the test driver controls
+ *   ordering directly.
+ *
+ * Issue: #278. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 1.
+ */
+
+#include "fs_svc.h"
+
+#include "../../tests/harness/svc_subjects.h"
+#include "../cap/capability.h"
+#include "../ipc/ipc_port.h"
+
+/*
+ * Module-private state. Two port handles plus an "initialised" latch.
+ * No dynamic allocation; no other state — the recv loops and
+ * fs-envelope handling land in slice 3 (#280).
+ */
+static ipc_port_t g_fs_svc_port_read = IPC_PORT_INVALID;
+static ipc_port_t g_fs_svc_port_write = IPC_PORT_INVALID;
+static bool g_fs_svc_initialised = false;
+
+fs_svc_result_t fs_svc_init(void) {
+  if (g_fs_svc_initialised) {
+    return FS_SVC_ERR_ALREADY_INIT;
+  }
+
+  ipc_port_t read_handle = IPC_PORT_INVALID;
+  ipc_result_t rc = ipc_port_create((cap_subject_id_t)SUBJECT_M3_FS_SVC,
+                                    CAP_FS_READ,
+                                    CAP_FS_READ,
+                                    &read_handle);
+  if (rc != IPC_OK || read_handle == IPC_PORT_INVALID) {
+    return FS_SVC_ERR_PORT_ALLOC_READ;
+  }
+
+  ipc_port_t write_handle = IPC_PORT_INVALID;
+  rc = ipc_port_create((cap_subject_id_t)SUBJECT_M3_FS_SVC,
+                       CAP_FS_WRITE,
+                       CAP_FS_WRITE,
+                       &write_handle);
+  if (rc != IPC_OK || write_handle == IPC_PORT_INVALID) {
+    /* Leave the read port allocated; the caller can clean up via
+     * ipc_port_table_reset(). Module state stays uninitialised so a
+     * retry after reset is well-defined. */
+    return FS_SVC_ERR_PORT_ALLOC_WRITE;
+  }
+
+  g_fs_svc_port_read = read_handle;
+  g_fs_svc_port_write = write_handle;
+  g_fs_svc_initialised = true;
+  return FS_SVC_OK;
+}
+
+void fs_svc_reset(void) {
+  /* Intentionally do not call ipc_port_destroy() here. Tests that want
+   * the ports released use ipc_port_table_reset() in the same phase;
+   * kernel-side reset is owned by the boot sequence in a future slice
+   * if needed. Same convention as console_svc_reset(). */
+  g_fs_svc_port_read = IPC_PORT_INVALID;
+  g_fs_svc_port_write = IPC_PORT_INVALID;
+  g_fs_svc_initialised = false;
+}
+
+ipc_port_t fs_svc_port_read(void) {
+  return g_fs_svc_port_read;
+}
+
+ipc_port_t fs_svc_port_write(void) {
+  return g_fs_svc_port_write;
+}
+
+bool fs_svc_is_initialised(void) {
+  return g_fs_svc_initialised;
+}

--- a/kernel/svc/fs_svc.h
+++ b/kernel/svc/fs_svc.h
@@ -1,0 +1,134 @@
+/**
+ * @file fs_svc.h
+ * @brief M3-on-M1 fs service: kernel-side IPC endpoint module
+ *        (dual-port — read + write).
+ *
+ * Purpose:
+ *   Allocates two well-known IPC ports via `kernel/ipc/ipc_port.c` at
+ *   subsystem init time. Both ports are owned by the canonical fs
+ *   subject (`SUBJECT_M3_FS_SVC`, see `tests/harness/svc_subjects.h`).
+ *   The READ port is gated by `CAP_FS_READ` on both send/recv sides;
+ *   the WRITE port is gated by `CAP_FS_WRITE`. Recv side is also
+ *   gated by the port-owner check in `ipc_recv` (same convention as
+ *   `console_svc`, #272).
+ *
+ *   This is **slice 1 of plan #277 (M3-on-M1 substrate, issue #276)**.
+ *   Subsequent slices wire `launcher_fs_spawn_app_with_fs_caps` (#279),
+ *   HelloApp fs-demo + persist allow/deny `_qemu` tests (#280), and
+ *   the ephemeral-reset `_qemu` peer (#281) on top of this module.
+ *
+ *   Out of scope for slice 1:
+ *     - Driving an actual recv loop / handling fs_read/fs_write
+ *       envelopes — that lands with the persist tests in #280.
+ *     - PCB allocation for the service itself.
+ *     - Any user-visible ABI surface — see "ABI" below.
+ *
+ * ABI:
+ *   Internal-only. This header is not part of the frozen `docs/abi/`
+ *   surface; the module exposes its port handles to in-kernel callers
+ *   (launcher, registry walkers) only. The on-wire envelope continues
+ *   to be the canonical `ipc_msg_v0` defined by `kernel/ipc/ipc_msg.h`.
+ *
+ * Interactions:
+ *   - kernel/ipc/ipc_port.{c,h}: port table; this module is one client.
+ *   - kernel/cap/capability.h: `CAP_FS_READ`/`CAP_FS_WRITE` send/recv gates.
+ *   - tests/harness/svc_subjects.h: canonical subject ids.
+ *
+ * Launched by:
+ *   `fs_svc_init()` is called by `kernel/core/kmain.c` at boot after
+ *   `ipc_port_table_init()` and `console_svc_init()` and before any
+ *   module-registry walk that may try to mint a handle for the fs
+ *   ports (boot-order edge documented in the implementation). In host
+ *   tests, the test driver calls it directly after
+ *   `ipc_port_table_reset()`.
+ *
+ * Issue: #278. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 1.
+ */
+
+#ifndef SECUREOS_KERNEL_SVC_FS_SVC_H
+#define SECUREOS_KERNEL_SVC_FS_SVC_H
+
+#include <stdbool.h>
+
+#include "../cap/capability.h"
+#include "../ipc/ipc_port.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Result vocabulary for the slice-1 init entry point. Distinct from
+ * `ipc_result_t` so callers can tell module-level wiring failures
+ * (already initialised, port table full on either port) apart from
+ * IPC-level errors. Mirrors `console_svc_result_t` from #272.
+ */
+typedef enum {
+  FS_SVC_OK = 0,
+  FS_SVC_ERR_PORT_ALLOC_READ = 1,
+  FS_SVC_ERR_PORT_ALLOC_WRITE = 2,
+  FS_SVC_ERR_ALREADY_INIT = 3,
+} fs_svc_result_t;
+
+/*
+ * Allocate the two well-known fs-service ports. Idempotent-by-error:
+ * a second call before `fs_svc_reset()` returns
+ * `FS_SVC_ERR_ALREADY_INIT` and does not allocate fresh ports.
+ *
+ * On success the read port:
+ *   - is owned by `SUBJECT_M3_FS_SVC`,
+ *   - has `send_cap = CAP_FS_READ`,
+ *   - has `recv_cap = CAP_FS_READ`.
+ * On success the write port:
+ *   - is owned by `SUBJECT_M3_FS_SVC`,
+ *   - has `send_cap = CAP_FS_WRITE`,
+ *   - has `recv_cap = CAP_FS_WRITE`.
+ *
+ * Failure path: if the read-port allocation fails, no write port is
+ * allocated and `FS_SVC_ERR_PORT_ALLOC_READ` is returned. If the read
+ * port succeeds but the write port fails, the read port is left
+ * allocated (the caller is responsible for `ipc_port_table_reset()`
+ * to clean up; the fs_svc module state stays uninitialised so a retry
+ * after reset is well-defined).
+ *
+ * The port handles are retrievable via `fs_svc_port_read()` /
+ * `fs_svc_port_write()` until reset.
+ */
+fs_svc_result_t fs_svc_init(void);
+
+/*
+ * Tear down the in-memory state. Does NOT call `ipc_port_destroy()` on
+ * the underlying handles — callers that want the ports released must
+ * either `ipc_port_table_reset()` (test harness) or land slice 4's
+ * destroy wiring. Always safe to call; no-op when not initialised.
+ *
+ * Provided so test setup/teardown can run in any order without leaking
+ * state across phases. Same contract as `console_svc_reset()`.
+ */
+void fs_svc_reset(void);
+
+/*
+ * Return the read-port handle allocated by `fs_svc_init()`. Returns
+ * `IPC_PORT_INVALID` when the service has not been initialised. The
+ * launcher (slice 2, #279) calls this when minting handles for a
+ * spawned app.
+ */
+ipc_port_t fs_svc_port_read(void);
+
+/*
+ * Return the write-port handle allocated by `fs_svc_init()`. Returns
+ * `IPC_PORT_INVALID` when the service has not been initialised.
+ */
+ipc_port_t fs_svc_port_write(void);
+
+/*
+ * Return true iff `fs_svc_init()` has been called and not yet reset.
+ * Exposed so the validator test can assert exact init/teardown lifecycle.
+ */
+bool fs_svc_is_initialised(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_KERNEL_SVC_FS_SVC_H */

--- a/tests/fs_svc_port_alloc_test.c
+++ b/tests/fs_svc_port_alloc_test.c
@@ -1,0 +1,227 @@
+/**
+ * @file fs_svc_port_alloc_test.c
+ * @brief Validator for slice 1 of plan #277 (issue #278).
+ *
+ * Asserts the contract documented in `kernel/svc/fs_svc.h`:
+ *
+ *   1. Before init: fs_svc_is_initialised() is false and both
+ *      fs_svc_port_read() / fs_svc_port_write() return
+ *      IPC_PORT_INVALID.
+ *   2. After init: fs_svc_is_initialised() is true; both handles are
+ *      non-IPC_PORT_INVALID; the read handle is owned by
+ *      SUBJECT_M3_FS_SVC with send_cap=recv_cap=CAP_FS_READ; the
+ *      write handle is owned by SUBJECT_M3_FS_SVC with
+ *      send_cap=recv_cap=CAP_FS_WRITE; the two handles are distinct.
+ *   3. A second init without reset returns FS_SVC_ERR_ALREADY_INIT
+ *      and does NOT allocate fresh ports (handles unchanged).
+ *   4. After fs_svc_reset(): both ports are IPC_PORT_INVALID and
+ *      is_initialised is false. A subsequent init succeeds and yields
+ *      fresh handles.
+ *
+ * Output markers (consumed by build/scripts/test_fs_svc_port_alloc.sh):
+ *   TEST:PASS:fs_svc_port_alloc_uninit
+ *   TEST:PASS:fs_svc_port_alloc_init
+ *   TEST:PASS:fs_svc_port_alloc_double_init
+ *   TEST:PASS:fs_svc_port_alloc_reset
+ *   TEST:PASS:fs_svc_port_alloc
+ *
+ * Pure host-side, no kernel runtime dependencies beyond the slice-1
+ * source files. Modeled on tests/console_svc_port_alloc_test.c.
+ *
+ * Issue: #278. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 1.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/svc/fs_svc.h"
+#include "harness/svc_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:fs_svc_port_alloc:%s\n", reason);
+  g_fail = 1;
+}
+
+static void reset_world(void) {
+  fs_svc_reset();
+  ipc_port_table_reset();
+}
+
+static void test_uninit(void) {
+  reset_world();
+  if (fs_svc_is_initialised()) {
+    fail("uninit_is_initialised_true");
+    return;
+  }
+  if (fs_svc_port_read() != IPC_PORT_INVALID) {
+    fail("uninit_read_port_not_invalid");
+    return;
+  }
+  if (fs_svc_port_write() != IPC_PORT_INVALID) {
+    fail("uninit_write_port_not_invalid");
+    return;
+  }
+  printf("TEST:PASS:fs_svc_port_alloc_uninit\n");
+}
+
+static int assert_port(const char *label,
+                       ipc_port_t handle,
+                       capability_id_t expected_cap) {
+  cap_subject_id_t owner = 0u;
+  if (ipc_port_owner(handle, &owner) != IPC_OK) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_owner_query_failed", label);
+    fail(r);
+    return 0;
+  }
+  if (owner != (cap_subject_id_t)SUBJECT_M3_FS_SVC) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_owner_mismatch", label);
+    fail(r);
+    return 0;
+  }
+  capability_id_t send_cap = 0;
+  if (ipc_port_send_cap(handle, &send_cap) != IPC_OK) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_send_cap_query_failed", label);
+    fail(r);
+    return 0;
+  }
+  if (send_cap != expected_cap) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_send_cap_mismatch", label);
+    fail(r);
+    return 0;
+  }
+  capability_id_t recv_cap = 0;
+  if (ipc_port_recv_cap(handle, &recv_cap) != IPC_OK) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_recv_cap_query_failed", label);
+    fail(r);
+    return 0;
+  }
+  if (recv_cap != expected_cap) {
+    char r[64];
+    snprintf(r, sizeof(r), "init_%s_recv_cap_mismatch", label);
+    fail(r);
+    return 0;
+  }
+  return 1;
+}
+
+static void test_init(void) {
+  reset_world();
+  fs_svc_result_t rc = fs_svc_init();
+  if (rc != FS_SVC_OK) {
+    fail("init_not_ok");
+    return;
+  }
+  if (!fs_svc_is_initialised()) {
+    fail("init_flag_not_set");
+    return;
+  }
+  ipc_port_t read_handle = fs_svc_port_read();
+  if (read_handle == IPC_PORT_INVALID) {
+    fail("init_read_port_invalid");
+    return;
+  }
+  ipc_port_t write_handle = fs_svc_port_write();
+  if (write_handle == IPC_PORT_INVALID) {
+    fail("init_write_port_invalid");
+    return;
+  }
+  if (read_handle == write_handle) {
+    fail("init_handles_collide");
+    return;
+  }
+  if (!assert_port("read", read_handle, CAP_FS_READ)) {
+    return;
+  }
+  if (!assert_port("write", write_handle, CAP_FS_WRITE)) {
+    return;
+  }
+  printf("TEST:PASS:fs_svc_port_alloc_init\n");
+}
+
+static void test_double_init(void) {
+  reset_world();
+  if (fs_svc_init() != FS_SVC_OK) {
+    fail("double_first_init_failed");
+    return;
+  }
+  ipc_port_t first_read = fs_svc_port_read();
+  ipc_port_t first_write = fs_svc_port_write();
+  if (first_read == IPC_PORT_INVALID || first_write == IPC_PORT_INVALID) {
+    fail("double_first_handles_invalid");
+    return;
+  }
+
+  fs_svc_result_t second = fs_svc_init();
+  if (second != FS_SVC_ERR_ALREADY_INIT) {
+    fail("double_second_init_did_not_reject");
+    return;
+  }
+  if (fs_svc_port_read() != first_read) {
+    fail("double_read_changed_on_second_init");
+    return;
+  }
+  if (fs_svc_port_write() != first_write) {
+    fail("double_write_changed_on_second_init");
+    return;
+  }
+  printf("TEST:PASS:fs_svc_port_alloc_double_init\n");
+}
+
+static void test_reset(void) {
+  reset_world();
+  if (fs_svc_init() != FS_SVC_OK) {
+    fail("reset_init_failed");
+    return;
+  }
+  fs_svc_reset();
+  if (fs_svc_is_initialised()) {
+    fail("reset_flag_still_true");
+    return;
+  }
+  if (fs_svc_port_read() != IPC_PORT_INVALID) {
+    fail("reset_read_port_not_invalid");
+    return;
+  }
+  if (fs_svc_port_write() != IPC_PORT_INVALID) {
+    fail("reset_write_port_not_invalid");
+    return;
+  }
+
+  ipc_port_table_reset();
+  if (fs_svc_init() != FS_SVC_OK) {
+    fail("reset_reinit_failed");
+    return;
+  }
+  if (fs_svc_port_read() == IPC_PORT_INVALID) {
+    fail("reset_reinit_read_port_invalid");
+    return;
+  }
+  if (fs_svc_port_write() == IPC_PORT_INVALID) {
+    fail("reset_reinit_write_port_invalid");
+    return;
+  }
+  printf("TEST:PASS:fs_svc_port_alloc_reset\n");
+}
+
+int main(void) {
+  test_uninit();
+  test_init();
+  test_double_init();
+  test_reset();
+
+  if (g_fail) {
+    fprintf(stderr, "TEST:FAIL:fs_svc_port_alloc\n");
+    return 1;
+  }
+  printf("TEST:PASS:fs_svc_port_alloc\n");
+  return 0;
+}

--- a/tests/harness/m2_subjects.h
+++ b/tests/harness/m2_subjects.h
@@ -1,54 +1,22 @@
 /**
  * @file m2_subjects.h
- * @brief Canonical subject ids for the M2-on-M1 substrate test suite.
+ * @brief Backwards-compatibility alias for the M2-only spelling of the
+ *        substrate subject-id header.
  *
- * Single source of truth for the three subject ids the slice-1 / -2 /
- * -3 / -4 PRs reference (console service, launcher, HelloApp). Issuing
- * them from one header keeps the three substrate slices from drifting
- * into mismatched id pickers.
+ * Original M2-only contract lived here (issue #268). Generalised under
+ * issue #278 to also cover M3 fs_svc and future substrate slices; the
+ * canonical header is now `tests/harness/svc_subjects.h`.
  *
- * Numeric values:
- *   - Kept LOW (single digits) so they stay under
- *     `CAP_TABLE_MAX_SUBJECTS` (8 in v0) — same constraint the M1
- *     module-registry subjects already obey
- *     (`kernel/proc/module_registry.h` SUBJECT_M1_*).
- *   - Distinct from SUBJECT_M1_SENDER/RECEIVER/UNAUTH (5/6/7) so the
- *     M1 IPC demo and the M2 substrate demo can coexist in the same
- *     test phase without subject-id collisions.
- *   - `0` is reserved (the IPC v0 spec requires kernel-stamped
- *     `sender_subject != 0` on receive); never used here.
+ * Existing slice consumers (`#include "harness/m2_subjects.h"`) keep
+ * compiling unchanged via this alias. New code should prefer the
+ * canonical header.
  *
- * Subject map (frozen under `OS_ABI_VERSION = 0`):
- *   SUBJECT_M2_LAUNCHER    = 1   launcher (M2 mediation point)
- *   SUBJECT_M2_CONSOLE_SVC = 2   in-kernel console service module
- *   SUBJECT_M2_HELLOAPP    = 3   spawned HelloApp under launcher
- *                                (placeholder until slice 3 lands)
- *
- * Issue: #268 (slice 1). Consumed by slices 2 / 3 / 4 (#269 / #270 /
- * #271). Plan: plans/2026-05-23-m2-on-m1-substrate.md §"Risks and
- * explicit assumptions" — shared helper to keep each new test under
- * ~120 LoC.
+ * Issue: #278. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md.
  */
 
 #ifndef SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H
 #define SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H
 
-#include "../../kernel/cap/capability.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/*
- * Canonical M2 substrate subject ids. Pinned by tests; do NOT
- * renumber without updating every slice-1..4 consumer in the same PR.
- */
-#define SUBJECT_M2_LAUNCHER    ((cap_subject_id_t)1u)
-#define SUBJECT_M2_CONSOLE_SVC ((cap_subject_id_t)2u)
-#define SUBJECT_M2_HELLOAPP    ((cap_subject_id_t)3u)
-
-#ifdef __cplusplus
-}
-#endif
+#include "svc_subjects.h"
 
 #endif /* SECUREOS_TESTS_HARNESS_M2_SUBJECTS_H */

--- a/tests/harness/svc_subjects.c
+++ b/tests/harness/svc_subjects.c
@@ -1,0 +1,53 @@
+/**
+ * @file svc_subjects.c
+ * @brief Compile-time assertions for the canonical substrate subject ids.
+ *
+ * Values live in `svc_subjects.h`. This translation unit only:
+ *
+ *   1. Statically asserts the ids are in the legal cap-table range
+ *      (mirrors the SUBJECT_M1_* range guard in
+ *      `kernel/proc/module_registry.h`).
+ *   2. Asserts all ids are distinct from one another and from the
+ *      reserved `0` so a future renumbering can't silently re-alias.
+ *   3. Gives the build a non-empty object file when this header is
+ *      consumed via a `.c,h` pair.
+ *
+ * Issue: #278. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md.
+ */
+
+#include "svc_subjects.h"
+
+/* CAP_TABLE_MAX_SUBJECTS is 8 in v0 (see comment in
+ * kernel/proc/module_registry.h on the same constraint). Subject ids
+ * must be strictly less than that bound; replicating the literal `8u`
+ * here mirrors the m2_subjects.c rationale (single source of truth
+ * lives in kernel/cap/cap_table.h; this guard fires loudly if cap_table
+ * grows past 8 without updating this file in the same PR). */
+_Static_assert(SUBJECT_M2_LAUNCHER < 8u,
+               "SUBJECT_M2_LAUNCHER must fit under CAP_TABLE_MAX_SUBJECTS");
+_Static_assert(SUBJECT_M2_CONSOLE_SVC < 8u,
+               "SUBJECT_M2_CONSOLE_SVC must fit under CAP_TABLE_MAX_SUBJECTS");
+_Static_assert(SUBJECT_M2_HELLOAPP < 8u,
+               "SUBJECT_M2_HELLOAPP must fit under CAP_TABLE_MAX_SUBJECTS");
+_Static_assert(SUBJECT_M3_FS_SVC < 8u,
+               "SUBJECT_M3_FS_SVC must fit under CAP_TABLE_MAX_SUBJECTS");
+
+_Static_assert(SUBJECT_M2_LAUNCHER != 0u
+               && SUBJECT_M2_CONSOLE_SVC != 0u
+               && SUBJECT_M2_HELLOAPP != 0u
+               && SUBJECT_M3_FS_SVC != 0u,
+               "substrate subject ids must not collide with the "
+               "reserved 0 used by ipc_msg_v0 to signal "
+               "unstamped/invalid sender_subject");
+
+_Static_assert(SUBJECT_M2_LAUNCHER != SUBJECT_M2_CONSOLE_SVC
+               && SUBJECT_M2_LAUNCHER != SUBJECT_M2_HELLOAPP
+               && SUBJECT_M2_LAUNCHER != SUBJECT_M3_FS_SVC
+               && SUBJECT_M2_CONSOLE_SVC != SUBJECT_M2_HELLOAPP
+               && SUBJECT_M2_CONSOLE_SVC != SUBJECT_M3_FS_SVC
+               && SUBJECT_M2_HELLOAPP != SUBJECT_M3_FS_SVC,
+               "substrate subject ids must be pairwise distinct");
+
+/* Keep at least one external symbol in the .o so linkers that strip
+ * empty TUs don't drop the static_asserts above on an LTO build. */
+const unsigned int svc_subjects_compile_marker = 0xC0DEC0DFu;

--- a/tests/harness/svc_subjects.h
+++ b/tests/harness/svc_subjects.h
@@ -1,0 +1,60 @@
+/**
+ * @file svc_subjects.h
+ * @brief Canonical subject ids for the SecureOS substrate test suite
+ *        (M2 + M3 + future), generalised from the M2-only
+ *        `m2_subjects.h` introduced by issue #268.
+ *
+ * Single source of truth for the substrate subject ids referenced by
+ * the M2 console + launcher + HelloApp slices (#268..#271) and the M3
+ * fs_svc slices (#278..#281). Issuing them from one header keeps the
+ * substrate slices from drifting into mismatched id pickers.
+ *
+ * Numeric values:
+ *   - Kept LOW (single digits) so they stay under
+ *     `CAP_TABLE_MAX_SUBJECTS` (8 in v0) — same constraint the M1
+ *     module-registry subjects already obey
+ *     (`kernel/proc/module_registry.h` SUBJECT_M1_*).
+ *   - Distinct from SUBJECT_M1_SENDER/RECEIVER/UNAUTH (5/6/7) so the
+ *     M1 IPC demo and the substrate demos can coexist in the same
+ *     test phase without subject-id collisions.
+ *   - `0` is reserved (the IPC v0 spec requires kernel-stamped
+ *     `sender_subject != 0` on receive); never used here.
+ *
+ * Subject map (frozen under `OS_ABI_VERSION = 0`):
+ *   SUBJECT_M2_LAUNCHER    = 1   launcher (M2 mediation point)
+ *   SUBJECT_M2_CONSOLE_SVC = 2   in-kernel console service module
+ *   SUBJECT_M2_HELLOAPP    = 3   spawned HelloApp under launcher
+ *   SUBJECT_M3_FS_SVC      = 4   in-kernel fs service module (#278)
+ *
+ * Backwards compatibility:
+ *   The pre-existing `tests/harness/m2_subjects.h` header still
+ *   compiles via a one-line re-include of this file (see that header
+ *   for the alias). Slice consumers should prefer the new spelling.
+ *
+ * Issue: #278 (slice 1 of M3 substrate). Consumed by slices 2/3/4
+ * (#279/#280/#281). Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md.
+ */
+
+#ifndef SECUREOS_TESTS_HARNESS_SVC_SUBJECTS_H
+#define SECUREOS_TESTS_HARNESS_SVC_SUBJECTS_H
+
+#include "../../kernel/cap/capability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Canonical substrate subject ids. Pinned by tests; do NOT renumber
+ * without updating every slice consumer in the same PR.
+ */
+#define SUBJECT_M2_LAUNCHER    ((cap_subject_id_t)1u)
+#define SUBJECT_M2_CONSOLE_SVC ((cap_subject_id_t)2u)
+#define SUBJECT_M2_HELLOAPP    ((cap_subject_id_t)3u)
+#define SUBJECT_M3_FS_SVC      ((cap_subject_id_t)4u)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECUREOS_TESTS_HARNESS_SVC_SUBJECTS_H */


### PR DESCRIPTION
Closes #278. Slice 1 of M3-on-M1 substrate plan #277.

## Summary

Mirrors the M2 `console_svc` module (#272) one domino later in BUILD_ROADMAP §5.3:
allocates two well-known IPC ports (read + write) at fs_svc init, both owned by
the canonical `SUBJECT_M3_FS_SVC` subject, gated by the existing `CAP_FS_READ` /
`CAP_FS_WRITE` capabilities. Idempotent-by-error: a second init without reset
returns `FS_SVC_ERR_ALREADY_INIT`. No ABI surface change.

## What landed

- `kernel/svc/fs_svc.{c,h}` — dual-port allocator + accessors:
  `fs_svc_init()`, `fs_svc_reset()`, `fs_svc_port_read()`,
  `fs_svc_port_write()`, `fs_svc_is_initialised()`.
- `tests/harness/svc_subjects.{c,h}` — generalises the M2-only
  `m2_subjects.{c,h}` to cover M2 + M3 substrate. Added
  `SUBJECT_M3_FS_SVC = 4` (under `CAP_TABLE_MAX_SUBJECTS = 8`,
  pairwise-distinct, non-zero). Static asserts cover the same shape
  the M2 file did.
- `tests/harness/m2_subjects.h` — now a one-line alias re-include of
  `svc_subjects.h` so every existing M2 slice consumer (#268..#271 peers)
  compiles unchanged.
- `tests/fs_svc_port_alloc_test.c` — 5 markers modeled on the
  `console_svc_port_alloc` shape:
  - `TEST:PASS:fs_svc_port_alloc_uninit`
  - `TEST:PASS:fs_svc_port_alloc_init` (asserts owner + send_cap +
    recv_cap per port + handle distinctness)
  - `TEST:PASS:fs_svc_port_alloc_double_init`
  - `TEST:PASS:fs_svc_port_alloc_reset`
  - `TEST:PASS:fs_svc_port_alloc`
- `build/scripts/test_fs_svc_port_alloc.sh` + `test.sh` dispatch +
  `.shell_parity_allowlist` entry (issue #156 — `_qemu` peers
  still allowed under the existing rollout).

## Validation

```
$ bash build/scripts/test.sh fs_svc_port_alloc
TEST:PASS:fs_svc_port_alloc_uninit
TEST:PASS:fs_svc_port_alloc_init
TEST:PASS:fs_svc_port_alloc_double_init
TEST:PASS:fs_svc_port_alloc_reset
TEST:PASS:fs_svc_port_alloc

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 72 entries)

$ bash build/scripts/test.sh console_svc_port_alloc        # M2 sibling stays green
TEST:PASS:console_svc_port_alloc_{uninit,init,double_init,reset}
TEST:PASS:console_svc_port_alloc

$ bash build/scripts/test.sh launcher_spawn_handoff        # M2 consumer of m2_subjects.h alias
TEST:PASS:launcher_spawn_handoff_{grant,no_grant,destroy,invalid_manifest}
TEST:PASS:launcher_spawn_handoff

$ bash build/scripts/test.sh m2_helloapp_allow_qemu        # same
TEST:PASS:helloapp_allowed_console_write
TEST:PASS:helloapp_allow
```

## Design notes

- **No `kmain.c` boot wiring in this slice.** Same convention as the
  M2 `console_svc` slice 1 (#272): kmain currently never calls
  `console_svc_init()` either — wiring lives with the launcher/spawn
  slices. Slice 2 (#279) is the natural place to revisit boot order
  if/when the launcher actually needs both `fs_svc_init()` and
  `console_svc_init()` called from kmain.
- **Two ports, not one.** Matches the existing M3 fs_service surface
  which already distinguishes reads from writes via the `CAP_FS_READ`
  / `CAP_FS_WRITE` cap pair. No new capability id invented (plan #277
  explicit non-ask).
- **Failure path on write-port alloc.** If the read port allocates
  but the write port doesn't, module state stays uninitialised and
  `FS_SVC_ERR_PORT_ALLOC_WRITE` is returned; the read port is left in
  the port table for the caller to clean up via
  `ipc_port_table_reset()`. Documented in `fs_svc_init()`'s doc comment.
- **m2_subjects.h alias choice.** I generalised the file rather than
  ifdef-ing the macros to keep the substrate test harness as a single
  source of truth as M3/M4 slices land. The compatibility shim is a
  one-liner; no slice 1..4 M2 consumer needs touching.

## Follow-ups

- Slice 2: `launcher_fs_spawn_app_with_fs_caps` + `ipc_scratch`
  fs-handle handoff (#279).
- Slice 3: HelloApp fs-demo entry + persist allow/deny `_qemu`
  tests (#280).
- Slice 4: ephemeral-reset `_qemu` peer (#281).

_Filed by hourly issue-work cron e4c62e32, 2026-05-24 11:26 UTC._
