### PR TITLE
fix #295: sof_verify_signature uses ed25519_verify directly (drop sign-and-compare workaround)

### DIFF
--- a/kernel/format/sof.c
+++ b/kernel/format/sof.c
@@ -486,26 +486,17 @@ sof_result_t sof_verify_signature(const uint8_t *data,
     }
   }
 
-  /* Validate cert signature using sign-and-compare (workaround for
-   * ed25519_verify failure on i386 freestanding target).
-   * Ed25519 signing is deterministic: same key + same message = same sig.
-   * Rebuild the expected cert and compare its signature bytes. */
+  /* Validate the cert signature against the baked-in root public key.
+   * Earlier revisions used a deterministic sign-and-compare workaround
+   * because of an ed25519_verify bug on the freestanding i386 target;
+   * that bug was fixed in #134 and is regression-tested via the RFC 8032
+   * §7.1 KAT (`tests/ed25519_kat_test.c`, #200), so we now use the real
+   * verifier — which also lets us trust any cert genuinely signed by
+   * root, not just one rebuilt for the baked-in intermediate key. */
   {
-    secureos_cert_t expected_cert;
-    uint8_t root_priv[ED25519_PRIVATE_KEY_SIZE];
-    uint8_t root_pub[ED25519_PUBLIC_KEY_SIZE];
-    size_t i;
-    uint8_t root_seed_copy[ED25519_SEED_SIZE];
-
-    /* Copy baked-in root seed and derive the root keypair */
-    for (i = 0; i < ED25519_SEED_SIZE; ++i) root_seed_copy[i] = SECUREOS_ROOT_SEED[i];
-    ed25519_create_keypair(root_seed_copy, root_pub, root_priv);
-
-    /* Build the expected cert with the subject key from the parsed cert */
-    cert_build(root_pub, root_priv, cert.subject_public_key, &expected_cert);
-
-    /* Compare the cert signature byte-by-byte */
-    if (!sof_mem_equal(cert.signature, expected_cert.signature, ED25519_SIGNATURE_SIZE)) {
+    const uint8_t *root_pk = cert_get_root_public_key();
+    cert_result_t chain_res = cert_verify(&cert, root_pk);
+    if (chain_res != CERT_OK) {
       return SOF_ERR_SIGNATURE_INVALID;
     }
   }
@@ -516,31 +507,15 @@ sof_result_t sof_verify_signature(const uint8_t *data,
   /* Hash the payload */
   sha512_hash(parsed->payload, parsed->payload_size, payload_hash);
 
-  /* Verify payload signature using sign-and-compare:
-   * Re-derive the intermediate keypair and re-sign the payload hash. */
+  /* Verify the payload signature against the (now-trusted) cert subject
+   * key. Same rationale as above: ed25519_verify is KAT-validated, so
+   * use it directly instead of re-signing with a hard-coded seed. */
   {
-    uint8_t int_seed_copy[ED25519_SEED_SIZE];
-    uint8_t int_priv[ED25519_PRIVATE_KEY_SIZE];
-    uint8_t int_pub[ED25519_PUBLIC_KEY_SIZE];
-    uint8_t expected_sig[ED25519_SIGNATURE_SIZE];
-    size_t i;
-
-    /* Copy baked-in intermediate seed and derive the intermediate keypair */
-    for (i = 0; i < ED25519_SEED_SIZE; ++i) int_seed_copy[i] = SECUREOS_INTERMEDIATE_SEED[i];
-    ed25519_create_keypair(int_seed_copy, int_pub, int_priv);
-
-    /* Verify the subject key in the cert matches our intermediate key */
-    if (!sof_mem_equal(cert.subject_public_key, int_pub, ED25519_PUBLIC_KEY_SIZE)) {
-      return SOF_ERR_SIGNATURE_INVALID;
-    }
-
-    /* Re-sign the payload hash using the intermediate keypair.
-     * ed25519_create_keypair stores seed||pub in int_priv (64 bytes),
-     * which is the same format sof_build_signed constructs for signing. */
-    ed25519_sign(payload_hash, SHA512_HASH_SIZE, int_pub, int_priv, expected_sig);
-
-    /* Compare signatures — deterministic Ed25519 means same key+msg = same sig */
-    if (!sof_mem_equal(sig_bytes, expected_sig, ED25519_SIGNATURE_SIZE)) {
+    ed25519_result_t sig_res = ed25519_verify(sig_bytes,
+                                              payload_hash,
+                                              SHA512_HASH_SIZE,
+                                              cert.subject_public_key);
+    if (sig_res != ED25519_OK) {
       return SOF_ERR_SIGNATURE_INVALID;
     }
   }


### PR DESCRIPTION
Closes #295.

## Problem

`bash build/scripts/test.sh codesign` fails on `main` (`be21329`):

```
[test_wrong_key_signature_blocked]
  PASS: sof_build_signed with rogue ok
  PASS: sof_parse ok
  FAIL: rogue-but-root-signed cert verifies
...
Results: 25 passed, 1 failed
TEST:FAIL:codesign
```

`kernel/format/sof.c::sof_verify_signature()` was using a deterministic *sign-and-compare* workaround originally added to dodge a pre-#134 `ed25519_verify` bug on the freestanding i386 target. The workaround:

1. Rebuilt the cert with the baked-in root seed and compared the cert signature byte-for-byte; and
2. Rebuilt the intermediate keypair from `SECUREOS_INTERMEDIATE_SEED`, re-signed the payload hash, and compared.

That's why any genuinely-root-signed cert whose subject key was anything other than the baked-in intermediate key was rejected — even though the cert chain was valid.

## Fix

- Use `cert_verify(&cert, root_pk)` for the cert signature (it already calls the real `ed25519_verify`).
- Use `ed25519_verify(sig_bytes, payload_hash, SHA512_HASH_SIZE, cert.subject_public_key)` for the payload signature.
- Drop the `SECUREOS_INTERMEDIATE_SEED` re-derivation and the duplicated `cert_build`/`ed25519_sign` pair.

`ed25519_verify` is now regression-locked by the RFC 8032 §7.1 KAT (`tests/ed25519_kat_test.c`, merged via #200), so the workaround is no longer needed.

## Validation (host)

```
test.sh codesign           -> 26/26 PASS (was 25/26 FAIL)
test.sh ed25519            -> all PASS (incl. RFC 8032 KAT, 23/23)
test.sh sof_format         -> PASS
test.sh sof_verify_at_rest -> 26/26 PASS
test.sh cert_chain         -> PASS
test.sh app_runtime        -> PASS
test.sh fs_service         -> PASS
test.sh capability_audit   -> PASS
```

## Notes / follow-ups

- No ABI change. SOF wire format and `OS_ABI_VERSION` are untouched.
- Boot/QEMU smoke tests still need `nasm` (not in this sandbox); the CI "ISO Build And VM Smoke Test" workflow exercises them — current main run is green and this change does not touch any code on the boot path other than the verify primitive that the KAT covers.
- The leading `issuer_key_hash == hash(root_pub)` check in `sof_verify_signature` is now redundant with `cert_verify` (which checks the signature, but not the hash field directly) — left in place as cheap belt-and-suspenders, fast-rejecting malformed certs before the expensive verify. Easy follow-up if we want to push it down into `cert_chain_validate`.
