### PR TITLE
feat(launcher): fs-svc cap-handle handoff into ipc_scratch (closes #279)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -68,6 +68,7 @@ test_kernel_persistence
 test_launcher_console
 test_launcher_fs
 test_launcher_spawn_handoff
+test_launcher_fs_spawn_handoff
 test_manifest_persistence_enum
 test_manifest_required_fields
 test_netlib_url_scheme

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -174,6 +174,9 @@ case "$TEST_NAME" in
     ;;
   launcher_spawn_handoff)
     run_script "$ROOT_DIR/build/scripts/test_launcher_spawn_handoff.sh"
+    ;;
+  launcher_fs_spawn_handoff)
+    run_script "$ROOT_DIR/build/scripts/test_launcher_fs_spawn_handoff.sh"
     ;;
   event_bus)
     run_script "$ROOT_DIR/build/scripts/test_event_bus.sh"

--- a/build/scripts/test_launcher_fs_spawn_handoff.sh
+++ b/build/scripts/test_launcher_fs_spawn_handoff.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# build/scripts/test_launcher_fs_spawn_handoff.sh
+#
+# Build + run the M3-on-M1 substrate launcher fs-spawn handoff
+# validator (issue #279, plan plans/2026-05-24-m3-fs-on-m1-substrate.md
+# slice 2).
+#
+# Covers:
+#   - launcher_fs_spawn_app_with_fs_caps(..., grant_write=false, ...)
+#     spawns a real PCB, mints CAP_FS_READ, and writes it LE64 into
+#     ipc_scratch[8..16). ipc_scratch[16..24) stays CAP_HANDLE_NULL.
+#   - launcher_fs_spawn_app_with_fs_caps(..., grant_write=true, ...)
+#     additionally mints CAP_FS_WRITE into ipc_scratch[16..24); both
+#     handles gate-check and resolve to the spawned subject.
+#   - launcher_fs_spawn_destroy() cascades cap_handle_revoke_subject()
+#     so both fs handles fail closed afterwards.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/kernel/user/launcher_fs.c" \
+  "$ROOT_DIR/tests/harness/svc_subjects.c" \
+  "$ROOT_DIR/tests/launcher_fs_spawn_handoff_test.c" \
+  -o "$OUT_DIR/launcher_fs_spawn_handoff_test"
+
+LOG_PATH="$OUT_DIR/launcher_fs_spawn_handoff_test.log"
+"$OUT_DIR/launcher_fs_spawn_handoff_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:launcher_fs_spawn_handoff_read_only" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_spawn_handoff_read_write" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_spawn_handoff_revoke_on_destroy" "$LOG_PATH"
+grep -q "TEST:PASS:launcher_fs_spawn_handoff$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/architecture/m1-m2-handoff.md
+++ b/docs/architecture/m1-m2-handoff.md
@@ -42,9 +42,18 @@ For the M1→M2 initial handoff, the launcher writes the freshly minted
 
 ```
 offset  bytes  meaning
-   0      4    cap_handle_t (LE)  — launcher-minted initial grant
-   4     60    reserved (zeroed by aspace_partition)
+   0      4    cap_handle_t (LE)  — launcher-minted initial grant (M2 console)
+   4      4    reserved (zeroed by aspace_partition)
+   8      8    LE64(cap_handle_t) — M3 fs_svc READ handle  (#279)
+  16      8    LE64(cap_handle_t) — M3 fs_svc WRITE handle (#279, zero when not granted)
+  24     40    reserved (zeroed by aspace_partition)
 ```
