### PR TITLE
fix #260: wire aspace_contains into ipc_send/recv with IPC_ERR_BOUNDS

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -67,6 +67,7 @@ test_ipc_port_lifecycle
 test_console_svc_port_alloc
 test_fs_svc_port_alloc
 test_ipc_handle_gate
+test_ipc_bounds
 test_syscall_entry_stub
 test_kernel_persistence
 test_launcher_console

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -69,6 +69,7 @@ $testScript = switch ($TestName) {
   "ipc_sync_v0" { "./build/scripts/test_ipc_sync_v0.sh" }
   "ipc_port_lifecycle" { "./build/scripts/test_ipc_port_lifecycle.sh" }
   "ipc_handle_gate" { "./build/scripts/test_ipc_handle_gate.sh" }
+  "ipc_bounds" { "./build/scripts/test_ipc_bounds.sh" }
   "process_table" { "./build/scripts/test_process_table.sh" }
   "proc_sched" { "./build/scripts/test_proc_sched.sh" }
   "m1_ipc_demo" { "./build/scripts/test_m1_ipc_demo.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -316,6 +316,12 @@ case "$TEST_NAME" in
     # — allow + wrong-cap deny + stale deny + wrong-owner-on-recv deny
     # + cap_handle_owner contract. Locks in plan #197's final slice.
     run_script "$ROOT_DIR/build/scripts/test_ipc_handle_gate.sh"
+    ;;
+  ipc_bounds)
+    # Issue #260: M1 process address-space bounds enforcement on the
+    # IPC envelope buffer. allow + one-past-end deny + straddle deny
+    # + backward-compat carve-out (no PCB ⇒ check skipped).
+    run_script "$ROOT_DIR/build/scripts/test_ipc_bounds.sh"
     ;;
   m1_ipc_demo)
     # Issue #251 (plan #198 slice 4): M1 two-module IPC acceptance

--- a/build/scripts/test_ipc_bounds.sh
+++ b/build/scripts/test_ipc_bounds.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# build/scripts/test_ipc_bounds.sh
+#
+# Build + run the end-to-end IPC address_space bounds enforcement test
+# (issue #260 — IPC half of the runtime bounds check, on top of the
+# aspace_contains helper / process_find_aspace_by_subject lookup).
+#
+# Covers:
+#   - allow: in-window send + recv succeeds with a live PCB+aspace.
+#   - deny: one-past-end envelope returns IPC_ERR_BOUNDS and emits
+#     exactly one CAP:DENY:<sender>:ipc_send:bounds marker.
+#   - deny: envelope straddling the upper boundary is also rejected.
+#   - backward-compat: subjects with no live PCB skip the check, so
+#     ipc_sync_v0 / ipc_handle_gate harnesses keep working unchanged.
+#
+# Outputs deterministic TEST:PASS markers consumed by
+# build/scripts/test.sh and validate_bundle.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  "$ROOT_DIR/kernel/cap/capability.c" \
+  "$ROOT_DIR/kernel/cap/cap_table.c" \
+  "$ROOT_DIR/kernel/cap/cap_handle.c" \
+  "$ROOT_DIR/kernel/cap/cap_deny_marker.c" \
+  "$ROOT_DIR/kernel/proc/process.c" \
+  "$ROOT_DIR/kernel/proc/address_space.c" \
+  "$ROOT_DIR/kernel/proc/proc_sched.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_port.c" \
+  "$ROOT_DIR/kernel/ipc/ipc_ops.c" \
+  "$ROOT_DIR/tests/ipc_bounds_test.c" \
+  -o "$OUT_DIR/ipc_bounds_test"
+
+LOG_PATH="$OUT_DIR/ipc_bounds_test.log"
+"$OUT_DIR/ipc_bounds_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:ipc_bounds_allow" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_bounds_deny_one_past_end" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_bounds_deny_straddle" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_bounds_no_pcb_skipped" "$LOG_PATH"
+grep -q "TEST:PASS:ipc_bounds$" "$LOG_PATH"
+! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -179,6 +179,7 @@ The IPC layer surfaces a small, frozen-for-v0 error enum. It is the
 | 3 | `IPC_ERR_CAP_DENIED` | Caller lacks the required capability for the requested op. Path **must** emit the capability-denied marker per [`capability-deny-contract.md`](./capability-deny-contract.md) (e.g. `CAP:DENY:<subject>:CAP_IPC_SEND`) **before** returning. This is the only IPC error that maps to a capability decision and the only one tests should treat as such. |
 | 4 | `IPC_ERR_WOULD_BLOCK` | Reserved for a future non-blocking path. V0 implementations MUST NOT return this — they block instead and ultimately return `IPC_OK`. Consumers MAY test for it for forward compatibility. |
 | 5 | `IPC_ERR_PEER_GONE` | Peer port was destroyed mid-rendezvous (`ipc_call` only). |
+| 6 | `IPC_ERR_BOUNDS` | Caller-supplied envelope buffer escapes the caller's `address_space_t` window (the M1 flat-with-bounds substitute for page-table enforcement — see [`address_space.h`](../../kernel/proc/address_space.h) / `aspace_contains`). Path **must** emit `CAP:DENY:<subject>:ipc_send:bounds` (or `:ipc_recv:bounds`) via the canonical formatter before returning. Returned by `ipc_send` / `ipc_recv` (and their `_h` handle-gated variants) when the call originates from a subject with a live PCB whose aspace does not contain the envelope (issue #260). Subjects with no live PCB skip the check for backward compatibility with the v0 in-kernel test harnesses. |
 
 ### 5.1 Error class taxonomy
 
@@ -193,6 +194,12 @@ and #164's deny-marker contract):
 - **Malformed message:** `IPC_ERR_INVALID_MSG`. Indicates the envelope
   itself is not parseable under `OS_ABI_VERSION`. MUST NOT be silently
   collapsed into `IPC_ERR_CAP_DENIED`.
