### PR TITLE
fix #285: manifest schema v0 — optional capabilities.persistence enum (ephemeral|persistent)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -68,6 +68,7 @@ test_kernel_persistence
 test_launcher_console
 test_launcher_fs
 test_launcher_spawn_handoff
+test_manifest_persistence_enum
 test_manifest_required_fields
 test_netlib_url_scheme
 test_scheduler

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -277,6 +277,14 @@ case "$TEST_NAME" in
     # os_abi_version) with a deterministic MANIFEST_VALIDATE:*
     # marker so the disk-image build gate cannot silently pass.
     run_script "$ROOT_DIR/build/scripts/test_manifest_required_fields.sh"
+    ;;
+  manifest_persistence_enum)
+    # Issue #285: positive + negative coverage for the optional
+    # `capabilities.persistence` enum (ephemeral|persistent) added
+    # to manifests/schema/v0.json. Asserts the checked-in persistent
+    # example validates and that a bad enum value is rejected with a
+    # deterministic MANIFEST_VALIDATE:* marker.
+    run_script "$ROOT_DIR/build/scripts/test_manifest_persistence_enum.sh"
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"

--- a/build/scripts/test_manifest_persistence_enum.sh
+++ b/build/scripts/test_manifest_persistence_enum.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# build/scripts/test_manifest_persistence_enum.sh
+#
+# Issue #285: positive + negative coverage for the optional
+# `capabilities.persistence` enum (ephemeral|persistent, default
+# ephemeral) added to manifests/schema/v0.json.
+#
+# Asserts:
+#
+#   1. The checked-in positive example (manifests/examples/helloapp.persistent.json)
+#      validates against the schema and is reported as MANIFEST_VALIDATE:PASS
+#      by the standard validator wrapper.
+#   2. A synthesized manifest that sets `capabilities.persistence` to a
+#      value outside the enum (e.g. "forever") is REJECTED by the
+#      validator wrapper, with a deterministic MANIFEST_VALIDATE:(ERROR|FAIL)
+#      marker on stderr, and the offending field name surfaces in the
+#      error text. This is the regression that keeps a typo'd / drifted
+#      enum from silently leaking back in.
+#
+# Exit codes:
+#   0  - both checks passed
+#   1  - regression: validator accepted a bad enum, or missed the good one
+#   78 - harness error (env/tool missing)
+#
+# Markers emitted on this script's own success path:
+#   TEST:PASS:manifest_persistence_enum
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
+POSITIVE="$ROOT_DIR/manifests/examples/helloapp.persistent.json"
+
+if [[ ! -r "$WRAPPER" ]]; then
+  echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
+  exit 78
+fi
+if [[ ! -r "$POSITIVE" ]]; then
+  echo "TEST:FAIL:harness_missing_positive_example:$POSITIVE" >&2
+  exit 78
+fi
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_python" >&2
+  exit 78
+fi
+if ! "$PY" -c "import jsonschema" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_jsonschema" >&2
+  exit 78
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Positive: the checked-in persistent example must validate. ---
+POS_OUT="$TMP/pos.log"
+set +e
+bash "$WRAPPER" "$POSITIVE" >"$POS_OUT" 2>&1
+POS_RC=$?
+set -e
+
+if [[ "$POS_RC" -ne 0 ]]; then
+  echo "TEST:FAIL:manifest_persistence_enum:positive_example_rejected" >&2
+  sed 's/^/  | /' "$POS_OUT" >&2
+  exit 1
+fi
+if ! grep -q "MANIFEST_VALIDATE:PASS" "$POS_OUT"; then
+  echo "TEST:FAIL:manifest_persistence_enum:positive_example_missing_pass_marker" >&2
+  sed 's/^/  | /' "$POS_OUT" >&2
+  exit 1
+fi
+
+# --- Negative: synthesize an out-of-enum value and assert rejection. ---
+TAMPERED="$TMP/persistence_bad.json"
+cat >"$TAMPERED" <<'EOF'
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "persistence": "forever"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}
+EOF
+
+NEG_OUT="$TMP/neg.log"
+set +e
+bash "$WRAPPER" "$TAMPERED" >"$NEG_OUT" 2>&1
+NEG_RC=$?
+set -e
+
+if [[ "$NEG_RC" -eq 0 ]]; then
+  echo "TEST:FAIL:manifest_persistence_enum:bad_enum_accepted" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_persistence_enum:missing_deterministic_marker" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -q "persistence" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_persistence_enum:field_name_not_in_error" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:manifest_persistence_enum"

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -108,6 +108,19 @@ Field semantics we are committing to at v0:
   Apps that list a capability here MUST check the `OS_STATUS_DENIED`
   result and degrade gracefully (see
   [`capability-deny-contract.md`](./capability-deny-contract.md)).
