### PR TITLE
proc: emit canonical CAP:DENY:<subject>:app_exec:proc_table_full marker on process_create exhaustion (fixes #261)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -36,6 +36,7 @@ test_cap_handle_repr
 test_cap_handle_revoke_subject
 test_cap_handle_revoke_subtree
 test_process_table
+test_process_create_table_full_deny_marker
 test_proc_sched
 test_proc_sched_aspace_invariant
 test_aspace_carve

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -117,6 +117,16 @@ case "$TEST_NAME" in
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"
+    ;;
+  process_create_table_full_deny_marker)
+    # Issue #261: PROC_TABLE_FULL deny path emits the canonical
+    # CAP:DENY:<subject>:app_exec:proc_table_full marker that
+    # round-trips through cap_deny_marker_validate (the #221
+    # conformance predicate). Reuses CAP_APP_EXEC + literal
+    # resource string "proc_table_full" so the launcher's
+    # `CAP:DENY:*:app_exec:*` greps pick up both policy and
+    # exhaustion denies under one shape.
+    run_script "$ROOT_DIR/build/scripts/test_process_create_table_full_deny_marker.sh"
     ;;
   proc_sched)
     run_script "$ROOT_DIR/build/scripts/test_proc_sched.sh"

--- a/build/scripts/test_cap_handle_revoke_subject.sh
+++ b/build/scripts/test_cap_handle_revoke_subject.sh
@@ -13,6 +13,7 @@ mkdir -p "$OUT_DIR"
 
 cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/tests/cap_handle_revoke_subject_test.c" \
   -o "$OUT_DIR/cap_handle_revoke_subject_test"

--- a/build/scripts/test_launcher_console.sh
+++ b/build/scripts/test_launcher_console.sh
@@ -11,6 +11,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/kernel/user/launcher.c" \

--- a/build/scripts/test_launcher_fs_spawn_handoff.sh
+++ b/build/scripts/test_launcher_fs_spawn_handoff.sh
@@ -30,6 +30,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/kernel/user/launcher.c" \

--- a/build/scripts/test_launcher_spawn_handoff.sh
+++ b/build/scripts/test_launcher_spawn_handoff.sh
@@ -31,6 +31,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
   "$ROOT_DIR/kernel/cap/cap_gate.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/address_space.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/kernel/user/launcher.c" \

--- a/build/scripts/test_process_create_table_full_deny_marker.sh
+++ b/build/scripts/test_process_create_table_full_deny_marker.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build + run the issue #261 PROC_TABLE_FULL CAP:DENY marker test.
+#
+# Asserts that process_create(), upon hitting PROC_TABLE_MAX, emits a
+# byte-exact `CAP:DENY:<subject>:app_exec:proc_table_full\n` line that
+# round-trips through cap_deny_marker_validate() (the #221 conformance
+# predicate), and that the happy create path stays silent.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/tests/process_create_table_full_deny_marker_test.c" \
+  -o "$OUT_DIR/process_create_table_full_deny_marker_test"
+
+LOG_PATH="$OUT_DIR/process_create_table_full_deny_marker_test.log"
+"$OUT_DIR/process_create_table_full_deny_marker_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:process_create_table_full_deny_marker_canonical_shape" "$LOG_PATH"
+grep -q "TEST:PASS:process_create_table_full_deny_marker_happy_path_silent" "$LOG_PATH"
+grep -q "TEST:PASS:process_create_table_full_deny_marker$" "$LOG_PATH"

--- a/build/scripts/test_process_table.sh
+++ b/build/scripts/test_process_table.sh
@@ -25,6 +25,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/cap/capability.c" \
   "$ROOT_DIR/kernel/cap/cap_table.c" \
   "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
   "$ROOT_DIR/kernel/proc/process.c" \
   "$ROOT_DIR/tests/process_table_test.c" \
   -o "$OUT_DIR/process_table_test"

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -35,10 +35,54 @@
 #include "process.h"
 
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 
+#include "../cap/cap_deny_marker.h"
 #include "../cap/cap_handle.h"
 #include "../../user/include/secureos_abi.h"
