### PR TITLE
proc: process_find_aspace_by_subject() helper for IPC bounds wiring (refs #260)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -36,6 +36,7 @@ test_cap_handle_repr
 test_cap_handle_revoke_subject
 test_cap_handle_revoke_subtree
 test_process_table
+test_process_find_aspace_by_subject
 test_proc_sched
 test_proc_sched_aspace_invariant
 test_aspace_carve

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -117,6 +117,9 @@ case "$TEST_NAME" in
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"
+    ;;
+  process_find_aspace_by_subject)
+    run_script "$ROOT_DIR/build/scripts/test_process_find_aspace_by_subject.sh"
     ;;
   proc_sched)
     run_script "$ROOT_DIR/build/scripts/test_proc_sched.sh"

--- a/build/scripts/test_process_find_aspace_by_subject.sh
+++ b/build/scripts/test_process_find_aspace_by_subject.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build + run the host-side test for process_find_aspace_by_subject()
+# (issue #260 — IPC bounds-check prerequisite helper).
+#
+# Mirrors test_process_table.sh shape: compile the helper's TU plus its
+# transitive cap deps, run, scan log for deterministic PASS markers,
+# reject any FAIL marker.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/tests/process_find_aspace_by_subject_test.c" \
+  -o "$OUT_DIR/process_find_aspace_by_subject_test"
+
+LOG_PATH="$OUT_DIR/process_find_aspace_by_subject_test.log"
+"$OUT_DIR/process_find_aspace_by_subject_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:process_find_aspace_by_subject:hit_returns_stored_aspace" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject:miss_returns_null" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject:subject_zero_returns_null" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject:destroy_then_miss" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject:multiple_subjects_first_wins" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject:null_aspace_returns_null" "$LOG_PATH"
+grep -q "TEST:PASS:process_find_aspace_by_subject$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -197,6 +197,27 @@ bool process_is_live_for_tests(process_id_t pid) {
   return resolve(pid) != NULL;
 }
 