+- `capabilities.persistence` is an optional enum (`"ephemeral"` |
+  `"persistent"`) that declares the FS persistence mode the app
+  requests from `launcher_fs` (BUILD_ROADMAP §5.3, issue #285).
+  The default is `"ephemeral"`: writes go to the faux FS and are
+  wiped at `process_destroy` / relaunch. `"persistent"` is a
+  *request* only — it is granted at spawn time **only** if
+  `launcher_fs` policy approves `CAP_FS_WRITE` for this subject;
+  apps MUST tolerate being downgraded to ephemeral the same way
+  they tolerate `OS_STATUS_DENIED` on an `optional` capability.
+  Adding the field is schema-only at v0 — the launcher_fs wiring
+  lands in issue #279 — so this is an additive, v0-compatible
+  change and does **not** bump `OS_ABI_VERSION` (see Compatibility
+  policy below).
 - `provides[]` lists IPC endpoints the app exposes (see
   [`ipc-wire.md`](./ipc-wire.md)). Endpoint names use a narrow
   reverse-DNS-ish pattern.

--- a/manifests/examples/helloapp.persistent.json
+++ b/manifests/examples/helloapp.persistent.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "persistence": "persistent"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -67,6 +67,12 @@
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/capabilityId" },
           "default": []
+        },
+        "persistence": {
+          "description": "FS persistence mode the app requests from launcher_fs (BUILD_ROADMAP §5.3, issue #285). 'ephemeral' (default) writes to the faux FS and is wiped at process_destroy / relaunch; 'persistent' is granted only if launcher_fs policy approves CAP_FS_WRITE for this subject. Schema-only at v0; launcher_fs wiring lands in issue #279.",
+          "type": "string",
+          "enum": ["ephemeral", "persistent"],
+          "default": "ephemeral"
         }
       }
     },


### PR DESCRIPTION
Closes #285.

## Summary

Adds the M3-SUBSTRATE-DOC follow-up from plan #277 to manifest schema v0: a new **optional** `capabilities.persistence` enum (`ephemeral` | `persistent`, default `ephemeral`) that lets a manifest declare the FS persistence mode it requests from `launcher_fs`. Schema + doc + examples + CI gate only — **no** launcher_fs wiring (that is #279).

### Field placement

The field lives under `capabilities` (alongside `request` / `optional`), not at the top-level `app` object. Rationale: it is a *request* from the app to the launcher in the same posture as `capabilities.request` / `capabilities.optional`, and `launcher_fs`'s share-policy check will gate it against `CAP_FS_WRITE`. Keeping all launcher-policy inputs in one node also keeps the schema readable.

### ABI / compat

No `OS_ABI_VERSION` bump. Per `docs/abi/manifest.md` Compatibility policy, adding an optional field with a default is a v0-compatible additive change; existing `helloapp.json` / `helloapp.deny.json` continue to validate unchanged (the schema-default of `ephemeral` is satisfied implicitly). `additionalProperties: false` discipline is preserved — the new property is added explicitly to `capabilities.properties`.

## Changes

- `manifests/schema/v0.json` — new optional `capabilities.persistence` property, enum-bounded.
- `manifests/examples/helloapp.persistent.json` — new positive example mirroring the style of `helloapp.json` / `helloapp.deny.json`.
- `docs/abi/manifest.md` — new field-semantics bullet describing the ephemeral default, the persistent-as-request contract, and that launcher_fs wiring lands in #279.
- `build/scripts/test_manifest_persistence_enum.sh` — positive (persistent example validates → `MANIFEST_VALIDATE:PASS`) + negative (`persistence: \"forever\"` rejected with deterministic `MANIFEST_VALIDATE:(ERROR|FAIL)` marker mentioning the field name). Mirrors the regression style of `test_manifest_required_fields.sh` (#226).
- `build/scripts/test.sh` — new `manifest_persistence_enum` dispatcher case.
- `build/scripts/.shell_parity_allowlist` — sibling allowlist entry alongside `test_manifest_required_fields` / `test_validate_manifests_abi_major` (#156 tracking debt; PowerShell peer not added in this PR to keep the diff scoped, consistent with how #226's test was landed).

## Validation

```
build/scripts/validate_manifests.sh                  → MANIFEST_VALIDATE:SUMMARY:pass 3/3
build/scripts/test_manifest_persistence_enum.sh      → TEST:PASS:manifest_persistence_enum
build/scripts/test_manifest_required_fields.sh       → TEST:PASS:manifest_required_fields    (unaffected)
build/scripts/test_validate_manifests_abi_major.sh   → TEST:PASS:validate_manifests_abi_major (unaffected)
build/scripts/check_shell_parity.sh                  → PARITY:OK
```

## Out of scope (deferred to follow-ups noted in #285 / plan #277)

- Wiring `persistence` into `launcher_fs_spawn_app_with_fs_caps` → #279.
- Adding a `CAP_FS_PERSIST` capability id → declined by plan #277.
- Updating `docs/architecture/m3-substrate-ridden-topology.md` → deferred until all four §5.3 substrate slices land.
- Adding a PowerShell peer for `test_manifest_persistence_enum.sh` → tracked under the existing #156 parity allowlist; matches how #226's sibling test was landed.

## Follow-ups for reviewer attention

- Confirm the field-placement choice (under `capabilities` rather than the top-level `app` object) matches the implementer's intent for #279.