+
+/* Canonical CAP:DENY:<subject>:app_exec:<resource> marker emitter for
+ * resource-exhaustion denies on process creation (issue #261).
+ *
+ * Design notes (decision recorded inline because this is the only
+ * non-cap-gate deny path that currently rides the cap_deny_marker):
+ *
+ *   The PROC_TABLE_FULL deny is structurally a resource-exhaustion
+ *   condition, not a cap_check() miss. But issue #261 explicitly asks
+ *   for cross-cutting greppability through the same canonical
+ *   CAP:DENY:<...> marker the IPC and syscall deny paths already use
+ *   (#167 / #211 / #221 / PR #244). The marker grammar locked by
+ *   docs/abi/capability-deny-contract.md §4 + cap_deny_marker_validate
+ *   requires field 0 to be a decimal cap_subject_id_t and field 1 to be
+ *   a registered name in cdm_cap_names[]. "proc_table" / "process_create"
+ *   as proposed in the issue body would fail both checks.
+ *
+ *   The minimum-blast-radius resolution that satisfies the spirit of
+ *   the issue (single greppable shape, zero ABI churn, passes the #221
+ *   conformance test unmodified) is to reuse CAP_APP_EXEC — the cap the
+ *   M2 launcher will gate process spawn on — with the would-be
+ *   subject in field 0 and the literal "proc_table_full" in the
+ *   resource slot. M2 launcher-mediated greps for
+ *   `CAP:DENY:*:app_exec:*` therefore observe both real policy denies
+ *   and kernel exhaustion denies with the same predicate.
+ *
+ *   See the long comment thread on #261 for the full A/B/C/D options
+ *   considered; this is option A. */
+#define PROC_CREATE_DENY_RESOURCE_TABLE_FULL "proc_table_full"
+
+static void proc_emit_table_full_deny_marker(cap_subject_id_t subject) {
+  char buf[CAP_DENY_MARKER_MAX];
+  int n = cap_deny_marker_format(subject, CAP_APP_EXEC,
+                                 PROC_CREATE_DENY_RESOURCE_TABLE_FULL,
+                                 buf, sizeof(buf));
+  if (n > 0) {
+    /* fwrite preserves the trailing '\n' the formatter already wrote.
+     * Matches the kernel/ipc/ipc_ops.c emission discipline so the
+     * conformance test's stdout-scan harness works unchanged. */
+    (void)fwrite(buf, 1u, (size_t)n, stdout);
+  }
+}
 
 /* Handle layout: low 16 bits = table index, high 16 bits = generation.
  * Static-asserted against OS_ABI_VERSION = 0 so any future packing
@@ -150,6 +194,10 @@ proc_result_t process_create(cap_subject_id_t subject,
       return PROC_OK;
     }
   }
+  /* All slots live: emit the canonical CAP:DENY:<subject>:app_exec:proc_table_full
+   * marker (issue #261) before returning the exhaustion error. The emission
+   * is one-per-attempt; idempotency is the caller's responsibility. */
+  proc_emit_table_full_deny_marker(subject);
   return PROC_ERR_TABLE_FULL;
 }
 