+- **Bounds violation:** `IPC_ERR_BOUNDS`. The envelope was well-formed,
+  the caller was authorized, but the buffer's byte range escapes the
+  caller's `address_space_t` window. The deny marker uses the
+  resource tag `bounds` so consumers can grep it independently of the
+  permissions deny (resource `-`). See `aspace_contains` for the
+  exact containment predicate.
 - **Transport fault:** `IPC_ERR_INVALID_PORT`, `IPC_ERR_PEER_GONE`. The
   envelope was well-formed and the caller was authorized, but the
   rendezvous could not complete.
@@ -209,6 +216,7 @@ Where an IPC error must surface through the syscall ABI's
 | `IPC_ERR_CAP_DENIED` | `OS_STATUS_DENIED` |
 | `IPC_ERR_INVALID_PORT`, `IPC_ERR_PEER_GONE` | `OS_STATUS_ERROR` |
 | `IPC_ERR_INVALID_MSG`, `IPC_ERR_WOULD_BLOCK` | `OS_STATUS_ERROR` |
+| `IPC_ERR_BOUNDS` | `OS_STATUS_ERROR` |
 
 This preserves the
 [`syscalls.md`](./syscalls.md) invariant that `OS_STATUS_DENIED` is
@@ -268,4 +276,4 @@ implementation work begins under #180 / #185. Implementation issues that
 must conform to this surface are enumerated in the M1 plan referenced
 above.
 
-Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6
+Last verified against commit: 76b3fff60c4f1b06da5feee72149f95dda8cc117

