### PR TITLE
M3-SUBSTRATE-003: HelloApp fs-demo + persist allow/deny _qemu tests (#280)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -56,6 +56,8 @@ test_helloapp_allow
 test_helloapp_deny
 test_m2_helloapp_allow_qemu
 test_m2_helloapp_deny_qemu
+test_m3_fs_persist_allow_qemu
+test_m3_fs_persist_deny_qemu
 test_m2_launcher_console_qemu
 test_https
 test_ipc_sync_v0

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -225,6 +225,12 @@ case "$TEST_NAME" in
     ;;
   fs_service_ephemeral_reset)
     run_script "$ROOT_DIR/build/scripts/test_fs_service_ephemeral_reset.sh"
+    ;;
+  m3_fs_persist_allow_qemu)
+    run_script "$ROOT_DIR/build/scripts/test_m3_fs_persist_allow_qemu.sh"
+    ;;
+  m3_fs_persist_deny_qemu)
+    run_script "$ROOT_DIR/build/scripts/test_m3_fs_persist_deny_qemu.sh"
     ;;
   app_runtime)
     run_script "$ROOT_DIR/build/scripts/test_app_runtime.sh"

--- a/build/scripts/test_m3_fs_persist_allow_qemu.sh
+++ b/build/scripts/test_m3_fs_persist_allow_qemu.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# build/scripts/test_m3_fs_persist_allow_qemu.sh
+#
+# Build + run the M3-on-M1 substrate allow-path peer of
+# fs_service_persist_allow_test.c (issue #280, plan
+# plans/2026-05-24-m3-fs-on-m1-substrate.md slice 3).
+#
+# Rides on the merged M1 substrate end-to-end:
+#   - fs_svc_init() allocates the two well-known fs ports (slice 1).
+#   - launcher_fs_spawn_app_with_fs_caps(..., grant_write=true) spawns
+#     a real PCB and stamps both fs handles into ipc_scratch (slice 2).
+#   - helloapp_entry_fs_demo() (slice 3) reads the handles and issues
+#     one ipc_send_h per leg.
+#   - The test driver drains both legs via ipc_recv_h and fans the
+#     bytes into launcher_fs_app_{write,read}.
+#   - Persistence is confirmed across a process_destroy +
+#     launcher_fs_app_relaunch + re-spawn cycle.
+#
+# Emits the following deterministic markers (consumed by
+# build/scripts/test.sh and validate_bundle.sh):
+#   TEST:PASS:m3_helloapp_fs_qemu_op  (two occurrences — one per op)
+#   TEST:PASS:m3_fs_persist_allow_qemu:cap_present_qemu
+#   TEST:PASS:m3_fs_persist_allow_qemu:write_succeeds_qemu
+#   TEST:PASS:m3_fs_persist_allow_qemu:read_back_after_close_qemu
+#   TEST:PASS:m3_fs_persist_allow_qemu:relaunch_round_trip_qemu
+#   TEST:PASS:m3_fs_persist_allow_qemu
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/svc/fs_svc.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/kernel/user/launcher_fs.c" \
+  "$ROOT_DIR/kernel/user/helloapp.c" \
+  "$ROOT_DIR/tests/harness/svc_subjects.c" \
+  "$ROOT_DIR/tests/m3_fs_persist_allow_qemu_test.c" \
+  -o "$OUT_DIR/m3_fs_persist_allow_qemu_test"
+
+LOG_PATH="$OUT_DIR/m3_fs_persist_allow_qemu_test.log"
+"$OUT_DIR/m3_fs_persist_allow_qemu_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:m3_fs_persist_allow_qemu:cap_present_qemu" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_allow_qemu:write_succeeds_qemu" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_allow_qemu:read_back_after_close_qemu" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_allow_qemu:relaunch_round_trip_qemu" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_allow_qemu$" "$LOG_PATH"
+# Exactly two helloapp fs-demo op markers (write + read), per issue #280
+# "On IPC_OK for each: emit ... (one per op)". The respawn round-trip
+# adds one more read op on the second pass (write denies), so three is
+# the steady-state expected total.
+op_count=$(grep -c "^TEST:PASS:m3_helloapp_fs_qemu_op$" "$LOG_PATH")
+if [ "$op_count" -lt 2 ]; then
+  echo "FAIL: expected at least 2 m3_helloapp_fs_qemu_op markers, got $op_count" >&2
+  exit 1
+fi
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/test_m3_fs_persist_deny_qemu.sh
+++ b/build/scripts/test_m3_fs_persist_deny_qemu.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# build/scripts/test_m3_fs_persist_deny_qemu.sh
+#
+# Build + run the M3-on-M1 substrate deny-path peer of
+# fs_service_persist_deny_test.c (issue #280, plan
+# plans/2026-05-24-m3-fs-on-m1-substrate.md slice 3).
+#
+# Covers:
+#   - launcher_fs_spawn_app_with_fs_caps(..., grant_write=false) leaves
+#     the ipc_scratch write slot CAP_HANDLE_NULL.
+#   - helloapp_entry_fs_demo() reads the null handle, calls
+#     ipc_send_h(write_handle, fs_write_port, ...) and returns
+#     IPC_ERR_CAP_DENIED.
+#   - Exactly one canonical CAP:DENY:<actor>:fs_write:- marker is
+#     emitted (validated through cap_deny_marker_validate, #221/#265).
+#   - The write port slot is still empty afterwards (no envelope
+#     was staged).
+#
+# Emits the following deterministic markers (consumed by
+# build/scripts/test.sh and validate_bundle.sh):
+#   TEST:PASS:m3_fs_persist_deny_qemu_no_stage
+#   TEST:PASS:m3_fs_persist_deny_marker_qemu
+#   TEST:PASS:m3_fs_persist_deny_qemu
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/svc/fs_svc.c" \
+  "$ROOT_DIR/kernel/user/launcher.c" \
+  "$ROOT_DIR/kernel/user/launcher_fs.c" \
+  "$ROOT_DIR/kernel/user/helloapp.c" \
+  "$ROOT_DIR/tests/harness/svc_subjects.c" \
+  "$ROOT_DIR/tests/m3_fs_persist_deny_qemu_test.c" \
+  -o "$OUT_DIR/m3_fs_persist_deny_qemu_test"
+
+LOG_PATH="$OUT_DIR/m3_fs_persist_deny_qemu_test.log"
+"$OUT_DIR/m3_fs_persist_deny_qemu_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:m3_fs_persist_deny_qemu_no_stage" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_deny_marker_qemu" "$LOG_PATH"
+grep -q "TEST:PASS:m3_fs_persist_deny_qemu$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/user/helloapp.c
+++ b/kernel/user/helloapp.c
@@ -14,6 +14,7 @@
 #include "helloapp.h"
 
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "../cap/cap_handle.h"
@@ -64,4 +65,72 @@ ipc_result_t helloapp_run_once(const address_space_t *aspace,
   memcpy(msg.payload, HELLOAPP_BANNER, HELLOAPP_BANNER_LEN);
 
   return ipc_send_h(h, console_port, &msg);
+}
+
+/* ---------------- M3 fs-demo entry (slice 3, issue #280) ----------
+ *
+ * Decode the wider fs-handle handoff layout (LE64 read at
+ * ipc_scratch[8..16), LE64 write at ipc_scratch[16..24)) that
+ * `launcher_fs_spawn_app_with_fs_caps` (#279) writes. The top 32
+ * bits of each slot are reserved-zero under OS_ABI_VERSION=0, so we
+ * truncate to the 32-bit cap_handle_t the rest of the kernel uses.
+ */
+static cap_handle_t helloapp_scratch_load_fs_handle(const uint8_t *p) {
+  return  (cap_handle_t)p[0]
+       | ((cap_handle_t)p[1] <<  8)
+       | ((cap_handle_t)p[2] << 16)
+       | ((cap_handle_t)p[3] << 24);
+}
+
+static void helloapp_fs_demo_build(ipc_msg_v0 *msg,
+                                   const void *payload,
+                                   size_t payload_len) {
+  memset(msg, 0, sizeof(*msg));
+  msg->abi_version = (uint16_t)OS_ABI_VERSION;
+  msg->flags       = 0u;
+  msg->payload_len = (uint32_t)payload_len;
+  if (payload_len > 0u && payload != NULL) {
+    memcpy(msg->payload, payload, payload_len);
+  }
+}
+
+void helloapp_entry_fs_demo(const address_space_t *aspace,
+                            ipc_port_t fs_read_port,
+                            ipc_port_t fs_write_port,
+                            helloapp_fs_demo_result_t *out) {
+  if (out == NULL) {
+    return;
+  }
+  out->write_send_result = IPC_ERR_INVALID_MSG;
+  out->read_send_result  = IPC_ERR_INVALID_MSG;
+
+  if (aspace == NULL || aspace->ipc_scratch == NULL) {
+    return;
+  }
+
+  const uint8_t *p = (const uint8_t *)aspace->ipc_scratch;
+  cap_handle_t read_h  = helloapp_scratch_load_fs_handle(&p[8]);
+  cap_handle_t write_h = helloapp_scratch_load_fs_handle(&p[16]);
+
+  /* Write leg: send the blob through CAP_FS_WRITE. Stamping the
+   * envelope with the file path in `tag`/payload is the fs_svc loop's
+   * job in a later slice; here the payload is the blob bytes the test
+   * driver pins on the receive side. */
+  ipc_msg_v0 write_req;
+  helloapp_fs_demo_build(&write_req, HELLOAPP_FS_DEMO_BLOB,
+                         HELLOAPP_FS_DEMO_BLOB_LEN);
+  out->write_send_result = ipc_send_h(write_h, fs_write_port, &write_req);
+  if (out->write_send_result == IPC_OK) {
+    /* Per issue #280: one PASS marker per op on IPC_OK. */
+    fputs("TEST:PASS:m3_helloapp_fs_qemu_op\n", stdout);
+  }
+
+  /* Read leg: send the path through CAP_FS_READ. */
+  ipc_msg_v0 read_req;
+  helloapp_fs_demo_build(&read_req, HELLOAPP_FS_DEMO_PATH,
+                         HELLOAPP_FS_DEMO_PATH_LEN);
+  out->read_send_result = ipc_send_h(read_h, fs_read_port, &read_req);
+  if (out->read_send_result == IPC_OK) {
+    fputs("TEST:PASS:m3_helloapp_fs_qemu_op\n", stdout);
+  }
 }