--- a/tests/process_create_table_full_deny_marker_test.c
+++ b/tests/process_create_table_full_deny_marker_test.c
@@ -1,0 +1,220 @@
+/**
+ * @file process_create_table_full_deny_marker_test.c
+ * @brief Asserts that process_create(), when the PROC_TABLE_MAX slot
+ *        cap is reached, emits the canonical capability-denied marker
+ *        defined by docs/abi/capability-deny-contract.md §4 (issue #261).
+ *
+ * Design recap (the long version lives in process.c next to
+ * proc_emit_table_full_deny_marker):
+ *
+ *   PROC_TABLE_FULL is a resource-exhaustion deny, not a cap_check()
+ *   deny, but #261 explicitly asks for the same `CAP:DENY:<...>` shape
+ *   so cross-cutting greps in the launcher / acceptance suites pick it
+ *   up alongside policy denies. The cap_deny_marker grammar locked by
+ *   #211 / #221 / PR #244 requires field 0 to be a decimal
+ *   cap_subject_id_t and field 1 to be a registered name in
+ *   cdm_cap_names[]. The least-blast-radius resolution is to reuse
+ *   CAP_APP_EXEC (the cap the launcher gates spawn on) with the would-be
+ *   subject in field 0 and the literal "proc_table_full" in the
+ *   resource slot — no new capability_id_t, no marker grammar change,
+ *   passes cap_deny_marker_validate() unchanged.
+ *
+ * This test:
+ *
+ *   1. Fills the process table to PROC_TABLE_MAX.
+ *   2. Captures stdout while invoking the (PROC_TABLE_MAX + 1)st
+ *      process_create with a sentinel subject (4242).
+ *   3. Asserts:
+ *        - The call returns PROC_ERR_TABLE_FULL with PID_INVALID.
+ *        - Exactly one CAP:DENY line was emitted.
+ *        - The line is byte-exactly
+ *            "CAP:DENY:4242:app_exec:proc_table_full\n"
+ *        - The line round-trips through cap_deny_marker_validate()
+ *          with rc == 0 (the #221 conformance predicate).
+ *   4. Additionally asserts that a *successful* create after freeing
+ *      one slot does NOT emit any CAP:DENY marker (happy-path is silent).
+ *
+ * Launched by:
+ *   build/scripts/test_process_create_table_full_deny_marker.sh,
+ *   dispatched via `build/scripts/test.sh process_create_table_full_deny_marker`.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_deny_marker.h"
+#include "../kernel/proc/process.h"
+
+static void die(const char *reason) {
+  /* Always emit on stderr so a partially-captured stdout cannot eat
+   * the FAIL marker. */
+  fprintf(stderr, "TEST:FAIL:process_create_table_full_deny_marker:%s\n",
+          reason);
+  exit(1);
+}
+
+/* Capture stdout into a buffer for the duration of `fn`. Returns the
+ * captured bytes (NUL-terminated) in `out`; truncates at `out_size - 1`. */
+static void with_captured_stdout(void (*fn)(void *), void *ctx,
+                                 char *out, size_t out_size) {
+  fflush(stdout);
+  int saved = dup(STDOUT_FILENO);
+  if (saved < 0) {
+    die("dup_stdout");
+  }
+  char tmpl[] = "/tmp/proc_full_deny_marker.XXXXXX";
+  int tmpfd = mkstemp(tmpl);
+  if (tmpfd < 0) {
+    die("mkstemp");
+  }
+  /* Unlink early so we leak nothing on a crash later in the run. */
+  unlink(tmpl);
+  if (dup2(tmpfd, STDOUT_FILENO) < 0) {
+    die("dup2_redirect");
+  }
+  fn(ctx);
+  fflush(stdout);
+  /* Restore stdout. */
+  if (dup2(saved, STDOUT_FILENO) < 0) {
+    die("dup2_restore");
+  }
+  close(saved);
+  /* Read back. */
+  if (lseek(tmpfd, 0, SEEK_SET) < 0) {
+    die("lseek_tmpfd");
+  }
+  ssize_t n = read(tmpfd, out, out_size - 1u);
+  if (n < 0) {
+    die("read_tmpfd");
+  }
+  out[n] = '\0';
+  close(tmpfd);
+}
+
+typedef struct {
+  cap_subject_id_t subject;
+  proc_result_t rc;
+  process_id_t out_pid;
+} create_call_t;
+
+static void do_create(void *ctx) {
+  create_call_t *c = (create_call_t *)ctx;
+  c->out_pid = (process_id_t)0xDEADBEEFu;
+  c->rc = process_create(c->subject, NULL, &c->out_pid);
+}
+
+/* Count occurrences of "CAP:DENY:" in `s`. */
+static size_t count_deny_markers(const char *s) {
+  size_t n = 0u;
+  const char *p = s;
+  while ((p = strstr(p, "CAP:DENY:")) != NULL) {
+    n++;
+    p++;
+  }
+  return n;
+}
+
+static void check_table_full_emits_canonical_marker(void) {
+  process_table_reset();
+
+  /* Fill the table. */
+  for (uint32_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    process_id_t pid = PID_INVALID;
+    proc_result_t rc = process_create((cap_subject_id_t)(200u + i),
+                                      NULL, &pid);
+    if (rc != PROC_OK || pid == PID_INVALID) {
+      die("fill_to_capacity");
+    }
+  }
+
+  /* One more — must deny + emit. */
+  create_call_t call = { .subject = (cap_subject_id_t)4242u };
+  char captured[1024];
+  with_captured_stdout(do_create, &call, captured, sizeof(captured));
+
+  if (call.rc != PROC_ERR_TABLE_FULL) {
+    die("overflow_create_did_not_signal_table_full");
+  }
+  if (call.out_pid != PID_INVALID) {
+    die("overflow_create_did_not_clear_out_pid");
+  }
+
+  const char *expected =
+      "CAP:DENY:4242:app_exec:proc_table_full\n";
+  if (strcmp(captured, expected) != 0) {
+    fprintf(stderr,
+            "TEST:FAIL:process_create_table_full_deny_marker:wire_mismatch\n"
+            "  expected: %s"
+            "  captured: %s",
+            expected, captured);
+    exit(1);
+  }
+
+  if (count_deny_markers(captured) != 1u) {
+    die("expected_exactly_one_deny_marker");
+  }
+
+  /* Round-trip the captured line through the #221 conformance validator. */
+  char reason[128] = {0};
+  int vrc = cap_deny_marker_validate(captured, reason, sizeof(reason));
+  if (vrc != 0) {
+    fprintf(stderr,
+            "TEST:FAIL:process_create_table_full_deny_marker:validate_rc=%d:%s\n",
+            vrc, reason);
+    exit(1);
+  }
+
+  printf("TEST:PASS:process_create_table_full_deny_marker_canonical_shape\n");
+}
+
+/* The successful-create path MUST be silent — emission belongs only to
+ * the exhaustion deny, never the happy path. Regression guard against a
+ * future refactor that hoists the marker emit above the slot scan. */
+static void check_success_emits_no_marker(void) {
+  process_table_reset();
+
+  /* Fill, then free one. */
+  process_id_t pids[PROC_TABLE_MAX];
+  for (uint32_t i = 0; i < PROC_TABLE_MAX; ++i) {
+    pids[i] = PID_INVALID;
+    if (process_create((cap_subject_id_t)(300u + i), NULL, &pids[i]) != PROC_OK) {
+      die("refill_to_capacity");
+    }
+  }
+  if (process_destroy(pids[0]) != PROC_OK) {
+    die("free_one_slot");
+  }
+
+  create_call_t call = { .subject = (cap_subject_id_t)9999u };
+  char captured[1024];
+  with_captured_stdout(do_create, &call, captured, sizeof(captured));
+
+  if (call.rc != PROC_OK) {
+    die("post_free_create_failed");
+  }
+  if (call.out_pid == PID_INVALID) {
+    die("post_free_create_returned_invalid_pid");
+  }
+  if (strstr(captured, "CAP:DENY:") != NULL) {
+    fprintf(stderr,
+            "TEST:FAIL:process_create_table_full_deny_marker:"
+            "happy_path_emitted_marker:%s\n", captured);
+    exit(1);
+  }
+  printf("TEST:PASS:process_create_table_full_deny_marker_happy_path_silent\n");
+}
+
+int main(void) {
+  check_table_full_emits_canonical_marker();
+  check_success_emits_no_marker();
+  printf("TEST:PASS:process_create_table_full_deny_marker\n");
+  return 0;
+}