+address_space_t *process_find_aspace_by_subject(cap_subject_id_t subject) {
+  /* Subject 0 is the v0 "unknown / unset" sentinel: callers must never
+   * see a non-NULL aspace for it. process_create stores whatever the
+   * caller passes (including 0), so we filter here rather than at
+   * create-time to avoid changing process_create's documented
+   * contract. */
+  if (subject == 0u) {
+    return NULL;
+  }
+  if (!g_table_initialized) {
+    return NULL;
+  }
+  for (uint16_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    process_slot_t *slot = &g_procs[i];
+    if (slot->live && slot->subject == subject) {
+      return slot->aspace;
+    }
+  }
+  return NULL;
+}
+
 /* ---------------- slice-3 (#250) mutator accessors ---------------- */
 
 proc_result_t process_set_state(process_id_t pid, process_state_t state) {

--- a/kernel/proc/process.h
+++ b/kernel/proc/process.h
@@ -192,6 +192,37 @@ proc_result_t process_lookup(process_id_t pid, process_t *out_proc);
  */
 bool process_is_live_for_tests(process_id_t pid);
 
+/*
+ * Resolve the `address_space_t *` bound to the live PCB whose
+ * `subject` field equals `subject`. Returns the stored pointer on hit
+ * (which may itself be NULL — `address_space` is optional in v0) and
+ * NULL on miss (no live PCB with that subject).
+ *
+ * This is the M1 substitute for a "current process / current
+ * address-space" lookup at IPC entry. It is needed by the runtime
+ * bounds-enforcement work in issue #260 (IPC `aspace_contains` half),
+ * which has to ground `aspace_contains(...)` on the caller's window
+ * but has nothing else to key on from the existing `ipc_send` /
+ * `ipc_recv` signatures (`cap_subject_id_t` only).
+ *
+ * Semantics:
+ *   - O(n) linear scan over PROC_TABLE_MAX. PROC_TABLE_MAX = 16 in v0
+ *     so this is bounded and constant w.r.t. workload.
+ *   - `subject == 0` always returns NULL (the v0 "unknown subject"
+ *     sentinel is never live in the table — see process_create).
+ *   - First live match wins. In M1 the (subject -> PCB) mapping is 1:1
+ *     at any instant by convention (one subject per PCB at
+ *     process_create; process_destroy clears it). If a caller violates
+ *     that convention the lookup is still well-defined but the
+ *     returned aspace belongs to whichever slot was scanned first.
+ *   - Stateless: does not mutate the table or any generation counter.
+ *
+ * Strictly additive: no existing call site is moved onto this helper
+ * by this slice. Callers who need bounds-checking against a live PCB
+ * (the IPC wiring in #260) opt in explicitly.
+ */
+address_space_t *process_find_aspace_by_subject(cap_subject_id_t subject);
+
 /* ----------------------------------------------------------------
  * Slice-3 (#250) mutator accessors used by kernel/proc/proc_sched.{c,h}
  * to drive the cooperative-scheduler state machine without exposing

--- a/tests/process_find_aspace_by_subject_test.c
+++ b/tests/process_find_aspace_by_subject_test.c
@@ -1,0 +1,171 @@
+/**
+ * @file process_find_aspace_by_subject_test.c
+ * @brief Lookup-by-subject helper for the M1 process table
+ *        (issue #260, IPC bounds-check prerequisite).
+ *
+ * Purpose:
+ *   Exercises `process_find_aspace_by_subject(...)`, the M1 substitute
+ *   for a "current process / current address-space" lookup at IPC
+ *   entry. The IPC bounds-check half of #260 needs to ground
+ *   `aspace_contains(...)` on the caller's window but has nothing else
+ *   to key on from `ipc_send` / `ipc_recv` signatures (`cap_subject_id_t`
+ *   only). This helper is the bridge.
+ *
+ *   The IPC wiring itself is intentionally not in this slice — that
+ *   half of #260 is still pending a marker-grammar / ABI design call
+ *   (see the issue's most recent design-clarification comment). This
+ *   slice is strictly additive and unblocks the wiring without locking
+ *   in any of the open decisions.
+ *
+ * Covered cases (each emits exactly one TEST:PASS marker on success;
+ * any failure path emits a TEST:FAIL marker and exits non-zero):
+ *
+ *   1. hit_returns_stored_aspace        — create with sentinel aspace,
+ *      lookup returns identical pointer.
+ *   2. miss_returns_null                — unrelated subject returns NULL.
+ *   3. subject_zero_returns_null        — the v0 unknown-subject
+ *      sentinel always misses, even after a create with subject 0.
+ *   4. destroy_then_miss                — destroy clears the row; the
+ *      same subject no longer resolves.
+ *   5. multiple_subjects_first_wins     — two live PCBs with distinct
+ *      subjects each resolve to their own aspace.
+ *   6. null_aspace_returns_null         — a create with NULL aspace
+ *      resolves to NULL (the hit case is still observable: the slot
+ *      is occupied, the stored pointer is just NULL).
+ *
+ * Launched by:
+ *   build/scripts/test_process_find_aspace_by_subject.sh
+ *   (dispatched via build/scripts/test.sh process_find_aspace_by_subject).
+ *
+ * Issue: #260.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/proc/process.h"
+
+static void die(const char *reason) {
+  printf("TEST:FAIL:process_find_aspace_by_subject:%s\n", reason);
+  exit(1);
+}
+
+static void reset_world(void) {
+  process_table_reset();
+}
+
+static process_id_t create_or_die(cap_subject_id_t subject,
+                                  address_space_t *aspace,
+                                  const char *where) {
+  process_id_t pid = PID_INVALID;
+  proc_result_t rc = process_create(subject, aspace, &pid);
+  if (rc != PROC_OK || pid == PID_INVALID) {
+    die(where);
+  }
+  return pid;
+}
+
+static void check_hit_returns_stored_aspace(void) {
+  reset_world();
+  address_space_t *sentinel = (address_space_t *)(uintptr_t)0xCAFEBABEu;
+  (void)create_or_die((cap_subject_id_t)42u, sentinel, "create_for_hit");
+
+  address_space_t *got = process_find_aspace_by_subject((cap_subject_id_t)42u);
+  if (got != sentinel) {
+    die("hit_did_not_return_stored_pointer");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:hit_returns_stored_aspace\n");
+}
+
+static void check_miss_returns_null(void) {
+  reset_world();
+  address_space_t *sentinel = (address_space_t *)(uintptr_t)0xDEADBEEFu;
+  (void)create_or_die((cap_subject_id_t)7u, sentinel, "create_for_miss");
+
+  if (process_find_aspace_by_subject((cap_subject_id_t)999u) != NULL) {
+    die("miss_did_not_return_null");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:miss_returns_null\n");
+}
+
+static void check_subject_zero_returns_null(void) {
+  reset_world();
+  /* Even if a caller manages to wedge subject 0 into the table, the
+   * sentinel must not resolve. Documented as the v0 "unknown / unset"
+   * sentinel in process.h. */
+  address_space_t *sentinel = (address_space_t *)(uintptr_t)0xF00DBABEu;
+  (void)create_or_die((cap_subject_id_t)0u, sentinel, "create_with_subject_zero");
+
+  if (process_find_aspace_by_subject((cap_subject_id_t)0u) != NULL) {
+    die("subject_zero_resolved");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:subject_zero_returns_null\n");
+}
+
+static void check_destroy_then_miss(void) {
+  reset_world();
+  address_space_t *sentinel = (address_space_t *)(uintptr_t)0xABCD1234u;
+  process_id_t pid = create_or_die((cap_subject_id_t)11u, sentinel,
+                                   "create_for_destroy");
+
+  if (process_find_aspace_by_subject((cap_subject_id_t)11u) != sentinel) {
+    die("pre_destroy_hit_missing");
+  }
+  if (process_destroy(pid) != PROC_OK) {
+    die("destroy_failed");
+  }
+  if (process_find_aspace_by_subject((cap_subject_id_t)11u) != NULL) {
+    die("post_destroy_still_resolves");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:destroy_then_miss\n");
+}
+
+static void check_multiple_subjects_each_resolves(void) {
+  reset_world();
+  address_space_t *a = (address_space_t *)(uintptr_t)0xA0A0A0A0u;
+  address_space_t *b = (address_space_t *)(uintptr_t)0xB0B0B0B0u;
+  (void)create_or_die((cap_subject_id_t)21u, a, "create_a");
+  (void)create_or_die((cap_subject_id_t)22u, b, "create_b");
+
+  if (process_find_aspace_by_subject((cap_subject_id_t)21u) != a) {
+    die("subject_21_wrong_aspace");
+  }
+  if (process_find_aspace_by_subject((cap_subject_id_t)22u) != b) {
+    die("subject_22_wrong_aspace");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:multiple_subjects_first_wins\n");
+}
+
+static void check_null_aspace_returns_null(void) {
+  reset_world();
+  /* A create with NULL aspace still occupies a slot. The lookup
+   * returns NULL not because of a miss, but because the stored
+   * pointer is NULL. That is the v0-correct behaviour: the IPC
+   * bounds wiring (#260) treats NULL aspace as "no PCB-keyed bounds
+   * check available", and this case round-trips the same value. */
+  (void)create_or_die((cap_subject_id_t)33u, NULL, "create_with_null_aspace");
+
+  if (process_find_aspace_by_subject((cap_subject_id_t)33u) != NULL) {
+    die("null_aspace_did_not_return_null");
+  }
+  /* Sanity: the slot really is occupied. Asking for an unrelated
+   * subject should also be NULL (i.e. we are not accidentally
+   * conflating "miss" with "hit-but-null"). */
+  if (process_find_aspace_by_subject((cap_subject_id_t)34u) != NULL) {
+    die("unrelated_subject_resolved");
+  }
+  printf("TEST:PASS:process_find_aspace_by_subject:null_aspace_returns_null\n");
+}
+
+int main(void) {
+  check_hit_returns_stored_aspace();
+  check_miss_returns_null();
+  check_subject_zero_returns_null();
+  check_destroy_then_miss();
+  check_multiple_subjects_each_resolves();
+  check_null_aspace_returns_null();
+  printf("TEST:PASS:process_find_aspace_by_subject\n");
+  return 0;
+}


### PR DESCRIPTION
## What

Adds `address_space_t *process_find_aspace_by_subject(cap_subject_id_t)` — the M1 substitute for a "current process / current address-space" lookup at IPC entry. This is the option-(a) helper the most recent cron comment on #260 flagged as a blocker for the IPC bounds-enforcement half of that issue.

Strictly additive. No existing call site is moved onto this helper by this PR; the IPC wiring (`ipc_send` / `ipc_recv` bounds rejection + `IPC_ERR_BOUNDS` slot + new `CAP:DENY:...:bounds` marker row) is deferred to a follow-up PR pending the marker-grammar / ABI-slot design call still open on #260.

## Behaviour (documented in `process.h`)

- `subject == 0` (v0 "unknown / unset" sentinel) always returns NULL, even if a caller wedged subject 0 into the table.
- Uninitialised table returns NULL (no implicit init side effect — does not mutate generation counters).
- O(`PROC_TABLE_MAX`) linear scan; first live match wins. The 1:1 (subject → PCB) convention is documented but not enforced here.
- Returns the stored `address_space_t *` verbatim. A live PCB with `aspace == NULL` returns NULL — the IPC wiring will treat that as "no PCB-keyed bounds check available", preserving back-compat for the existing IPC tests that do not wire a process table.

## Validation

- New `tests/process_find_aspace_by_subject_test.c` (six cases, each emitting a deterministic `TEST:PASS:...` marker):
  1. `hit_returns_stored_aspace`
  2. `miss_returns_null`
  3. `subject_zero_returns_null`
  4. `destroy_then_miss`
  5. `multiple_subjects_first_wins`
  6. `null_aspace_returns_null`
- Wired into `build/scripts/test.sh` (`process_find_aspace_by_subject`) + `.shell_parity_allowlist` (#156 follows the same `.sh`-only treatment as `test_process_table`).
- Regression sweep local: `process_table`, `proc_sched`, `ipc_sync_v0`, `ipc_handle_gate`, `cap_handle_revoke_subject`, `m1_ipc_demo` all still green; `lint` green.

## Scope guard / non-goals

- **No** IPC integration. `ipc_send`/`ipc_recv` are untouched.
- **No** new ABI surface, no `OS_ABI_VERSION` bump, no new `ipc_result_t` slot.
- **No** new `CAP:DENY` marker. The marker-grammar question raised in the latest cron comment on #260 is left for the wiring PR.
- **No** scheduler / paging / IPC behaviour change.

## Follow-up

The remaining #260 IPC half can now stack on this PR. It still needs an explicit maintainer call on:
1. `IPC_ERR_BOUNDS = 6` ABI slot under `OS_ABI_VERSION=0` (additive vs. bumping).
2. Marker shape: `CAP:DENY:<sender_subject>:ipc_send:bounds` (issue body's `<aspace>` is not §4-grammar-valid).
3. "No PCB → skip check" back-compat carve-out for existing IPC tests.

Refs #260.