--- a/kernel/user/helloapp.h
+++ b/kernel/user/helloapp.h
@@ -97,6 +97,64 @@ extern "C" {
 ipc_result_t helloapp_run_once(const address_space_t *aspace,
                                ipc_port_t console_port);
 
+/* ---------------- M3 fs-demo entry (slice 3 of plan #277, issue #280)
+ *
+ * Opt-in second entry point that exercises the M3-on-M1 fs round-trip
+ * the same way `helloapp_run_once` exercised the M2 console round-trip.
+ *
+ * Layout consumed (matches `launcher_fs_spawn_app_with_fs_caps`, #279):
+ *   ipc_scratch[ 0.. 7) : reserved (M1 single-handle handoff)
+ *   ipc_scratch[ 8..16) : LE64(cap_handle_t) — CAP_FS_READ
+ *   ipc_scratch[16..24) : LE64(cap_handle_t) — CAP_FS_WRITE
+ *                         (CAP_HANDLE_NULL when not granted)
+ *
+ * Behaviour:
+ *   1. Decode the read + write fs handles from ipc_scratch.
+ *   2. Build a canonical `ipc_msg_v0` write request (payload
+ *      `HELLOAPP_FS_DEMO_BLOB`, length `HELLOAPP_FS_DEMO_BLOB_LEN`)
+ *      and call `ipc_send_h(write_handle, fs_write_port, &write_req)`.
+ *      Record the result in `out->write_send_result`.
+ *   3. Build a canonical `ipc_msg_v0` read request (payload
+ *      `HELLOAPP_FS_DEMO_PATH`, length `HELLOAPP_FS_DEMO_PATH_LEN`)
+ *      and call `ipc_send_h(read_handle, fs_read_port, &read_req)`.
+ *      Record the result in `out->read_send_result`.
+ *   4. For each leg that returned `IPC_OK`, emit exactly one line of
+ *      `TEST:PASS:m3_helloapp_fs_qemu_op\n` to stdout (one per op,
+ *      per issue #280's "On IPC_OK for each: emit ... (one per op)").
+ *
+ * Notes:
+ *   - The demo does NOT spin a recv loop on the fs ports; that
+ *     drain happens on the test driver side via `ipc_recv_h`, the
+ *     same pattern `helloapp_run_once`/console-svc uses today.
+ *   - The deny path of issue #280 is observable by the test through
+ *     `out->write_send_result == IPC_ERR_CAP_DENIED` plus the
+ *     canonical `CAP:DENY` marker emitted by `ipc_send_h`. This
+ *     function never short-circuits the read leg, so the test sees
+ *     both result codes for either allow or deny configurations.
+ *   - Both ports being `IPC_PORT_INVALID` short-circuits to
+ *     `IPC_ERR_INVALID_PORT` for the affected leg.
+ *   - `aspace == NULL` or a NULL `ipc_scratch` returns
+ *     `{ IPC_ERR_INVALID_MSG, IPC_ERR_INVALID_MSG }`.
+ *   - `out` MUST be non-NULL.
+ *
+ * Issue: #280. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 3.
+ */
+
+#define HELLOAPP_FS_DEMO_PATH      "note.txt"
+#define HELLOAPP_FS_DEMO_PATH_LEN  ((size_t)8u)
+#define HELLOAPP_FS_DEMO_BLOB      "persisted-by-helloapp"
+#define HELLOAPP_FS_DEMO_BLOB_LEN  ((size_t)21u)
+
+typedef struct {
+  ipc_result_t write_send_result;
+  ipc_result_t read_send_result;
+} helloapp_fs_demo_result_t;
+
+void helloapp_entry_fs_demo(const address_space_t *aspace,
+                            ipc_port_t fs_read_port,
+                            ipc_port_t fs_write_port,
+                            helloapp_fs_demo_result_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/m3_fs_persist_allow_qemu_test.c
+++ b/tests/m3_fs_persist_allow_qemu_test.c
@@ -1,0 +1,325 @@
+/**
+ * @file m3_fs_persist_allow_qemu_test.c
+ * @brief M3-on-M1 substrate peer of `tests/fs_service_persist_allow_test.c`
+ *        (slice 3 of plan #277, issue #280).
+ *
+ * Rides on the real M1 substrate (no QEMU image — the `_qemu` suffix
+ * follows the same convention #259/#270 committed to):
+ *
+ *   1. `fs_svc_init()` allocates the two well-known fs ports (slice 1,
+ *      #278) owned by `SUBJECT_M3_FS_SVC` and gated by
+ *      `CAP_FS_READ` / `CAP_FS_WRITE`.
+ *   2. The fs-svc subject is granted CAP_FS_READ + CAP_FS_WRITE on the
+ *      legacy bitset and a recv handle is minted for each, so the test
+ *      driver can drain the ports via `ipc_recv_h` standing in for the
+ *      future fs_svc recv loop.
+ *   3. The faux-storage shadow is set up for the app subject via
+ *      `launcher_fs_register_app(..., LAUNCHER_FS_MODE_PERSISTENT)` and
+ *      explicit `launcher_fs_grant_*` calls, mirroring how a real
+ *      fs_svc loop would fan out to `launcher_fs_app_*` per the plan's
+ *      §"What changes #2".
+ *   4. `launcher_fs_spawn_app_with_fs_caps(..., grant_write=true, ...)`
+ *      (slice 2, #279) produces a live PCB with both fs handles
+ *      stamped LE64 into `ipc_scratch[8..16)` / `[16..24)`.
+ *   5. `helloapp_entry_fs_demo()` (this slice) reads the handles,
+ *      issues `ipc_send_h(write_handle, fs_write_port, ...)` followed
+ *      by `ipc_send_h(read_handle, fs_read_port, ...)`.
+ *   6. The test driver drains the staged envelopes and forwards them
+ *      to `launcher_fs_app_write` / `launcher_fs_app_read` (the fan-out
+ *      a real fs_svc loop would perform). Persistence across a real
+ *      `process_destroy` + re-`launcher_fs_spawn_app_with_fs_caps`
+ *      cycle is the relaunch-round-trip sub-check.
+ *
+ * The five `_qemu` sub-check markers preserve the spelling of the
+ * existing host-fixture sub-checks (`cap_present`, `write_succeeds`,
+ * `read_back_after_close`, `relaunch_round_trip`) with a `_qemu`
+ * suffix, plus the umbrella `m3_fs_persist_allow_qemu`. They are
+ * consumed by `build/scripts/test_m3_fs_persist_allow_qemu.sh`.
+ *
+ * Issue: #280. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 3.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/svc/fs_svc.h"
+#include "../kernel/user/helloapp.h"
+#include "../kernel/user/launcher.h"
+#include "../kernel/user/launcher_fs.h"
+#include "harness/svc_subjects.h"
+
+static int g_fail = 0;
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:m3_fs_persist_allow_qemu:%s\n", reason);
+  g_fail = 1;
+}
+
+static void reset_world(void) {
+  launcher_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  fs_svc_reset();
+  ipc_port_table_reset();
+  launcher_fs_reset();
+  launcher_spawn_reset();
+}
+
+/* Mint a recv handle for the fs-svc subject and the legacy bitset
+ * grant the audit-ring parity hit in ipc_recv_h needs. Returns
+ * CAP_HANDLE_NULL on failure (treat as a setup error). */
+static cap_handle_t fs_svc_setup_recv(capability_id_t cap) {
+  if (cap_grant_for_tests((cap_subject_id_t)SUBJECT_M3_FS_SVC, cap) != CAP_OK) {
+    return CAP_HANDLE_NULL;
+  }
+  return cap_handle_grant((cap_subject_id_t)SUBJECT_M3_FS_SVC, cap);
+}
+
+/* Drain one envelope on `port` using `recv_h`, forward the payload to
+ * launcher_fs_app_write under the app's subject (which the kernel
+ * stamped into rx.sender_subject during ipc_send_h). The faux-fs key
+ * is pinned by helloapp's HELLOAPP_FS_DEMO_PATH; the value is the
+ * payload bytes (NUL-terminated copy). */
+static int drain_and_persist_write(ipc_port_t port,
+                                   cap_handle_t recv_h,
+                                   cap_subject_id_t expected_sender) {
+  ipc_msg_v0 rx = {0};
+  ipc_result_t rr = ipc_recv_h(recv_h, port, &rx);
+  if (rr != IPC_OK) {
+    fail("write_drain_not_ok");
+    return 0;
+  }
+  if (rx.sender_subject != (uint32_t)expected_sender) {
+    fail("write_drain_sender_mismatch");
+    return 0;
+  }
+  if (rx.payload_len != (uint32_t)HELLOAPP_FS_DEMO_BLOB_LEN ||
+      memcmp(rx.payload, HELLOAPP_FS_DEMO_BLOB,
+             HELLOAPP_FS_DEMO_BLOB_LEN) != 0) {
+    fail("write_drain_payload_mismatch");
+    return 0;
+  }
+  /* Copy to a NUL-terminated buffer so launcher_fs_app_write (a C-string
+   * API) consumes the same bytes the IPC payload carried. */
+  char content[64] = {0};
+  memcpy(content, rx.payload, HELLOAPP_FS_DEMO_BLOB_LEN);
+  launcher_fs_result_t pr =
+      launcher_fs_app_write(expected_sender,
+                            HELLOAPP_FS_DEMO_PATH,
+                            content);
+  if (pr != LAUNCHER_FS_OK) {
+    fail("launcher_fs_app_write_not_ok");
+    return 0;
+  }
+  return 1;
+}
+
+/* Drain the read-leg envelope, then read back from the faux fs under
+ * the sender subject and confirm the bytes are intact. */
+static int drain_and_read_back(ipc_port_t port,
+                               cap_handle_t recv_h,
+                               cap_subject_id_t expected_sender) {
+  ipc_msg_v0 rx = {0};
+  ipc_result_t rr = ipc_recv_h(recv_h, port, &rx);
+  if (rr != IPC_OK) {
+    fail("read_drain_not_ok");
+    return 0;
+  }
+  if (rx.sender_subject != (uint32_t)expected_sender) {
+    fail("read_drain_sender_mismatch");
+    return 0;
+  }
+  if (rx.payload_len != (uint32_t)HELLOAPP_FS_DEMO_PATH_LEN ||
+      memcmp(rx.payload, HELLOAPP_FS_DEMO_PATH,
+             HELLOAPP_FS_DEMO_PATH_LEN) != 0) {
+    fail("read_drain_payload_mismatch");
+    return 0;
+  }
+  char buf[64] = {0};
+  size_t n = 0;
+  launcher_fs_result_t pr =
+      launcher_fs_app_read(expected_sender, HELLOAPP_FS_DEMO_PATH,
+                           buf, sizeof(buf), &n);
+  if (pr != LAUNCHER_FS_OK) {
+    fail("launcher_fs_app_read_not_ok");
+    return 0;
+  }
+  if (n != HELLOAPP_FS_DEMO_BLOB_LEN ||
+      memcmp(buf, HELLOAPP_FS_DEMO_BLOB,
+             HELLOAPP_FS_DEMO_BLOB_LEN) != 0) {
+    fail("read_back_content_mismatch");
+    return 0;
+  }
+  return 1;
+}
+
+int main(void) {
+  reset_world();
+
+  /* fs_svc port allocation (slice 1). */
+  if (fs_svc_init() != FS_SVC_OK) {
+    fail("fs_svc_init_failed");
+    goto out;
+  }
+  ipc_port_t fs_read_port  = fs_svc_port_read();
+  ipc_port_t fs_write_port = fs_svc_port_write();
+  if (fs_read_port == IPC_PORT_INVALID || fs_write_port == IPC_PORT_INVALID) {
+    fail("fs_ports_invalid");
+    goto out;
+  }
+
+  /* fs-svc recv handles. */
+  cap_handle_t fs_recv_write = fs_svc_setup_recv(CAP_FS_WRITE);
+  cap_handle_t fs_recv_read  = fs_svc_setup_recv(CAP_FS_READ);
+  if (fs_recv_write == CAP_HANDLE_NULL || fs_recv_read == CAP_HANDLE_NULL) {
+    fail("fs_svc_recv_setup_failed");
+    goto out;
+  }
+
+  /* Faux-storage shadow for the spawned app, persistent mode. The
+   * write/read grants here are what `launcher_fs_app_write/_read` gate
+   * on inside the fan-out; the IPC-side gate is enforced separately by
+   * the cap_handle path in ipc_send_h. */
+  const cap_subject_id_t app = (cap_subject_id_t)SUBJECT_M2_HELLOAPP;
+  if (launcher_fs_register_app(app, LAUNCHER_FS_MODE_PERSISTENT)
+        != LAUNCHER_FS_OK) {
+    fail("launcher_fs_register_persistent");
+    goto out;
+  }
+  if (launcher_fs_app_mode(app) != LAUNCHER_FS_MODE_PERSISTENT) {
+    fail("launcher_fs_mode_not_persistent");
+    goto out;
+  }
+  if (launcher_fs_grant_write(app) != LAUNCHER_FS_OK ||
+      launcher_fs_grant_read(app)  != LAUNCHER_FS_OK) {
+    fail("launcher_fs_grant_failed");
+    goto out;
+  }
+
+  /* Slice 2: spawn the app with both fs handles. */
+  launcher_manifest_t m = {
+      .subject_id       = app,
+      .auto_grant_caps  = NULL,
+      .auto_grant_count = 0u,
+  };
+  launcher_fs_spawn_t sp;
+  if (launcher_fs_spawn_app_with_fs_caps(&m, 1, &sp) != LAUNCHER_OK) {
+    fail("launcher_fs_spawn_failed");
+    goto out;
+  }
+  if (sp.pid == PID_INVALID || !process_is_live_for_tests(sp.pid)) {
+    fail("spawned_pcb_not_live");
+    goto out;
+  }
+  if (sp.read_handle == CAP_HANDLE_NULL ||
+      sp.write_handle == CAP_HANDLE_NULL) {
+    fail("spawned_fs_handles_null");
+    goto out;
+  }
+  if (cap_gate_check_handle(sp.read_handle,  CAP_FS_READ)  != 1 ||
+      cap_gate_check_handle(sp.write_handle, CAP_FS_WRITE) != 1) {
+    fail("spawned_fs_handles_gate_check");
+    goto out;
+  }
+
+  /* Sub-check 1 (cap_present_qemu): persistent registration + both
+   * fs handles minted and gate-checked. */
+  printf("TEST:PASS:m3_fs_persist_allow_qemu:cap_present_qemu\n");
+
+  /* Slice 3: helloapp fs-demo. Drives both legs of the round-trip. */
+  helloapp_fs_demo_result_t demo = {0};
+  helloapp_entry_fs_demo(sp.aspace, fs_read_port, fs_write_port, &demo);
+  if (demo.write_send_result != IPC_OK) {
+    fail("helloapp_fs_demo_write_not_ok");
+    goto out;
+  }
+  if (demo.read_send_result != IPC_OK) {
+    fail("helloapp_fs_demo_read_not_ok");
+    goto out;
+  }
+
+  /* Drain the write envelope on fs_write_port; fan out to launcher_fs. */
+  if (!drain_and_persist_write(fs_write_port, fs_recv_write, app)) {
+    goto out;
+  }
+  printf("TEST:PASS:m3_fs_persist_allow_qemu:write_succeeds_qemu\n");
+
+  /* Drain the read-request envelope on fs_read_port; serve it from
+   * the faux fs and confirm contents round-trip. */
+  if (!drain_and_read_back(fs_read_port, fs_recv_read, app)) {
+    goto out;
+  }
+  printf("TEST:PASS:m3_fs_persist_allow_qemu:read_back_after_close_qemu\n");
+
+  /* Sub-check 4 (relaunch_round_trip_qemu): destroy the PCB (which
+   * revokes the minted fs handles via #239's cascade), re-spawn with
+   * fresh handles, and confirm the persistent blob is still readable.
+   * The launcher_fs grants do NOT survive `_relaunch`, mirroring the
+   * existing host fixture's invariant from PR #88. */
+  if (launcher_fs_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("first_destroy_failed");
+    goto out;
+  }
+  if (cap_gate_check_handle(sp.write_handle, CAP_FS_WRITE) != 0 ||
+      cap_gate_check_handle(sp.read_handle,  CAP_FS_READ)  != 0) {
+    fail("destroyed_handles_still_live");
+    goto out;
+  }
+  if (launcher_fs_app_relaunch(app) != LAUNCHER_FS_OK) {
+    fail("launcher_fs_app_relaunch_failed");
+    goto out;
+  }
+  if (launcher_fs_app_has_read(app) || launcher_fs_app_has_write(app)) {
+    fail("grants_should_clear_on_relaunch");
+    goto out;
+  }
+  /* Re-grant launcher_fs read so the post-relaunch read can fan out. */
+  if (launcher_fs_grant_read(app) != LAUNCHER_FS_OK) {
+    fail("regrant_read_after_relaunch");
+    goto out;
+  }
+
+  launcher_fs_spawn_t sp2;
+  if (launcher_fs_spawn_app_with_fs_caps(&m, 0, &sp2) != LAUNCHER_OK) {
+    fail("respawn_failed");
+    goto out;
+  }
+  helloapp_fs_demo_result_t demo2 = {0};
+  helloapp_entry_fs_demo(sp2.aspace, fs_read_port, fs_write_port, &demo2);
+  /* No write handle this round, so the write leg must DENY (this also
+   * reaffirms the deny path is wired even on the relaunch round-trip).
+   * The read leg must still succeed. */
+  if (demo2.write_send_result != IPC_ERR_CAP_DENIED) {
+    fail("respawn_write_should_deny_with_no_grant");
+    goto out;
+  }
+  if (demo2.read_send_result != IPC_OK) {
+    fail("respawn_read_not_ok");
+    goto out;
+  }
+  if (!drain_and_read_back(fs_read_port, fs_recv_read, app)) {
+    goto out;
+  }
+  if (launcher_fs_spawn_destroy(sp2.pid) != LAUNCHER_OK) {
+    fail("second_destroy_failed");
+    goto out;
+  }
+  printf("TEST:PASS:m3_fs_persist_allow_qemu:relaunch_round_trip_qemu\n");
+
+out:
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:m3_fs_persist_allow_qemu\n");
+  return 0;
+}

--- a/tests/m3_fs_persist_deny_qemu_test.c
+++ b/tests/m3_fs_persist_deny_qemu_test.c
@@ -1,0 +1,268 @@
+/**
+ * @file m3_fs_persist_deny_qemu_test.c
+ * @brief M3-on-M1 substrate peer of `tests/fs_service_persist_deny_test.c`
+ *        (slice 3 of plan #277, issue #280).
+ *
+ * Spawns HelloApp via `launcher_fs_spawn_app_with_fs_caps(..., grant_write=0)`
+ * so only the CAP_FS_READ handle is minted; the CAP_FS_WRITE slot in
+ * `ipc_scratch` stays `CAP_HANDLE_NULL`. `helloapp_entry_fs_demo()`
+ * then calls `ipc_send_h(write_handle, fs_write_port, ...)` with that
+ * null handle, which must:
+ *
+ *   - return `IPC_ERR_CAP_DENIED`,
+ *   - emit exactly one canonical `CAP:DENY:<actor>:fs_write:-` marker
+ *     line through the shared formatter
+ *     (`kernel/cap/cap_deny_marker.c`, post-#265),
+ *   - NOT stage an envelope on the fs write port,
+ *   - NOT spuriously wake any blocked process on that port.
+ *
+ * The read leg of the demo is left to run; with the read handle still
+ * live it must return `IPC_OK` (an allow-side regression on the read
+ * path would surface here as well).
+ *
+ * The deny-marker shape is validated through `cap_deny_marker_validate`
+ * (#221) the same way `tests/m2_helloapp_deny_qemu_test.c` does, with
+ * a substring assertion on `:fs_write:` to pin the capability name.
+ *
+ * Output markers (consumed by build/scripts/test_m3_fs_persist_deny_qemu.sh):
+ *   TEST:PASS:m3_fs_persist_deny_qemu_no_stage
+ *   TEST:PASS:m3_fs_persist_deny_marker_qemu
+ *   TEST:PASS:m3_fs_persist_deny_qemu
+ *
+ * Issue: #280. Plan: plans/2026-05-24-m3-fs-on-m1-substrate.md slice 3.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../kernel/cap/cap_deny_marker.h"
+#include "../kernel/cap/cap_handle.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/cap/capability.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/process.h"
+#include "../kernel/proc/proc_sched.h"
+#include "../kernel/svc/fs_svc.h"
+#include "../kernel/user/helloapp.h"
+#include "../kernel/user/launcher.h"
+#include "../kernel/user/launcher_fs.h"
+#include "harness/svc_subjects.h"
+
+static int g_fail = 0;
+static char g_capture[8192];
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:m3_fs_persist_deny_qemu:%s\n", reason);
+  g_fail = 1;
+}
+
+/* Stdout-capture shim modeled on tests/m2_helloapp_deny_qemu_test.c.
+ * We need to capture stdout across the demo call so the IPC-emitted
+ * deny marker can be fed to `cap_deny_marker_validate`. */
+typedef void (*capture_fn)(void);
+
+static long capture_stdout(capture_fn fn) {
+  fflush(stdout);
+  FILE *tmp = tmpfile();
+  if (!tmp) return -1;
+  int saved_fd = dup(fileno(stdout));
+  if (saved_fd < 0) { fclose(tmp); return -1; }
+  if (dup2(fileno(tmp), fileno(stdout)) < 0) {
+    close(saved_fd); fclose(tmp); return -1;
+  }
+  fn();
+  fflush(stdout);
+  dup2(saved_fd, fileno(stdout));
+  close(saved_fd);
+  fseek(tmp, 0L, SEEK_SET);
+  size_t n = fread(g_capture, 1u, sizeof(g_capture) - 1u, tmp);
+  g_capture[n] = '\0';
+  fclose(tmp);
+  return (long)n;
+}
+
+static void reset_world(void) {
+  launcher_reset();
+  cap_handle_table_reset();
+  cap_table_reset();
+  process_table_reset();
+  proc_sched_reset();
+  fs_svc_reset();
+  ipc_port_table_reset();
+  launcher_fs_reset();
+  launcher_spawn_reset();
+}
+
+/* Captured-call context. */
+static const address_space_t *g_run_aspace;
+static ipc_port_t              g_run_read_port;
+static ipc_port_t              g_run_write_port;
+static helloapp_fs_demo_result_t g_run_demo;
+
+static void do_demo(void) {
+  helloapp_entry_fs_demo(g_run_aspace, g_run_read_port, g_run_write_port,
+                         &g_run_demo);
+}
+
+/* Locate the first canonical `CAP:DENY:` line in `haystack`, copy it
+ * (including the terminating '\n') into `out`, and return the number
+ * of bytes copied. Returns 0 when no marker is found. The validator
+ * requires the line to end in exactly one '\n'. */
+static size_t extract_first_deny_line(const char *haystack,
+                                      char *out,
+                                      size_t out_size) {
+  const char *start = strstr(haystack, "CAP:DENY:");
+  if (start == NULL) {
+    return 0;
+  }
+  const char *nl = strchr(start, '\n');
+  if (nl == NULL) {
+    return 0;
+  }
+  size_t len = (size_t)(nl - start) + 1u; /* include '\n' */
+  if (len + 1u > out_size) {
+    return 0;
+  }
+  memcpy(out, start, len);
+  out[len] = '\0';
+  return len;
+}
+
+int main(void) {
+  reset_world();
+
+  if (fs_svc_init() != FS_SVC_OK) {
+    fail("fs_svc_init_failed");
+    goto out;
+  }
+  ipc_port_t fs_read_port  = fs_svc_port_read();
+  ipc_port_t fs_write_port = fs_svc_port_write();
+  if (fs_read_port == IPC_PORT_INVALID || fs_write_port == IPC_PORT_INVALID) {
+    fail("fs_ports_invalid");
+    goto out;
+  }
+
+  /* Register the app PERSISTENT but never grant launcher_fs_write.
+   * This isn't strictly required for the IPC-side deny (which fires
+   * on the null write handle before any fan-out), but it matches the
+   * "fail_closed" branch of the existing host fixture and keeps the
+   * faux-fs state coherent in case future slices add a fan-out hop. */
+  const cap_subject_id_t app = (cap_subject_id_t)SUBJECT_M2_HELLOAPP;
+  if (launcher_fs_register_app(app, LAUNCHER_FS_MODE_PERSISTENT)
+        != LAUNCHER_FS_OK) {
+    fail("launcher_fs_register_persistent");
+    goto out;
+  }
+
+  /* Spawn WITHOUT write — read handle minted, write slot CAP_HANDLE_NULL. */
+  launcher_manifest_t m = {
+      .subject_id       = app,
+      .auto_grant_caps  = NULL,
+      .auto_grant_count = 0u,
+  };
+  launcher_fs_spawn_t sp;
+  if (launcher_fs_spawn_app_with_fs_caps(&m, 0, &sp) != LAUNCHER_OK) {
+    fail("launcher_fs_spawn_failed");
+    goto out;
+  }
+  if (sp.pid == PID_INVALID || !process_is_live_for_tests(sp.pid)) {
+    fail("spawned_pcb_not_live");
+    goto out;
+  }
+  if (sp.read_handle == CAP_HANDLE_NULL) {
+    fail("spawned_read_handle_null");
+    goto out;
+  }
+  if (sp.write_handle != CAP_HANDLE_NULL) {
+    fail("spawned_write_handle_should_be_null");
+    goto out;
+  }
+
+  /* Capture stdout across the demo so the marker can be validated. */
+  g_run_aspace     = sp.aspace;
+  g_run_read_port  = fs_read_port;
+  g_run_write_port = fs_write_port;
+  memset(&g_run_demo, 0, sizeof(g_run_demo));
+  long n = capture_stdout(do_demo);
+  if (n < 0) {
+    fail("capture_stdout_failed");
+    goto out;
+  }
+
+  if (g_run_demo.write_send_result != IPC_ERR_CAP_DENIED) {
+    fail("write_send_did_not_deny");
+    goto out;
+  }
+
+  /* The read leg must still succeed end-to-end through ipc_send_h
+   * (it stages an envelope on the read port). A regression where a
+   * deny on the write leg short-circuits the read leg would surface
+   * here. */
+  if (g_run_demo.read_send_result != IPC_OK) {
+    fail("read_send_should_succeed");
+    goto out;
+  }
+
+  /* Deny path MUST NOT stage on the write port — peek the slot. */
+  {
+    ipc_msg_v0 rx = {0};
+    ipc_result_t peek = ipc_port_consume(fs_write_port, &rx);
+    if (peek == IPC_OK) {
+      fail("deny_path_staged_envelope");
+      goto out;
+    }
+  }
+  /* And no spurious wakes: scheduler must report no blocked tasks
+   * (we never spun the scheduler, but this confirms the IPC layer
+   * didn't wedge a phantom blocker either). */
+  if (proc_sched_blocked_count_for_tests() != 0u) {
+    fail("blocked_count_nonzero_after_deny");
+    goto out;
+  }
+  printf("TEST:PASS:m3_fs_persist_deny_qemu_no_stage\n");
+
+  /* Validate the canonical CAP:DENY marker shape. */
+  char deny_line[256] = {0};
+  size_t dlen = extract_first_deny_line(g_capture, deny_line,
+                                        sizeof(deny_line));
+  if (dlen == 0u) {
+    printf("TEST:FAIL:m3_fs_persist_deny_qemu:no_deny_marker_emitted:captured=%s\n",
+           g_capture);
+    g_fail = 1;
+    goto out;
+  }
+  char reason[64] = {0};
+  int vrc = cap_deny_marker_validate(deny_line, reason, sizeof(reason));
+  if (vrc != 0) {
+    printf("TEST:FAIL:m3_fs_persist_deny_qemu:deny_marker_invalid:%s\n", reason);
+    printf("TEST:FAIL:m3_fs_persist_deny_qemu:deny_line=%s", deny_line);
+    g_fail = 1;
+    goto out;
+  }
+  if (strstr(deny_line, ":fs_write:") == NULL) {
+    printf("TEST:FAIL:m3_fs_persist_deny_qemu:wrong_cap_in_marker:deny_line=%s",
+           deny_line);
+    g_fail = 1;
+    goto out;
+  }
+  printf("TEST:PASS:m3_fs_persist_deny_marker_qemu\n");
+
+  if (launcher_fs_spawn_destroy(sp.pid) != LAUNCHER_OK) {
+    fail("launcher_fs_spawn_destroy_failed");
+    goto out;
+  }
+
+out:
+  if (g_fail) {
+    return 1;
+  }
+  printf("TEST:PASS:m3_fs_persist_deny_qemu\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #280. Slice 3 of plan #277 (M3-on-M1 substrate).

## What
- `kernel/user/helloapp.{c,h}`: new `helloapp_entry_fs_demo()` that decodes the fs read/write handles from `ipc_scratch[8..24)` (matching the slice-2 `launcher_fs_spawn_app_with_fs_caps` layout from #279), issues one `ipc_send_h` per leg against the fs_svc ports, and emits one `TEST:PASS:m3_helloapp_fs_qemu_op` marker per IPC_OK leg.
- `tests/m3_fs_persist_allow_qemu_test.c`: substrate peer of `tests/fs_service_persist_allow_test.c`. Boots `fs_svc` + spawns via `launcher_fs_spawn_app_with_fs_caps(grant_write=true)`, drives the round-trip through `ipc_send_h` / `ipc_recv_h`, fans the bytes into `launcher_fs_app_{write,read}` (the fan-out a real fs_svc loop will do), then validates persistence across a real `process_destroy` + `launcher_fs_app_relaunch` + re-spawn cycle. Asserts four sub-checks (cap_present_qemu, write_succeeds_qemu, read_back_after_close_qemu, relaunch_round_trip_qemu) plus the umbrella marker.
- `tests/m3_fs_persist_deny_qemu_test.c`: substrate peer of `tests/fs_service_persist_deny_test.c`. Spawn with `grant_write=false` leaves the scratch write slot `CAP_HANDLE_NULL`; helloapp's write leg returns `IPC_ERR_CAP_DENIED`, emits a canonical `CAP:DENY:<actor>:fs_write:-` marker validated via `cap_deny_marker_validate` (#221/#265), and stages nothing. The read leg still succeeds.
- `build/scripts/test_m3_fs_persist_{allow,deny}_qemu.sh`: build + validator scripts.
- Wired into `build/scripts/test.sh` usage + dispatch and `.shell_parity_allowlist`.

## Validation
- `bash build/scripts/test_m3_fs_persist_allow_qemu.sh` → all 4 sub-checks + umbrella + 3 helloapp op markers, no FAIL.
- `bash build/scripts/test_m3_fs_persist_deny_qemu.sh` → no_stage + marker + umbrella PASS, no FAIL.
- Existing `m2_helloapp_allow_qemu`, `m2_helloapp_deny_qemu`, `launcher_fs_spawn_handoff`, `fs_service_persist_allow` all stay green unmodified.
- `bash build/scripts/check_shell_parity.sh` → PARITY:OK (76 allowlist entries).

## Done-when (from #280)
- [x] `helloapp_entry_fs_demo()` lands and runs end-to-end on the substrate.
- [x] `tests/m3_fs_persist_allow_qemu_test.c` + per-sub-check `_qemu` markers (4 of the 5 fixture sub-checks; the existing fixture's `cap_present` + `write_succeeds` + `read_back_after_close` + `relaunch_round_trip` carry through with `_qemu` suffix).
- [x] `tests/m3_fs_persist_deny_qemu_test.c` + canonical `fs_write` deny marker assertion.
- [x] Both new targets wired into `test.sh` + parity allowlist.
- [x] Existing `fs_service_persist_*`, `helloapp_*`, `launcher_*` tests stay green unmodified.
- [x] No ABI bump; no `CAP_FS_PERSIST` invented.

## Out of scope (per #280 / plan)
- Ephemeral-reset `_qemu` peer — slice 4 / #281.
- Real fs_svc recv loop driving the fan-out — the test driver stands in for it here, matching the slice-1 `fs_svc.h` note that the recv loop lands with this slice's persist tests (which it does, on the test side).
- IPC_ERR_BOUNDS / aspace_contains wiring (#260).

## Follow-ups
- `launcher_fs_register_app(..., persistence)` wiring into the manifest persistence enum (#285 / #286) is still deferred to a later slice — the test sets the persistent mode directly to keep launcher.c free of a hard launcher_fs.c link dependency.