--- a/kernel/ipc/ipc_msg.h
+++ b/kernel/ipc/ipc_msg.h
@@ -101,6 +101,14 @@ typedef struct ipc_msg_v0 {
  *   - capability decision: IPC_ERR_CAP_DENIED only.
  *   - malformed message:   IPC_ERR_INVALID_MSG.
  *   - transport fault:     IPC_ERR_INVALID_PORT, IPC_ERR_PEER_GONE.
+ *   - bounds violation:    IPC_ERR_BOUNDS (caller-supplied envelope
+ *                          buffer escapes the caller's address_space_t
+ *                          window — see address_space.h /
+ *                          aspace_contains, plan #198 slice 2). The
+ *                          deny path MUST emit the canonical
+ *                          CAP:DENY:<subject>:ipc_send:bounds /
+ *                          :ipc_recv:bounds marker before returning
+ *                          (issue #260).
  *   - reserved future:     IPC_ERR_WOULD_BLOCK (MUST NOT be returned by
  *                          v0 implementations; consumers MAY test for
  *                          forward compat).
@@ -112,6 +120,7 @@ typedef enum {
   IPC_ERR_CAP_DENIED = 3,
   IPC_ERR_WOULD_BLOCK = 4,
   IPC_ERR_PEER_GONE = 5,
+  IPC_ERR_BOUNDS = 6,
 } ipc_result_t;
 
 /*

--- a/kernel/ipc/ipc_ops.c
+++ b/kernel/ipc/ipc_ops.c
@@ -42,6 +42,8 @@
 #include "../cap/capability.h"
 #include "../cap/cap_handle.h"
 #include "../cap/cap_deny_marker.h"
+#include "../proc/address_space.h"
+#include "../proc/process.h"
 #include "../proc/proc_sched.h"
 
 #include <stdio.h>
@@ -133,6 +135,59 @@ static void ipc_emit_deny_marker(cap_subject_id_t subject, capability_id_t cap) 
   }
 }
 
+/* Emit a canonical CAP:DENY marker with a concrete resource field.
+ * Used by the M1 bounds-check path (issue #260): the resource string
+ * tags the deny reason so consumers can distinguish a permissions
+ * deny (resource "-") from a bounds deny (resource "bounds"). */
+static void ipc_emit_deny_marker_resource(cap_subject_id_t subject,
+                                          capability_id_t cap,
+                                          const char *resource) {
+  char buf[CAP_DENY_MARKER_MAX];
+  int n = cap_deny_marker_format(subject, cap, resource, buf, sizeof(buf));
+  if (n > 0) {
+    (void)fwrite(buf, 1u, (size_t)n, stdout);
+  }
+}
+
+/* IPC bounds-check resource tag (issue #260, plan #198 slice 2). The
+ * deny marker on a bounds violation uses this literal resource string
+ * so consumers can grep it independently of the permissions deny
+ * (which uses the spec-mandated "-"). */
+#define IPC_DENY_RESOURCE_BOUNDS "bounds"
+
+/* M1 address-space bounds-check (issue #260).
+ *
+ * If the subject has a live PCB with a non-NULL aspace, require the
+ * envelope buffer to lie entirely inside that aspace's window. On a
+ * violation, emit CAP:DENY:<subject>:<cap>:bounds and return
+ * IPC_ERR_BOUNDS.
+ *
+ * Backward-compat carve-out: when no PCB with this subject exists OR
+ * the PCB's stored aspace is NULL, skip the check. This preserves the
+ * pre-#260 IPC test harnesses (`ipc_sync_v0`, `ipc_handle_gate`,
+ * `ipc_port_lifecycle`, `m1_ipc_demo`) which exercise IPC using raw
+ * cap_subject_id_t values without ever calling process_create — those
+ * remain in-bounds-by-definition because there is no window to escape
+ * from. M2+ callers that go through process_create + aspace_partition
+ * pick up enforcement automatically.
+ *
+ * Returns IPC_OK on "pass or n/a", IPC_ERR_BOUNDS on a real violation.
+ */
+static ipc_result_t ipc_aspace_bounds_check(cap_subject_id_t subject,
+                                            capability_id_t cap,
+                                            const ipc_msg_v0 *msg) {
+  address_space_t *as = process_find_aspace_by_subject(subject);
+  if (as == NULL) {
+    /* No PCB or no aspace bound — nothing to enforce against. */
+    return IPC_OK;
+  }
+  if (!aspace_contains(as, msg, sizeof(*msg))) {
+    ipc_emit_deny_marker_resource(subject, cap, IPC_DENY_RESOURCE_BOUNDS);
+    return IPC_ERR_BOUNDS;
+  }
+  return IPC_OK;
+}
+
 /* Capability-gate helpers. These intentionally mirror the shape of
  * cap_gate.c so audit-side behavior is identical to other gated paths. */
 static ipc_result_t cap_ipc_send_gate(cap_subject_id_t subject, capability_id_t required) {
@@ -186,6 +241,14 @@ ipc_result_t ipc_send(cap_subject_id_t sender, ipc_port_t target, const ipc_msg_
     return gate;
   }
 
+  /* Issue #260: address-space bounds enforcement on the caller-supplied
+   * envelope buffer. Runs after the cap gate so a permission deny still
+   * dominates a bounds deny (matches the order audit consumers expect). */
+  ipc_result_t bc = ipc_aspace_bounds_check(sender, required_send, msg);
+  if (bc != IPC_OK) {
+    return bc;
+  }
+
   /* Stamp authenticated sender id; spec §2.4 forbids trusting the
    * caller-supplied value. A delivered envelope with sender_subject == 0
    * is treated as IPC_ERR_INVALID_MSG by the receiver. */
@@ -227,6 +290,13 @@ ipc_result_t ipc_recv(cap_subject_id_t receiver, ipc_port_t self_port, ipc_msg_v
   ipc_result_t gate = cap_ipc_recv_gate(receiver, required_recv);
   if (gate != IPC_OK) {
     return gate;
+  }
+
+  /* Issue #260: address-space bounds enforcement on the caller-supplied
+   * receive buffer before the rendezvous can stamp into it. */
+  ipc_result_t bc = ipc_aspace_bounds_check(receiver, required_recv, out_msg);
+  if (bc != IPC_OK) {
+    return bc;
   }
 
   ipc_result_t cr = ipc_consume_blocking(self_port, out_msg);
@@ -341,6 +411,13 @@ ipc_result_t ipc_send_h(cap_handle_t send_handle,
     return IPC_ERR_INVALID_MSG;
   }
 
+  /* Issue #260: address-space bounds enforcement also applies to the
+   * handle-gated send path. */
+  ipc_result_t bc = ipc_aspace_bounds_check(sender, required_send, msg);
+  if (bc != IPC_OK) {
+    return bc;
+  }
+
   ipc_msg_v0 outbound;
   memcpy(&outbound, msg, sizeof(outbound));
   outbound.sender_subject = sender;
@@ -382,6 +459,13 @@ ipc_result_t ipc_recv_h(cap_handle_t recv_handle,
     return IPC_ERR_CAP_DENIED;
   }
   (void)cap_check(receiver, required_recv);
+
+  /* Issue #260: address-space bounds enforcement on the handle-gated
+   * receive path. Same backward-compat carve-out as the legacy path. */
+  ipc_result_t bc = ipc_aspace_bounds_check(receiver, required_recv, out_msg);
+  if (bc != IPC_OK) {
+    return bc;
+  }
 
   ipc_result_t cr = ipc_consume_blocking(self_port, out_msg);
   if (cr != IPC_OK) {

--- a/kernel/proc/module_registry.c
+++ b/kernel/proc/module_registry.c
@@ -160,20 +160,27 @@ static void entry_m1_receiver(void) {
     (void)proc_exit(901u);
   }
 
-  ipc_msg_v0 in;
-  memset(&in, 0xAA, sizeof(in));
-  ipc_result_t r = ipc_recv_h(recv_h, g_demo_port, &in);
+  /* Issue #260: receive buffer must live inside this subject's aspace
+   * window. Use the partitioned aspace's `ipc_scratch` slot, which
+   * aspace_partition() places inside [base, base+size). */
+  address_space_t *as_r = process_find_aspace_by_subject(SUBJECT_M1_RECEIVER);
+  if (as_r == NULL || as_r->ipc_scratch == NULL) {
+    (void)proc_exit(903u);
+  }
+  ipc_msg_v0 *in = (ipc_msg_v0 *)(void *)as_r->ipc_scratch;
+  memset(in, 0xAA, sizeof(*in));
+  ipc_result_t r = ipc_recv_h(recv_h, g_demo_port, in);
   if (r != IPC_OK) {
     (void)proc_exit(902u);
   }
 
   g_demo_obs.recv_ok++;
-  g_demo_obs.recv_sender_subject = in.sender_subject;
+  g_demo_obs.recv_sender_subject = in->sender_subject;
 
-  if (in.tag == M1_DEMO_TAG
-      && in.payload_len == M1_DEMO_PAYLOAD_LEN
-      && memcmp(in.payload, M1_DEMO_PAYLOAD, M1_DEMO_PAYLOAD_LEN) == 0
-      && in.sender_subject == SUBJECT_M1_SENDER) {
+  if (in->tag == M1_DEMO_TAG
+      && in->payload_len == M1_DEMO_PAYLOAD_LEN
+      && memcmp(in->payload, M1_DEMO_PAYLOAD, M1_DEMO_PAYLOAD_LEN) == 0
+      && in->sender_subject == SUBJECT_M1_SENDER) {
     g_demo_obs.recv_payload_ok = 1u;
   }
   (void)proc_exit(0u);
@@ -197,10 +204,15 @@ static void entry_m1_sender(void) {
     (void)proc_exit(801u);
   }
 
-  ipc_msg_v0 m;
-  demo_make_msg(&m);
+  /* Issue #260: build the envelope inside the sender's aspace window. */
+  address_space_t *as_s = process_find_aspace_by_subject(SUBJECT_M1_SENDER);
+  if (as_s == NULL || as_s->ipc_scratch == NULL) {
+    (void)proc_exit(803u);
+  }
+  ipc_msg_v0 *m = (ipc_msg_v0 *)(void *)as_s->ipc_scratch;
+  demo_make_msg(m);
 
-  ipc_result_t r = ipc_send_h(send_h, g_demo_port, &m);
+  ipc_result_t r = ipc_send_h(send_h, g_demo_port, m);
   if (r != IPC_OK) {
     (void)proc_exit(802u);
   }
@@ -228,10 +240,16 @@ static void entry_m1_unauth(void) {
     (void)proc_exit(702u);
   }
 
-  ipc_msg_v0 m;
-  demo_make_msg(&m);
+  /* Issue #260: build the envelope inside m1-unauth's aspace window
+   * so the cap-deny path (not the bounds path) fires. */
+  address_space_t *as_u = process_find_aspace_by_subject(SUBJECT_M1_UNAUTH);
+  if (as_u == NULL || as_u->ipc_scratch == NULL) {
+    (void)proc_exit(703u);
+  }
+  ipc_msg_v0 *m = (ipc_msg_v0 *)(void *)as_u->ipc_scratch;
+  demo_make_msg(m);
 
-  ipc_result_t r = ipc_send_h(bad_h, g_demo_port, &m);
+  ipc_result_t r = ipc_send_h(bad_h, g_demo_port, m);
   if (r == IPC_ERR_CAP_DENIED) {
     g_demo_obs.send_deny_cap_denied = 1u;
   }

--- a/tests/cap_deny_marker_shape_test.c
+++ b/tests/cap_deny_marker_shape_test.c
@@ -95,6 +95,16 @@ static const driver_t drivers[] = {
     {"ipc_recv_deny",           7u,  CAP_IPC_RECV,
      "-",
      "CAP:DENY:7:ipc_recv:-\n"},
+    /* M1 IPC bounds deny (#260): aspace_contains failed on the
+     * caller-supplied envelope buffer. Distinct resource tag
+     * "bounds" so consumers can grep this independently of the
+     * permissions deny (resource "-"). */
+    {"ipc_send_bounds_deny",    7u,  CAP_IPC_SEND,
+     "bounds",
+     "CAP:DENY:7:ipc_send:bounds\n"},
+    {"ipc_recv_bounds_deny",    7u,  CAP_IPC_RECV,
+     "bounds",
+     "CAP:DENY:7:ipc_recv:bounds\n"},
     /* Capability audit_event_subscribe deny (per §5 async fallback). */
     {"event_subscribe_deny",    9u,  CAP_EVENT_SUBSCRIBE,  "topic=fs.changed",
      "CAP:DENY:9:event_subscribe:topic=fs.changed\n"},

--- a/tests/ipc_bounds_test.c
+++ b/tests/ipc_bounds_test.c
@@ -1,0 +1,339 @@
+/**
+ * @file ipc_bounds_test.c
+ * @brief End-to-end host test for the M1 IPC address_space bounds
+ *        enforcement (issue #260, plan #198 slice 2).
+ *
+ * Wires together:
+ *   - kernel/proc/process.c                  (process table + aspace bind)
+ *   - kernel/proc/address_space.c            (aspace_partition / contains)
+ *   - kernel/ipc/ipc_ops.c                   (ipc_send / ipc_recv)
+ *   - kernel/cap/cap_deny_marker.c           (canonical marker formatter)
+ *
+ * Covers the done-when bullets from issue #260 IPC half:
+ *
+ *   1. Allow case: in-window send + recv succeeds. The previously-existing
+ *      ipc_sync_v0 / ipc_handle_gate tests continue to pass (no PCB =>
+ *      check skipped); this test additionally proves that *with* a live
+ *      PCB whose aspace contains the envelope buffer, the allow path
+ *      still completes. Emits TEST:PASS:ipc_bounds_allow.
+ *
+ *   2. Deny case: send with a buffer one byte past base+size returns
+ *      IPC_ERR_BOUNDS and emits exactly one canonical deny marker
+ *      CAP:DENY:<sender>:ipc_send:bounds. Emits
+ *      TEST:PASS:ipc_bounds_deny_one_past_end.
+ *
+ *   3. Deny case: send with a buffer that straddles the boundary
+ *      (base + size - 4, claimed length spanning past base + size) is
+ *      rejected with IPC_ERR_BOUNDS. Emits
+ *      TEST:PASS:ipc_bounds_deny_straddle.
+ *
+ *   4. Backward-compat carve-out: a sender with NO live PCB (legacy
+ *      cap_subject_id_t in the ipc_sync_v0 harness shape) is NOT
+ *      subject to the bounds check; an out-of-window buffer still
+ *      succeeds because there is no window to escape from. Emits
+ *      TEST:PASS:ipc_bounds_no_pcb_skipped.
+ *
+ *   5. Aggregate marker TEST:PASS:ipc_bounds is the rollup the harness
+ *      asserts, matching the per-target naming convention.
+ *
+ * Launched by:
+ *   build/scripts/test_ipc_bounds.sh (dispatched via test.sh and
+ *   validate_bundle.sh).
+ *
+ * Issue: #260.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/cap/cap_table.h"
+#include "../kernel/ipc/ipc_msg.h"
+#include "../kernel/ipc/ipc_ops.h"
+#include "../kernel/ipc/ipc_port.h"
+#include "../kernel/proc/address_space.h"
+#include "../kernel/proc/process.h"
+
+/* Arena big enough to partition into 2 windows that each satisfy
+ * aspace_window_min_bytes(). 256 KiB total → 128 KiB / window. */
+#define ARENA_BYTES (256u * 1024u)
+static uint8_t g_arena[ARENA_BYTES] __attribute__((aligned(64)));
+
+static int g_fail_count = 0;
+
+#define CHECK(cond, label)                                              \
+  do {                                                                  \
+    if (!(cond)) {                                                      \
+      fprintf(stderr, "TEST:FAIL:ipc_bounds:%s\n", (label));           \
+      g_fail_count++;                                                   \
+    }                                                                   \
+  } while (0)
+
+/* Build an ipc_msg_v0 in `dst` with a known payload byte. */
+static void fill_envelope(ipc_msg_v0 *dst, uint8_t marker) {
+  memset(dst, 0, sizeof(*dst));
+  dst->abi_version = (uint16_t)OS_ABI_VERSION;
+  dst->flags = 0u;
+  dst->sender_subject = 0u;  /* kernel will stamp on send */
+  dst->tag = 0u;
+  dst->payload_len = 1u;
+  dst->payload[0] = marker;
+}
+
+/* Reset all global tables to a known-empty state at the top of each case. */
+static void reset_all(void) {
+  process_table_reset();
+  ipc_port_table_reset();
+  cap_table_reset();
+}
+
+/* Count occurrences of a literal needle in a temp-redirected stdout file. */
+static int count_marker_in_file(const char *path, const char *needle) {
+  FILE *f = fopen(path, "rb");
+  if (f == NULL) {
+    return -1;
+  }
+  char buf[8192];
+  size_t n = fread(buf, 1u, sizeof(buf) - 1u, f);
+  fclose(f);
+  buf[n] = '\0';
+  int count = 0;
+  const char *p = buf;
+  size_t nlen = strlen(needle);
+  while ((p = strstr(p, needle)) != NULL) {
+    count++;
+    p += nlen;
+  }
+  return count;
+}
+
+/* Capture stdout while running `body`, then restore. Writes captured
+ * bytes to `tmp_path`. Returns 0 on success. */
+static int capture_stdout(const char *tmp_path, void (*body)(void *), void *arg) {
+  fflush(stdout);
+  int saved = dup(fileno(stdout));
+  if (saved < 0) {
+    return -1;
+  }
+  FILE *cap = freopen(tmp_path, "w+", stdout);
+  if (cap == NULL) {
+    return -1;
+  }
+  body(arg);
+  fflush(stdout);
+  /* Restore stdout. */
+  dup2(saved, fileno(stdout));
+  close(saved);
+  /* `cap` was redirected via freopen; the FILE* now points back at
+   * the original fd. Reopening tmp_path explicitly would be cleaner
+   * but is unnecessary — we only need the file contents. */
+  return 0;
+}
+
+/* --- Test 1: allow path with live PCB --- */
+typedef struct {
+  cap_subject_id_t sender;
+  cap_subject_id_t receiver;
+  ipc_port_t port;
+  ipc_msg_v0 *out_buf;
+  ipc_msg_v0 *in_buf;
+  ipc_result_t send_rc;
+  ipc_result_t recv_rc;
+} send_recv_ctx_t;
+
+static void do_send(void *p) {
+  send_recv_ctx_t *c = (send_recv_ctx_t *)p;
+  c->send_rc = ipc_send(c->sender, c->port, c->out_buf);
+}
+
+static void do_recv(void *p) {
+  send_recv_ctx_t *c = (send_recv_ctx_t *)p;
+  c->recv_rc = ipc_recv(c->receiver, c->port, c->in_buf);
+}
+
+static void test_allow_in_window(void) {
+  reset_all();
+
+  /* Carve the arena into 2 windows: sender + receiver. */
+  address_space_t windows[2];
+  aspace_result_t ar = aspace_partition((uintptr_t)g_arena, ARENA_BYTES,
+                                        windows, 2u);
+  CHECK(ar == ASPACE_OK, "allow:partition_ok");
+
+  cap_subject_id_t sender = 1u, receiver = 2u;
+
+  /* Bind PCBs to those subjects, each with their own aspace. */
+  process_id_t spid = 0u, rpid = 0u;
+  CHECK(process_create(sender, &windows[0], &spid) == PROC_OK,
+        "allow:process_create_sender");
+  CHECK(process_create(receiver, &windows[1], &rpid) == PROC_OK,
+        "allow:process_create_receiver");
+
+  CHECK(cap_table_grant(sender, CAP_IPC_SEND) == CAP_OK,
+        "allow:grant_send");
+  CHECK(cap_table_grant(receiver, CAP_IPC_RECV) == CAP_OK,
+        "allow:grant_recv");
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  ipc_result_t pc = ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV,
+                                    &port);
+  CHECK(pc == IPC_OK && port != IPC_PORT_INVALID, "allow:port_create");
+
+  /* Place the send envelope inside the sender's window. */
+  ipc_msg_v0 *out_buf = (ipc_msg_v0 *)(uintptr_t)windows[0].base;
+  fill_envelope(out_buf, 0x5Au);
+
+  /* Recv buffer inside the receiver's window. */
+  ipc_msg_v0 *in_buf = (ipc_msg_v0 *)(uintptr_t)windows[1].base;
+  memset(in_buf, 0, sizeof(*in_buf));
+
+  send_recv_ctx_t ctx = {sender, receiver, port, out_buf, in_buf,
+                         IPC_OK, IPC_OK};
+  do_send(&ctx);
+  CHECK(ctx.send_rc == IPC_OK, "allow:send_ok");
+  do_recv(&ctx);
+  CHECK(ctx.recv_rc == IPC_OK, "allow:recv_ok");
+  CHECK(in_buf->payload[0] == 0x5Au, "allow:payload_match");
+  CHECK(in_buf->sender_subject == sender, "allow:sender_stamped");
+
+  printf("TEST:PASS:ipc_bounds_allow\n");
+}
+
+/* --- Test 2: deny one-past-end --- */
+static void test_deny_one_past_end(void) {
+  reset_all();
+
+  address_space_t windows[2];
+  aspace_result_t ar = aspace_partition((uintptr_t)g_arena, ARENA_BYTES,
+                                        windows, 2u);
+  CHECK(ar == ASPACE_OK, "deny_past_end:partition_ok");
+
+  cap_subject_id_t sender = 3u, receiver = 4u;
+  process_id_t spid = 0u, rpid = 0u;
+  CHECK(process_create(sender, &windows[0], &spid) == PROC_OK,
+        "deny_past_end:process_create_sender");
+  CHECK(process_create(receiver, &windows[1], &rpid) == PROC_OK,
+        "deny_past_end:process_create_receiver");
+  CHECK(cap_table_grant(sender, CAP_IPC_SEND) == CAP_OK,
+        "deny_past_end:grant_send");
+  CHECK(cap_table_grant(receiver, CAP_IPC_RECV) == CAP_OK,
+        "deny_past_end:grant_recv");
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  CHECK(ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) == IPC_OK,
+        "deny_past_end:port_create");
+
+  /* Stage an envelope OUTSIDE the sender's window — placed entirely
+   * inside the receiver's window, which is past sender's [base,base+size). */
+  ipc_msg_v0 *out_of_window =
+      (ipc_msg_v0 *)(uintptr_t)(windows[0].base + windows[0].size);
+  fill_envelope(out_of_window, 0x42u);
+
+  /* Capture stdout to count the marker. */
+  const char *tmp = "artifacts/tests/ipc_bounds_one_past_end_stdout.log";
+  send_recv_ctx_t ctx = {sender, receiver, port, out_of_window, NULL,
+                         IPC_OK, IPC_OK};
+  CHECK(capture_stdout(tmp, do_send, &ctx) == 0,
+        "deny_past_end:capture_ok");
+  CHECK(ctx.send_rc == IPC_ERR_BOUNDS, "deny_past_end:send_rc");
+
+  int n = count_marker_in_file(tmp, "CAP:DENY:3:ipc_send:bounds\n");
+  CHECK(n == 1, "deny_past_end:marker_count_eq_1");
+
+  printf("TEST:PASS:ipc_bounds_deny_one_past_end\n");
+}
+
+/* --- Test 3: straddle the upper boundary --- */
+static void test_deny_straddle(void) {
+  reset_all();
+
+  address_space_t windows[2];
+  aspace_result_t ar = aspace_partition((uintptr_t)g_arena, ARENA_BYTES,
+                                        windows, 2u);
+  CHECK(ar == ASPACE_OK, "deny_straddle:partition_ok");
+
+  cap_subject_id_t sender = 5u, receiver = 6u;
+  process_id_t spid = 0u, rpid = 0u;
+  CHECK(process_create(sender, &windows[0], &spid) == PROC_OK,
+        "deny_straddle:process_create_sender");
+  CHECK(process_create(receiver, &windows[1], &rpid) == PROC_OK,
+        "deny_straddle:process_create_receiver");
+  CHECK(cap_table_grant(sender, CAP_IPC_SEND) == CAP_OK,
+        "deny_straddle:grant_send");
+  CHECK(cap_table_grant(receiver, CAP_IPC_RECV) == CAP_OK,
+        "deny_straddle:grant_recv");
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  CHECK(ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) == IPC_OK,
+        "deny_straddle:port_create");
+
+  /* Place the envelope at (base + size - 4): begins inside, ends past. */
+  uintptr_t straddle_addr = windows[0].base + windows[0].size - 4u;
+  ipc_msg_v0 *straddle_buf = (ipc_msg_v0 *)straddle_addr;
+  fill_envelope(straddle_buf, 0x33u);
+
+  const char *tmp = "artifacts/tests/ipc_bounds_straddle_stdout.log";
+  send_recv_ctx_t ctx = {sender, receiver, port, straddle_buf, NULL,
+                         IPC_OK, IPC_OK};
+  CHECK(capture_stdout(tmp, do_send, &ctx) == 0,
+        "deny_straddle:capture_ok");
+  CHECK(ctx.send_rc == IPC_ERR_BOUNDS, "deny_straddle:send_rc");
+
+  int n = count_marker_in_file(tmp, "CAP:DENY:5:ipc_send:bounds\n");
+  CHECK(n == 1, "deny_straddle:marker_count_eq_1");
+
+  printf("TEST:PASS:ipc_bounds_deny_straddle\n");
+}
+
+/* --- Test 4: backward-compat — no PCB means no enforcement --- */
+static void test_no_pcb_skipped(void) {
+  reset_all();
+
+  /* NO process_create here — sender/receiver are raw cap_subject_id_t
+   * values exactly the way ipc_sync_v0_test.c uses them. */
+  cap_subject_id_t sender = 7u, receiver = 6u;
+  CHECK(cap_table_grant(sender, CAP_IPC_SEND) == CAP_OK,
+        "no_pcb:grant_send");
+  CHECK(cap_table_grant(receiver, CAP_IPC_RECV) == CAP_OK,
+        "no_pcb:grant_recv");
+
+  ipc_port_t port = IPC_PORT_INVALID;
+  CHECK(ipc_port_create(receiver, CAP_IPC_SEND, CAP_IPC_RECV, &port) == IPC_OK,
+        "no_pcb:port_create");
+
+  /* Use a stack buffer with no aspace context whatsoever. */
+  ipc_msg_v0 out_buf;
+  fill_envelope(&out_buf, 0x11u);
+  ipc_msg_v0 in_buf;
+  memset(&in_buf, 0, sizeof(in_buf));
+
+  CHECK(ipc_send(sender, port, &out_buf) == IPC_OK,
+        "no_pcb:send_ok_despite_no_aspace");
+  CHECK(ipc_recv(receiver, port, &in_buf) == IPC_OK,
+        "no_pcb:recv_ok_despite_no_aspace");
+  CHECK(in_buf.payload[0] == 0x11u, "no_pcb:payload_match");
+
+  printf("TEST:PASS:ipc_bounds_no_pcb_skipped\n");
+}
+
+int main(void) {
+  /* Ensure the temp-capture directory exists. */
+  (void)system("mkdir -p artifacts/tests");
+
+  test_allow_in_window();
+  test_deny_one_past_end();
+  test_deny_straddle();
+  test_no_pcb_skipped();
+
+  if (g_fail_count != 0) {
+    fprintf(stderr, "TEST:FAIL:ipc_bounds (failures=%d)\n", g_fail_count);
+    return 1;
+  }
+  printf("TEST:PASS:ipc_bounds\n");
+  return 0;
+}

--- a/tests/proc_sched_test.c
+++ b/tests/proc_sched_test.c
@@ -91,8 +91,21 @@ static address_space_t *next_aspace(void) {
   return &g_test_aspaces[g_test_aspace_next++];
 }
 
+/* Issue #260: IPC envelope must lie inside the caller's aspace window.
+ * Returns the partitioned aspace's ipc_scratch slot for `subj`, typed
+ * as an ipc_msg_v0*. The slot is sized IPC_MSG_PAYLOAD_MAX bytes; the
+ * envelope fits because PROC_KSTACK_BYTES + IPC_MSG_PAYLOAD_MAX + 64u
+ * window already reserves enough headroom for the full ipc_msg_v0
+ * struct (a few headers + IPC_MSG_PAYLOAD_MAX payload). */
+static ipc_msg_v0 *subj_scratch(cap_subject_id_t subj) {
+  address_space_t *as = process_find_aspace_by_subject(subj);
+  if (as == NULL || as->ipc_scratch == NULL) {
+    die("no_ipc_scratch_for_subject");
+  }
+  return (ipc_msg_v0 *)(void *)as->ipc_scratch;
+}
+
 /* ------------------------------------------------------------------ */
-/* (1) Single-PCB dispatch + exit_code                                  */
 /* ------------------------------------------------------------------ */
 
 static int g_single_ticks = 0;
@@ -192,16 +205,16 @@ static int g_recv_blocked_observed = 0;
 static int g_send_after_recv_block = 0;
 
 static void entry_receiver(void) {
-  ipc_msg_v0 in;
-  memset(&in, 0, sizeof(in));
-  ipc_result_t r = ipc_recv(g_recv_subj, g_recv_port, &in);
+  ipc_msg_v0 *in = subj_scratch(g_recv_subj);
+  memset(in, 0, sizeof(*in));
+  ipc_result_t r = ipc_recv(g_recv_subj, g_recv_port, in);
   if (r != IPC_OK) {
     (void)proc_exit(101u);
   }
-  if (in.sender_subject != g_send_subj) {
+  if (in->sender_subject != g_send_subj) {
     (void)proc_exit(102u);
   }
-  if (in.payload_len != 4u || memcmp(in.payload, "PING", 4) != 0) {
+  if (in->payload_len != 4u || memcmp(in->payload, "PING", 4) != 0) {
     (void)proc_exit(103u);
   }
   g_recv_ok = 1;
@@ -213,13 +226,13 @@ static void entry_sender(void) {
   if (proc_sched_blocked_count_for_tests() == 1u) {
     g_recv_blocked_observed = 1;
   }
-  ipc_msg_v0 m;
-  memset(&m, 0, sizeof(m));
-  m.abi_version = (uint16_t)OS_ABI_VERSION;
-  m.tag = 0u;
-  m.payload_len = 4u;
-  memcpy(m.payload, "PING", 4);
-  ipc_result_t r = ipc_send(g_send_subj, g_recv_port, &m);
+  ipc_msg_v0 *m = subj_scratch(g_send_subj);
+  memset(m, 0, sizeof(*m));
+  m->abi_version = (uint16_t)OS_ABI_VERSION;
+  m->tag = 0u;
+  m->payload_len = 4u;
+  memcpy(m->payload, "PING", 4);
+  ipc_result_t r = ipc_send(g_send_subj, g_recv_port, m);
   if (r != IPC_OK) {
     (void)proc_exit(201u);
   }
@@ -278,16 +291,16 @@ static int g_owner_drained = 0;
 static void entry_blocker_send(void) {
   /* First send fills the slot; second send must block until the owner
    * drains. */
-  ipc_msg_v0 m;
-  memset(&m, 0, sizeof(m));
-  m.abi_version = (uint16_t)OS_ABI_VERSION;
-  m.payload_len = 1u;
-  m.payload[0] = 'A';
-  if (ipc_send(g_blocker_subj, g_full_port, &m) != IPC_OK) (void)proc_exit(301u);
-  m.payload[0] = 'B';
+  ipc_msg_v0 *m = subj_scratch(g_blocker_subj);
+  memset(m, 0, sizeof(*m));
+  m->abi_version = (uint16_t)OS_ABI_VERSION;
+  m->payload_len = 1u;
+  m->payload[0] = 'A';
+  if (ipc_send(g_blocker_subj, g_full_port, m) != IPC_OK) (void)proc_exit(301u);
+  m->payload[0] = 'B';
   /* Slot is full; without a scheduler this would return PEER_GONE.
    * With the scheduler this must block until owner consumes 'A'. */
-  if (ipc_send(g_blocker_subj, g_full_port, &m) != IPC_OK) (void)proc_exit(302u);
+  if (ipc_send(g_blocker_subj, g_full_port, m) != IPC_OK) (void)proc_exit(302u);
   g_second_send_unblocked = 1;
   (void)proc_exit(0u);
 }
@@ -295,13 +308,13 @@ static void entry_blocker_send(void) {
 static void entry_owner_drain(void) {
   /* Yield so the sender runs first and stages + blocks. */
   (void)proc_yield();
-  ipc_msg_v0 in;
-  memset(&in, 0, sizeof(in));
-  if (ipc_recv(g_owner_subj, g_full_port, &in) != IPC_OK) (void)proc_exit(401u);
-  if (in.payload_len != 1u || in.payload[0] != 'A') (void)proc_exit(402u);
+  ipc_msg_v0 *in = subj_scratch(g_owner_subj);
+  memset(in, 0, sizeof(*in));
+  if (ipc_recv(g_owner_subj, g_full_port, in) != IPC_OK) (void)proc_exit(401u);
+  if (in->payload_len != 1u || in->payload[0] != 'A') (void)proc_exit(402u);
   /* Drain the second envelope after the sender re-stages. */
-  if (ipc_recv(g_owner_subj, g_full_port, &in) != IPC_OK) (void)proc_exit(403u);
-  if (in.payload_len != 1u || in.payload[0] != 'B') (void)proc_exit(404u);
+  if (ipc_recv(g_owner_subj, g_full_port, in) != IPC_OK) (void)proc_exit(403u);
+  if (in->payload_len != 1u || in->payload[0] != 'B') (void)proc_exit(404u);
   g_owner_drained = 1;
   (void)proc_exit(0u);
 }
@@ -343,11 +356,11 @@ static cap_subject_id_t g_dead_subj = 0u;
 static int g_deadlock_recv_returned = 0;
 
 static void entry_dead_recv(void) {
-  ipc_msg_v0 in;
-  memset(&in, 0, sizeof(in));
+  ipc_msg_v0 *in = subj_scratch(g_dead_subj);
+  memset(in, 0, sizeof(*in));
   /* No peer will ever send. The scheduler must return DEADLOCK rather
    * than hang. The recv call will not return in this test. */
-  (void)ipc_recv(g_dead_subj, g_dead_port, &in);
+  (void)ipc_recv(g_dead_subj, g_dead_port, in);
   g_deadlock_recv_returned = 1;
   (void)proc_exit(0u);
 }


### PR DESCRIPTION
Closes #260.

Completes the runtime-check half of plan #198 slice 2: the IPC hot paths now consult the caller's `address_space_t` window via `aspace_contains` before trusting any user-supplied envelope pointer. The unenforced-bounds gap left by #248/#249 (plan-only coverage) is now actually wired.

## Design decisions (flagged for maintainer sign-off)

These match the cron design-notes comment on the issue:

1. **`IPC_ERR_BOUNDS = 6`** appended to `ipc_result_t`. Additive under `OS_ABI_VERSION=0` (pre-freeze), no minor bump per #228's anchor pattern. Docs updated in §5/§5.1/§5.2 of `docs/abi/ipc-wire.md`.
2. **Marker grammar:** `CAP:DENY:<subject>:ipc_send:bounds` / `:ipc_recv:bounds`, formatted through the canonical `cap_deny_marker_format` (no bespoke printf). Distinct resource tag `bounds` so consumers can grep it independently of the permissions deny (resource `-`).
3. **Subject resolution:** `process_find_aspace_by_subject` (just merged in #292) — exactly the helper #260 was waiting on.
4. **Backward-compat carve-out:** subjects with no live PCB (the v0 in-kernel test harnesses use raw `cap_subject_id_t` values like `7u` without ever calling `process_create`) skip the check. There is no window to escape from, so they remain in-bounds-by-definition. This keeps `ipc_sync_v0`, `ipc_handle_gate`, `ipc_port_lifecycle`, `m1_ipc_demo` green without harness rewrites.
5. **Check ordering:** runs *after* the cap gate, so a permission deny still dominates a bounds deny (matches the order audit consumers expect).
6. **Scheduler block/wake panic-on-OOB stack** (the kernel-internal half of #260's done-when 3) is already covered by `aspace_invariant_ok` + `proc_sched_aspace_invariant_test.c` shipped earlier in the slice; this PR doesn't duplicate that work.

## Wired-in callers

- `kernel/proc/module_registry.c` — m1-sender/m1-receiver/m1-unauth build envelopes in their aspace's `ipc_scratch` slot (which `aspace_partition` already places inside `[base,base+size)`).
- `tests/proc_sched_test.c` — scheduler IPC fixtures use a new `subj_scratch()` helper backed by each subject's aspace.

## Tests

- **New:** `tests/ipc_bounds_test.c` — allow (in-window send+recv with live PCBs + payload + sender_subject stamp), deny one-past-end, deny straddle (base+size-4), backward-compat no-PCB skip. Captures stdout to assert *exactly one* canonical marker per deny case.
- **Extended:** `tests/cap_deny_marker_shape_test.c` §211 driver table now locks in the two new bounds markers' wire shape.
- **Wired:** `build/scripts/test_ipc_bounds.sh` + `test.sh` / `test.ps1` dispatcher + `.shell_parity_allowlist`.

## Validation

```
bash build/scripts/test.sh ipc_bounds                          # new
bash build/scripts/test.sh ipc_sync_v0                         # still green
bash build/scripts/test.sh ipc_handle_gate                     # still green
bash build/scripts/test.sh ipc_port_lifecycle                  # still green
bash build/scripts/test.sh m1_ipc_demo                         # still green (now uses ipc_scratch)
bash build/scripts/test.sh proc_sched                          # still green (now uses ipc_scratch)
bash build/scripts/test.sh proc_sched_aspace_invariant         # still green
bash build/scripts/test.sh aspace_invariant                    # still green
bash build/scripts/test.sh aspace_bounds                       # still green
bash build/scripts/test.sh aspace_carve                        # still green
bash build/scripts/test.sh process_table                       # still green
bash build/scripts/test.sh process_find_aspace_by_subject      # still green
bash build/scripts/test.sh cap_deny_marker_shape               # still green (new drivers)
bash build/scripts/test.sh capability_gate                     # still green
bash build/scripts/test.sh launcher_console launcher_fs ...    # all green
bash build/scripts/check_shell_parity.sh                       # PARITY:OK
```

## Done-when checklist

- [x] `aspace_contains` exists and is overflow-safe (already shipped under #249).
- [x] `ipc_send` / `ipc_recv` reject out-of-bounds buffers with `IPC_ERR_BOUNDS` + canonical deny marker.
- [x] Scheduler block/wake panics on saved-stack-out-of-window — already covered by `aspace_invariant_ok` + `proc_sched_aspace_invariant` test (shipped earlier in the slice).
- [x] `tests/ipc_bounds_test.c` lands with allow + two deny cases (+ backward-compat carve-out as a third deny-class).
- [x] `test.sh ipc_bounds` + `.ps1` parity; `check_shell_parity.sh` stays green.
- [x] Existing IPC, scheduler, and carve tests stay green (`m1_ipc_demo` and `proc_sched` got minor in-window-buffer rewrites; semantics unchanged).
- [x] No ABI bump (`IPC_ERR_BOUNDS` slots into `OS_ABI_VERSION=0`).

## Follow-ups (out of scope)

- Per-process page tables (deferred to M2 per plan #198 `pt_reserved`).
- Cross-process zero-copy mappings.