### PR DESCRIPTION
## What

Closes #261. `process_create()` now emits the canonical capability-denied marker

```
CAP:DENY:<subject>:app_exec:proc_table_full\n
```

through the single-source-of-truth `cap_deny_marker_format()` when the `PROC_TABLE_MAX` slot cap is hit, immediately before returning `PROC_ERR_TABLE_FULL`.

## Design decision (option A from the issue thread)

`PROC_TABLE_FULL` is structurally a resource-exhaustion deny, not a `cap_check()` miss. But the marker grammar locked by `docs/abi/capability-deny-contract.md` §4 (#211 / #221 / PR #244) requires:

- field 0 = decimal `cap_subject_id_t`
- field 1 = a name registered in `cdm_cap_names[]`

So a hypothetical `\"proc_table\"` / `\"process_create\"` cap name (as floated in the original issue body) would fail `cap_deny_marker_validate` and force a new entry in `capability_id_t` — an ABI bump that this resource-exhaustion path does not warrant.

**Least-blast-radius resolution:** reuse `CAP_APP_EXEC` (the cap the M2 launcher gates spawn on) with the would-be subject in field 0 and the literal `\"proc_table_full\"` in the resource slot. Launcher-side greps for `CAP:DENY:*:app_exec:*` then pick up both policy denies and kernel exhaustion denies under one shape. **Zero ABI churn. `cap_deny_marker_validate` passes unchanged.**

The full decision log lives in the comment block above `proc_emit_table_full_deny_marker` in `kernel/proc/process.c`.

## Validation

New deterministic test `tests/process_create_table_full_deny_marker_test.c` (dispatched via `build/scripts/test.sh process_create_table_full_deny_marker`):

- Fills the table to `PROC_TABLE_MAX`, captures stdout for the (MAX+1)st create, asserts the byte-exact marker line **and** `rc == PROC_ERR_TABLE_FULL` / `out_pid == PID_INVALID`.
- Round-trips the captured line through `cap_deny_marker_validate` (the #221 conformance predicate).
- Asserts the happy create path emits **no** `CAP:DENY` line (regression guard against a refactor that hoists the emit above the slot scan).

Full local matrix run, all PASS:

```
process_create_table_full_deny_marker  process_table  cap_handle_revoke_subject
ipc_sync_v0  proc_sched  proc_sched_aspace_invariant  ipc_handle_gate
launcher_console  launcher_spawn_handoff  launcher_fs_spawn_handoff
m1_ipc_demo  cap_deny_marker_shape
m2_helloapp_allow_qemu  m2_helloapp_deny_qemu  m2_launcher_console_qemu
m3_fs_persist_allow_qemu  m3_fs_persist_deny_qemu  m3_fs_ephemeral_reset_qemu
parity
```

## Build-script housekeeping (no behavior change)

Adds `kernel/cap/cap_deny_marker.c` to the link line of every test binary that already links `kernel/proc/process.c`, so they link cleanly after this PR:

- `test_process_table.sh`
- `test_cap_handle_revoke_subject.sh`
- `test_launcher_console.sh`
- `test_launcher_spawn_handoff.sh`
- `test_launcher_fs_spawn_handoff.sh`

Allowlist + dispatcher updated; `parity` stays green.

## Follow-ups (not in this PR)

- PowerShell peer `test_process_create_table_full_deny_marker.ps1` — tracked under the #156 parity sweep; allowlist entry added so the parity check stays green meanwhile.
- Doc-only issue: extend `docs/abi/capability-deny-contract.md` with the proc-exhaustion convention (resource = literal `proc_table_full` under cap = `app_exec`). Filing separately rather than expanding this PR's scope.