+
+The M3 fs-handle slots ([8..16) and [16..24)) are written by
+`launcher_fs_spawn_app_with_fs_caps()` (slice 2 of plan #277). The
+upper 32 bits of each LE64 slot are reserved-zero under
+`OS_ABI_VERSION = 0`; a future cap-handle width bump can occupy them
+without shifting offsets.
 
 The wire is identical to how a future syscall would return the handle
 to userspace: a `uint32_t` in target-platform byte order, with the

--- a/kernel/user/launcher.c
+++ b/kernel/user/launcher.c
@@ -382,3 +382,152 @@ launcher_result_t launcher_spawn_destroy(process_id_t pid) {
   slot->cap = (capability_id_t)0;
   return LAUNCHER_OK;
 }
+
+/* ----------------------------------------------------------------
+ * M3-SUBSTRATE-002 (issue #279): launcher-mediated spawn variant
+ * that pre-stamps fs-svc capability handles into the spawned
+ * process's per-process ipc_scratch region.
+ *
+ * The single launcher spawn pool above is shared: an fs-cap spawn
+ * occupies one slot exactly like a console spawn. The slot's
+ * `handle`/`cap` fields are reused to track the fs READ handle
+ * (which is always minted); the WRITE handle is tracked implicitly
+ * by `cap_handle_revoke_subject()` at destroy time — we don't need
+ * a second slot field because process_destroy authoritatively kills
+ * every handle owned by the subject (#239).
+ * ---------------------------------------------------------------- */
+
+/* Write a 32-bit cap_handle_t as a little-endian 64-bit value into
+ * `bytes` (which MUST point to 8 writable bytes). The upper 32 bits
+ * are zeroed — reserved under OS_ABI_VERSION=0 per the handoff doc. */
+static void scratch_store_handle_le64(uint8_t *bytes, cap_handle_t h) {
+  if (bytes == NULL) {
+    return;
+  }
+  bytes[0] = (uint8_t)( h        & 0xFFu);
+  bytes[1] = (uint8_t)((h >>  8) & 0xFFu);
+  bytes[2] = (uint8_t)((h >> 16) & 0xFFu);
+  bytes[3] = (uint8_t)((h >> 24) & 0xFFu);
+  bytes[4] = 0u;
+  bytes[5] = 0u;
+  bytes[6] = 0u;
+  bytes[7] = 0u;
+}
+
+launcher_result_t launcher_fs_spawn_app_with_fs_caps(
+    const launcher_manifest_t *manifest,
+    int grant_write,
+    launcher_fs_spawn_t *out_spawn) {
+  if (out_spawn == NULL) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  out_spawn->pid = PID_INVALID;
+  out_spawn->aspace = NULL;
+  out_spawn->read_handle = CAP_HANDLE_NULL;
+  out_spawn->write_handle = CAP_HANDLE_NULL;
+
+  if (manifest == NULL) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  if (!launcher_subject_in_range(manifest->subject_id) ||
+      manifest->subject_id == 0u) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+  /* The fs-spawn path does not consume `auto_grant_caps` — fs handles
+   * are minted from the boolean `grant_write` argument plus the
+   * always-on CAP_FS_READ. Reject a non-zero auto_grant_count so the
+   * caller can't smuggle in a console grant by accident. */
+  if (manifest->auto_grant_count != 0u) {
+    return LAUNCHER_ERR_INVALID_MANIFEST;
+  }
+
+  launcher_spawn_slot_t *slot = launcher_spawn_slot_alloc();
+  if (slot == NULL) {
+    return LAUNCHER_ERR_INTERNAL;
+  }
+
+  /* (1) Carve a fresh aspace window. */
+  address_space_t *as = launcher_aspace_claim();
+  if (as == NULL) {
+    return LAUNCHER_ERR_ASPACE;
+  }
+  if (as->ipc_scratch == NULL) {
+    return LAUNCHER_ERR_SCRATCH;
+  }
+
+  /* (2) Spawn the PCB. */
+  process_id_t pid = PID_INVALID;
+  if (process_create(manifest->subject_id, as, &pid) != PROC_OK) {
+    return LAUNCHER_ERR_PROC_CREATE;
+  }
+
+  /* (3) The spawned subject is intentionally NOT auto-registered
+   * with launcher_fs's per-app faux-storage sandbox here. The fs
+   * handles minted below authorize the subject against the kernel
+   * fs_svc IPC ports directly via the cap-table gate — they do not
+   * need the launcher_fs ramfs-shadow to exist. Slice 3 (#280) is
+   * the right place to wire per-app persistence policy once the
+   * manifest persistence enum (#285 / #286) is consumed here. This
+   * also keeps launcher.c free of a hard launcher_fs.c link
+   * dependency, so the existing M2 builds (console, helloapp_qemu)
+   * stay linkable without dragging in the faux-fs surface.
+   */
+
+  /* (4) Zero the full scratch slot so reserved-bytes guarantees hold
+   * regardless of arena re-use. The LE writes below clobber bytes
+   * [8..24); bytes [0..8) and [24..64) are left zero. */
+  memset(as->ipc_scratch, 0, IPC_MSG_PAYLOAD_MAX);
+
+  /* (5) Mint the CAP_FS_READ handle (always) and, if requested, the
+   * CAP_FS_WRITE handle. Keep the legacy bitset grant in sync so
+   * audit-trail tests that go through cap_check still see the grant. */
+  if (cap_table_grant(manifest->subject_id, CAP_FS_READ) != CAP_OK) {
+    (void)process_destroy(pid);
+    return LAUNCHER_ERR_HANDLE_MINT;
+  }
+  cap_handle_t read_h = cap_handle_grant(manifest->subject_id, CAP_FS_READ);
+  if (read_h == CAP_HANDLE_NULL) {
+    (void)process_destroy(pid);
+    return LAUNCHER_ERR_HANDLE_MINT;
+  }
+
+  cap_handle_t write_h = CAP_HANDLE_NULL;
+  if (grant_write) {
+    if (cap_table_grant(manifest->subject_id, CAP_FS_WRITE) != CAP_OK) {
+      (void)process_destroy(pid);
+      return LAUNCHER_ERR_HANDLE_MINT;
+    }
+    write_h = cap_handle_grant(manifest->subject_id, CAP_FS_WRITE);
+    if (write_h == CAP_HANDLE_NULL) {
+      (void)process_destroy(pid);
+      return LAUNCHER_ERR_HANDLE_MINT;
+    }
+  }
+
+  /* (6) Stamp the handles into ipc_scratch at the slice-2 offsets.
+   * IPC_MSG_PAYLOAD_MAX == 64 so [8..16) and [16..24) are always
+   * in-bounds; assert via the runtime check on the aspace above. */
+  uint8_t *p = as->ipc_scratch;
+  scratch_store_handle_le64(&p[8], read_h);
+  scratch_store_handle_le64(&p[16], write_h);
+
+  slot->in_use = true;
+  slot->pid = pid;
+  slot->aspace = as;
+  slot->handle = read_h;
+  slot->cap = CAP_FS_READ;
+
+  out_spawn->pid = pid;
+  out_spawn->aspace = as;
+  out_spawn->read_handle = read_h;
+  out_spawn->write_handle = write_h;
+  return LAUNCHER_OK;
+}
+
+launcher_result_t launcher_fs_spawn_destroy(process_id_t pid) {
+  /* Identical contract to `launcher_spawn_destroy()`: the slot pool
+   * is shared so a single teardown path handles both spawn variants.
+   * process_destroy() cascades cap_handle_revoke_subject() (#239) so
+   * both the read and write handles fail cleanly post-call. */
+  return launcher_spawn_destroy(pid);
+}

--- a/kernel/user/launcher.h
+++ b/kernel/user/launcher.h
@@ -187,4 +187,55 @@ launcher_result_t launcher_spawn_destroy(process_id_t pid);
  * starts from a known-clean state. `launcher_reset()` calls into this. */
 void launcher_spawn_reset(void);
 
+/* ----------------------------------------------------------------
+ * Slice-2 of plan #277 (M3-SUBSTRATE-002, issue #279): launcher
+ * spawn variant that pre-stamps the fs-svc capability handles into
+ * the new process's per-process IPC scratch region.
+ *
+ * Mirrors the M2 console-handle handoff shape (`launcher_spawn_t`),
+ * but stamps the fs handles at fixed offsets in `ipc_scratch`:
+ *
+ *   offset  bytes  meaning
+ *      0      4    reserved (M1 single-handle handoff; e.g. console)
+ *      4      4    reserved (zero in v0)
+ *      8      8    LE64(cap_handle_t)  — CAP_FS_READ handle
+ *     16      8    LE64(cap_handle_t)  — CAP_FS_WRITE handle
+ *                  (zero / CAP_HANDLE_NULL when `grant_write=false`)
+ *
+ * The upper 32 bits of each LE64 slot are reserved and MUST be zero
+ * in v0 (cap_handle_t is 32-bit under OS_ABI_VERSION=0). Forward-
+ * compatibility: a future cap-handle width bump can occupy them
+ * without changing slot offsets.
+ *
+ * The spawned subject is NOT auto-registered with launcher_fs's
+ * per-app faux-storage sandbox here: the minted handles authorize
+ * the subject against the kernel fs_svc IPC ports via the cap-table
+ * gate directly, with no dependency on the launcher_fs ramfs shadow.
+ * Wiring the manifest persistence enum (#285 / #286) into a
+ * `launcher_fs_register_app(..., persistence)` call belongs in slice
+ * 3 (#280); doing it here would force every M2 build that links
+ * launcher.c (console, helloapp_qemu) to also drag in launcher_fs.c.
+ *
+ * No ABI bump: `launcher_result_t` codes, `cap_handle_t` layout, and
+ * `address_space_t::ipc_scratch` sizing are all pre-frozen under
+ * `OS_ABI_VERSION = 0`.
+ */
+typedef struct {
+  process_id_t      pid;
+  address_space_t  *aspace;
+  cap_handle_t      read_handle;   /* CAP_FS_READ; non-NULL on success */
+  cap_handle_t      write_handle;  /* CAP_FS_WRITE if requested; else CAP_HANDLE_NULL */
+} launcher_fs_spawn_t;
+
+launcher_result_t launcher_fs_spawn_app_with_fs_caps(
+    const launcher_manifest_t *manifest,
+    int grant_write,
+    launcher_fs_spawn_t *out_spawn);
+
+/* Destroy a spawn produced by `launcher_fs_spawn_app_with_fs_caps()`.
+ * Same contract as `launcher_spawn_destroy()`: PCB tear-down cascades
+ * `cap_handle_revoke_subject()` per #239 so the stamped fs handles
+ * fail closed after the call. */
+launcher_result_t launcher_fs_spawn_destroy(process_id_t pid);
+
 #endif

--- a/tests/launcher_fs_spawn_handoff_test.c
+++ b/tests/launcher_fs_spawn_handoff_test.c
@@ -1,0 +1,269 @@
+/**
+ * @file launcher_fs_spawn_handoff_test.c
+ * @brief Slice-2 acceptance test for plan #277 / issue #279
+ *        (M3-SUBSTRATE-002).
+ *
+ * Asserts the M3 launcher-fs spawn handoff contract:
+ *
+ *   1. `launcher_fs_spawn_app_with_fs_caps(..., grant_write=false, ...)`
+ *      returns a live PCB with a non-zero CAP_FS_READ handle stamped
+ *      LE64 into `ipc_scratch[8..16)`, and `ipc_scratch[16..24)` is
+ *      CAP_HANDLE_NULL.
+ *   2. `launcher_fs_spawn_app_with_fs_caps(..., grant_write=true, ...)`
+ *      stamps both handles; both resolve via `cap_handle_owner()` to
+ *      the spawned subject; both pass `cap_gate_check_handle()` for
+ *      their respective caps.
+ *   3. `launcher_fs_spawn_destroy(pid)` invalidates BOTH handles via
+ *      the cap_handle_revoke_subject() cascade in `process_destroy()`.
+ *
+ * Output markers (consumed by build/scripts/test_launcher_fs_spawn_handoff.sh):
+ *   TEST:PASS:launcher_fs_spawn_handoff_read_only
+ *   TEST:PASS:launcher_fs_spawn_handoff_read_write
+ *   TEST:PASS:launcher_fs_spawn_handoff_revoke_on_destroy
+ *   TEST:PASS:launcher_fs_spawn_handoff
+ *
+ * Pure host-side; no kernel runtime dependencies beyond the slice-2
+ * sources and their transitive M1 substrate.
+ *
+ * Issue: #279. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 2.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/user/launcher.h"
+#include "../kernel/user/launcher_fs.h"
+#include "harness/svc_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:launcher_fs_spawn_handoff:%s\n", reason);
+  g_fail = 1;
+}
+
+/* Read 8 little-endian bytes; the low 32 bits are cap_handle_t under
+ * OS_ABI_VERSION=0. Top 32 bits are reserved-zero. */
+static cap_handle_t scratch_load_handle_le64(const uint8_t *p) {
+  cap_handle_t lo = (cap_handle_t)p[0]
+                  | ((cap_handle_t)p[1] <<  8)
+                  | ((cap_handle_t)p[2] << 16)
+                  | ((cap_handle_t)p[3] << 24);
+  return lo;
+}
+
+static int scratch_top32_zero(const uint8_t *p) {
+  return p[4] == 0u && p[5] == 0u && p[6] == 0u && p[7] == 0u;
+}
+
+static void test_setup(void) {
+  launcher_reset();
+  launcher_fs_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  launcher_spawn_reset();
+}
+
+static void test_read_only(void) {
+  test_setup();
+
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = NULL,
+      .auto_grant_count  = 0,
+  };
+
+  launcher_fs_spawn_t sp;
+  launcher_result_t r = launcher_fs_spawn_app_with_fs_caps(&m, 0, &sp);
+  if (r != LAUNCHER_OK) {
+    fail("read_only_spawn_returned_nonok");
+    return;
+  }
+  if (sp.pid == PID_INVALID) {
+    fail("read_only_invalid_pid");
+    return;
+  }
+  if (sp.aspace == NULL || sp.aspace->ipc_scratch == NULL) {
+    fail("read_only_null_aspace_or_scratch");
+    return;
+  }
+  if (sp.read_handle == CAP_HANDLE_NULL) {
+    fail("read_only_null_read_handle");
+    return;
+  }
+  if (sp.write_handle != CAP_HANDLE_NULL) {
+    fail("read_only_nonzero_write_handle");
+    return;
+  }
+
+  const uint8_t *p = (const uint8_t *)sp.aspace->ipc_scratch;
+
+  /* Console reserved slot [0..8) must be zero on an fs-cap spawn. */
+  for (size_t i = 0; i < 8; ++i) {
+    if (p[i] != 0u) {
+      fail("read_only_console_slot_nonzero");
+      return;
+    }
+  }
+
+  /* [8..16): LE64(read_handle). */
+  if (scratch_load_handle_le64(&p[8]) != sp.read_handle) {
+    fail("read_only_scratch_read_handle_mismatch");
+    return;
+  }
+  if (!scratch_top32_zero(&p[8])) {
+    fail("read_only_scratch_read_top32_nonzero");
+    return;
+  }
+
+  /* [16..24): LE64(CAP_HANDLE_NULL). */
+  if (scratch_load_handle_le64(&p[16]) != CAP_HANDLE_NULL) {
+    fail("read_only_scratch_write_slot_nonzero");
+    return;
+  }
+  if (!scratch_top32_zero(&p[16])) {
+    fail("read_only_scratch_write_top32_nonzero");
+    return;
+  }
+
+  /* Reserved scratch bytes [24..64) must be zero. */
+  for (size_t i = 24; i < 64; ++i) {
+    if (p[i] != 0u) {
+      fail("read_only_scratch_reserved_bytes_nonzero");
+      return;
+    }
+  }
+
+  /* Read handle must gate-check positively for CAP_FS_READ and
+   * negatively for CAP_FS_WRITE. */
+  if (cap_gate_check_handle(sp.read_handle, CAP_FS_READ) != 1) {
+    fail("read_only_read_handle_gate_check_failed");
+    return;
+  }
+  if (cap_gate_check_handle(sp.read_handle, CAP_FS_WRITE) != 0) {
+    fail("read_only_read_handle_passed_write");
+    return;
+  }
+  if (cap_handle_owner(sp.read_handle) != SUBJECT_M2_HELLOAPP) {
+    fail("read_only_read_handle_owner_mismatch");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_fs_spawn_handoff_read_only\n");
+}
+
+static void test_read_write(void) {
+  test_setup();
+
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = NULL,
+      .auto_grant_count  = 0,
+  };
+
+  launcher_fs_spawn_t sp;
+  launcher_result_t r = launcher_fs_spawn_app_with_fs_caps(&m, 1, &sp);
+  if (r != LAUNCHER_OK) {
+    fail("read_write_spawn_returned_nonok");
+    return;
+  }
+  if (sp.read_handle == CAP_HANDLE_NULL || sp.write_handle == CAP_HANDLE_NULL) {
+    fail("read_write_null_handle");
+    return;
+  }
+  if (sp.read_handle == sp.write_handle) {
+    fail("read_write_handles_aliased");
+    return;
+  }
+
+  const uint8_t *p = (const uint8_t *)sp.aspace->ipc_scratch;
+  if (scratch_load_handle_le64(&p[8])  != sp.read_handle ||
+      scratch_load_handle_le64(&p[16]) != sp.write_handle) {
+    fail("read_write_scratch_handle_mismatch");
+    return;
+  }
+  if (!scratch_top32_zero(&p[8]) || !scratch_top32_zero(&p[16])) {
+    fail("read_write_scratch_top32_nonzero");
+    return;
+  }
+
+  if (cap_gate_check_handle(sp.read_handle,  CAP_FS_READ)  != 1 ||
+      cap_gate_check_handle(sp.write_handle, CAP_FS_WRITE) != 1) {
+    fail("read_write_gate_check_failed");
+    return;
+  }
+  if (cap_handle_owner(sp.read_handle)  != SUBJECT_M2_HELLOAPP ||
+      cap_handle_owner(sp.write_handle) != SUBJECT_M2_HELLOAPP) {
+    fail("read_write_owner_mismatch");
+    return;
+  }
+
+  /* Cross-check: write handle must NOT gate as CAP_FS_READ. */
+  if (cap_gate_check_handle(sp.write_handle, CAP_FS_READ) != 0) {
+    fail("read_write_write_handle_passed_read");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_fs_spawn_handoff_read_write\n");
+}
+
+static void test_revoke_on_destroy(void) {
+  test_setup();
+
+  launcher_manifest_t m = {
+      .subject_id        = SUBJECT_M2_HELLOAPP,
+      .auto_grant_caps   = NULL,
+      .auto_grant_count  = 0,
+  };
+
+  launcher_fs_spawn_t sp;
+  if (launcher_fs_spawn_app_with_fs_caps(&m, 1, &sp) != LAUNCHER_OK) {
+    fail("revoke_setup_failed");
+    return;
+  }
+  if (cap_gate_check_handle(sp.read_handle,  CAP_FS_READ)  != 1 ||
+      cap_gate_check_handle(sp.write_handle, CAP_FS_WRITE) != 1) {
+    fail("revoke_pre_gate_check_failed");
+    return;
+  }
+
+  if (launcher_fs_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("revoke_destroy_returned_nonok");
+    return;
+  }
+  if (cap_gate_check_handle(sp.read_handle,  CAP_FS_READ)  != 0) {
+    fail("revoke_read_handle_still_live");
+    return;
+  }
+  if (cap_gate_check_handle(sp.write_handle, CAP_FS_WRITE) != 0) {
+    fail("revoke_write_handle_still_live");
+    return;
+  }
+
+  /* PID_INVALID stays a no-op. */
+  if (launcher_fs_spawn_destroy(PID_INVALID) != LAUNCHER_OK) {
+    fail("revoke_pid_invalid_not_noop");
+    return;
+  }
+
+  printf("TEST:PASS:launcher_fs_spawn_handoff_revoke_on_destroy\n");
+}
+
+int main(void) {
+  test_read_only();
+  test_read_write();
+  test_revoke_on_destroy();
+
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:launcher_fs_spawn_handoff\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements **M3-SUBSTRATE-002** (slice 2 of plan #277, issue #279): the launcher bridge between the M3 `fs_svc` module (#278) and spawned apps.

Adds `launcher_fs_spawn_app_with_fs_caps(manifest, grant_write, out_spawn)` which:

1. Spawns a real PCB via `process_create()` on a fresh `address_space_t` window carved from the shared launcher arena.
2. Mints a `CAP_FS_READ` cap_handle (always) plus, if requested, a `CAP_FS_WRITE` cap_handle, via `cap_handle_grant()` (#247). The legacy `cap_table_grant()` bitset is kept in sync so audit-trail parity is preserved.
3. Stamps both handles **LE64** into the new PCB's `ipc_scratch` at the offsets reserved by the handoff doc:

```
offset  bytes  meaning
   0      4    M2 console handle (existing, slice 2 of plan #263)
   4      4    reserved
   8      8    LE64(cap_handle_t)  — CAP_FS_READ  (this PR)
  16      8    LE64(cap_handle_t)  — CAP_FS_WRITE (this PR; zero when not granted)
  24     40    reserved
```

The upper 32 bits of each LE64 slot are reserved-zero under `OS_ABI_VERSION = 0` so a future cap-handle width bump can occupy them without shifting offsets.

`launcher_fs_spawn_destroy(pid)` delegates to the shared spawn slot teardown; `process_destroy()`'s `cap_handle_revoke_subject()` cascade (#239) authoritatively invalidates both handles.

## Done-when checklist (issue #279)

- [x] `launcher_fs_spawn_app_with_fs_caps` lands with both grant variants.
- [x] `address_space_t::ipc_scratch[8..23]` convention documented in `docs/architecture/m1-m2-handoff.md`.
- [x] `tests/launcher_fs_spawn_handoff_test.c` lands with all four markers (read_only, read_write, revoke_on_destroy, overall).
- [x] `test.sh launcher_fs_spawn_handoff` + parity allowlist entry.
- [x] Existing launcher / cap-handle / process-table tests stay green unmodified.
- [x] No ABI bump.

## Intentional deviation from issue body

The issue spec asked to "register the spawned PID with launcher_fs so existing per-app fs policy lookups keep working". I deliberately **did not** add a hard `launcher_fs_register_app()` call from `launcher.c`, because:

- Four existing test scripts link `launcher.c` without `launcher_fs.c`: `test_launcher_console.sh`, `test_m2_helloapp_allow_qemu.sh`, `test_m2_helloapp_deny_qemu.sh`, `test_m2_launcher_console_qemu.sh`. A direct call breaks the link with `undefined reference to launcher_fs_register_app`.
- The minted handles authorize the subject against `fs_svc`'s IPC ports via the cap-table gate **directly** — they don't need the launcher_fs ramfs shadow to exist.
- The right place to wire persistence policy is slice 3 (#280) where the manifest persistence enum (#285 / #286) gets consumed; doing it there can either (a) move the registration into a slice-3-only call site, or (b) restructure `launcher_fs` to expose a no-op stub the M2 builds can link against. Either choice is bigger than a slice-2 PR should be making unilaterally.

Code comment in `launcher.h` flags this for slice 3.

## Validation

| Script | Result |
|---|---|
| `test_launcher_fs_spawn_handoff` | **PASS** (4 markers) |
| `test_launcher_spawn_handoff` (M2 sibling) | PASS unchanged |
| `test_launcher_console` | PASS unchanged |
| `test_console_svc_port_alloc` | PASS unchanged |
| `test_fs_svc_port_alloc` (#278 sibling) | PASS unchanged |
| `test_launcher_fs` | PASS unchanged |
| `check_shell_parity.sh` | PARITY:OK |

## Follow-ups (not blocking)

- Slice 3 / #280: wire manifest persistence enum into the spawn path; decide whether `launcher_fs_register_app()` should be called from `launcher_fs_spawn_app_with_fs_caps()` once the link-graph is restructured.
- `.ps1` peer for `test_launcher_fs_spawn_handoff.sh` — tracked under #156 (added to `.shell_parity_allowlist` for now).

_— cron:secureos-hourly-issue-work, 2026-05-24 16:53 UTC_