### PR TITLE
fix #297: CI check that docs/abi/ 'Last verified against commit' stamps don't predate the file's last content commit

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,6 +13,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # validate_abi_stamps (#297) walks `git log -- docs/abi/*.md`
+          # to find the most-recent content-changing commit per file.
+          # On a shallow checkout (the actions/checkout@v4 default of
+          # fetch-depth: 1) `git log` only sees the synthetic PR merge
+          # commit, which makes every file appear to have been created
+          # in that single commit and the validator wrongly reports
+          # `last_content=<merge-sha>` newer than every stamp. Fetch full
+          # history so freshness comparisons are accurate.
+          fetch-depth: 0
 
       - name: Ensure build scripts are executable
         # Defensive: mirrors the same step in iso-vm-build.yml.

--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -76,6 +76,8 @@ $testScript = switch ($TestName) {
   "syscall_entry_stub" { "./build/scripts/test_syscall_entry_stub.sh" }
   "validate_capability_registry" { "./build/scripts/validate_capability_registry.sh" }
   "capability_registry_drift" { "./tests/harness/capability_registry_drift_test.sh" }
+  "validate_abi_stamps" { "./build/scripts/validate_abi_stamps.sh" }
+  "abi_stamps_drift" { "./tests/harness/abi_stamps_drift_test.sh" }
   "harness_defense" { "./build/scripts/test_harness_defense.sh" }
   "canary_must_fail" { "./tests/integration/_canary_must_fail/canary_must_fail.sh" }
   "workflow_rule" { "./build/scripts/test_workflow_rule.sh" }

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -361,6 +361,20 @@ case "$TEST_NAME" in
     # emits the REGISTRY_VALIDATE:FAIL:enum_not_in_registry marker.
     # Mirrors the canary discipline from #213 / #177.
     run_script "$ROOT_DIR/tests/harness/capability_registry_drift_test.sh"
+    ;;
+  validate_abi_stamps)
+    # Issue #297: fails if any docs/abi/*.md `Last verified against
+    # commit:` stamp predates the file's most recent content-changing
+    # commit. Follow-up to #257 (one-shot stamp bump) so the drift
+    # cannot silently recur.
+    run_script "$ROOT_DIR/build/scripts/validate_abi_stamps.sh"
+    ;;
+  abi_stamps_drift)
+    # Issue #297: negative-canary self-test — builds a sandbox repo
+    # whose docs/abi/syscalls.md stamp is older than its last content
+    # commit and asserts the ABI_STAMP:FAIL:<file>:stamp=...:last_content=...
+    # marker fires. Mirrors the canary discipline from #213 / #234.
+    run_script "$ROOT_DIR/tests/harness/abi_stamps_drift_test.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/validate_abi_stamps.ps1
+++ b/build/scripts/validate_abi_stamps.ps1
@@ -1,0 +1,28 @@
+# build/scripts/validate_abi_stamps.ps1
+#
+# Issue #297: PowerShell peer of validate_abi_stamps.sh
+# (#156 cross-platform parity rule). Thin wrapper around
+# tools/validate_abi_stamps.py.
+#
+# Exit codes are passed through from the Python implementation:
+#   0  every in-scope docs/abi/*.md stamp is at least as new as its
+#      most recent content-changing commit
+#   1  one or more ABI_STAMP:FAIL markers emitted (stale stamps)
+#   2  environment / usage error (missing dir, not a git checkout)
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+$Py = if ($env:PYTHON) { $env:PYTHON } else { 'python3' }
+if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+    $Py = 'python'
+    if (-not (Get-Command $Py -ErrorAction SilentlyContinue)) {
+        Write-Error 'ABI_STAMP:FAIL:python3_not_found'
+        exit 2
+    }
+}
+
+$Script = Join-Path $RootDir 'tools/validate_abi_stamps.py'
+& $Py $Script --root $RootDir @args
+exit $LASTEXITCODE

--- a/build/scripts/validate_abi_stamps.sh
+++ b/build/scripts/validate_abi_stamps.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# build/scripts/validate_abi_stamps.sh
+#
+# Issue #297: thin wrapper around tools/validate_abi_stamps.py so the
+# ABI-stamp-freshness validator runs through the same build/scripts/*.sh
+# entrypoint as every other validator (issue #234 pattern). Mirror script:
+# build/scripts/validate_abi_stamps.ps1 (#156 parity rule).
+#
+# Exit codes are passed through from the Python implementation:
+#   0  every in-scope docs/abi/*.md stamp is at least as new as its
+#      most recent content-changing commit
+#   1  one or more ABI_STAMP:FAIL markers emitted (stale stamps)
+#   2  environment / usage error (missing dir, not a git checkout)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "ABI_STAMP:FAIL:python3_not_found" >&2
+  exit 2
+fi
+
+exec "$PY" "$ROOT_DIR/tools/validate_abi_stamps.py" --root "$ROOT_DIR" "$@"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -47,6 +47,7 @@ TEST_TARGETS=(
     ipc_handle_gate
     proc_sched
     m1_ipc_demo
+    validate_abi_stamps
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/docs/abi/ipc-wire.md
+++ b/docs/abi/ipc-wire.md
@@ -276,4 +276,4 @@ implementation work begins under #180 / #185. Implementation issues that
 must conform to this surface are enumerated in the M1 plan referenced
 above.
 
-Last verified against commit: 76b3fff60c4f1b06da5feee72149f95dda8cc117
+Last verified against commit: 7f303d7e901d6707e6f223a2b1fa1b0621792963

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -190,4 +190,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6
+Last verified against commit: 7f303d7e901d6707e6f223a2b1fa1b0621792963

--- a/tests/harness/abi_stamps_drift_test.sh
+++ b/tests/harness/abi_stamps_drift_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# tests/harness/abi_stamps_drift_test.sh
+#
+# Negative canary for the ABI-stamp-freshness validator (issue #297).
+#
+# Why this exists:
+#   build/scripts/validate_abi_stamps.sh claims that a docs/abi/*.md
+#   file whose `Last verified against commit:` stamp predates the
+#   file's most recent content-changing commit is a hard failure.
+#   This canary proves that claim is real -- not a silent no-op from a
+#   stale dispatcher arm, a typo in the regex, or a git-log invocation
+#   that returns the wrong order. Mirrors the discipline in #213
+#   (validator harness self-test) and #234 / capability_registry_drift.
+#
+# Mechanics:
+#   1. Build a throwaway git repo with one in-scope docs/abi/syscalls.md
+#      (initial commit + a stamp-only bump so the stamp validly points
+#      at the first commit's SHA).
+#   2. Add a third commit that edits prose but leaves the stamp alone.
+#      This is the drift the validator must catch.
+#   3. Run validate_abi_stamps.py against that sandbox repo and assert:
+#      - exit code 1
+#      - stderr contains ABI_STAMP:FAIL:docs/abi/syscalls.md:stamp=<OLD>:last_content=<NEW>
+#
+# Contract:
+#   On success: TEST:PASS:abi_stamps_drift_canary, exit 0.
+#   On failure: TEST:FAIL:abi_stamps_drift_canary:<reason>, exit 1.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '$TMP_DIR'" EXIT
+
+printf 'TEST:START:abi_stamps_drift_canary\n'
+
+SANDBOX="$TMP_DIR/repo"
+mkdir -p "$SANDBOX/docs/abi"
+(
+  cd "$SANDBOX"
+  git init -q -b main
+  git config user.email canary@local
+  git config user.name canary
+) || { printf 'TEST:FAIL:abi_stamps_drift_canary:sandbox_git_init_failed\n'; exit 1; }
+
+DOC="$SANDBOX/docs/abi/syscalls.md"
+
+# Commit 1: initial content with a placeholder stamp.
+cat > "$DOC" <<'EOF'
+# Sandbox: ABI surface
+
+Initial body text.
+
+Last verified against commit: PLACEHOLDER_STAMP
+EOF
+(
+  cd "$SANDBOX"
+  git add docs/abi/syscalls.md
+  git commit -q -m "sandbox: initial content"
+) || { printf 'TEST:FAIL:abi_stamps_drift_canary:sandbox_commit1_failed\n'; exit 1; }
+C1_SHA="$(git -C "$SANDBOX" rev-parse HEAD)"
+
+# Commit 2: stamp-only bump to point at C1 (treated as non-content by
+# the validator, so last_content stays at C1).
+sed -i "s|PLACEHOLDER_STAMP|${C1_SHA}|" "$DOC"
+(
+  cd "$SANDBOX"
+  git add docs/abi/syscalls.md
+  git commit -q -m "sandbox: stamp-only bump to commit 1"
+) || { printf 'TEST:FAIL:abi_stamps_drift_canary:sandbox_stamp_bump_failed\n'; exit 1; }
+OLD_SHA="$C1_SHA"
+
+# Commit 3: edit prose, leave stamp alone -- the drift the validator must catch.
+python3 - <<PY
+import pathlib
+p = pathlib.Path("$DOC")
+text = p.read_text()
+text = text.replace("Initial body text.", "Edited body text (drift introduced).")
+p.write_text(text)
+PY
+(
+  cd "$SANDBOX"
+  git add docs/abi/syscalls.md
+  git commit -q -m "sandbox: drift-introducing content edit"
+) || { printf 'TEST:FAIL:abi_stamps_drift_canary:sandbox_commit3_failed\n'; exit 1; }
+NEW_SHA="$(git -C "$SANDBOX" rev-parse HEAD)"
+
+if ! grep -q "Last verified against commit: ${OLD_SHA}" "$DOC"; then
+  printf 'TEST:FAIL:abi_stamps_drift_canary:stamp_not_old_after_edit\n'
+  exit 1
+fi
+
+LOG_PATH="$TMP_DIR/validator.log"
+set +e
+python3 "$ROOT_DIR/tools/validate_abi_stamps.py" --root "$SANDBOX" \
+  > "$LOG_PATH" 2>&1
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+  printf 'TEST:FAIL:abi_stamps_drift_canary:validator_returned_zero_on_drift\n'
+  cat "$LOG_PATH"
+  exit 1
+fi
+
+OLD_PREFIX="${OLD_SHA:0:10}"
+NEW_PREFIX="${NEW_SHA:0:10}"
+EXPECTED="ABI_STAMP:FAIL:docs/abi/syscalls.md:stamp=${OLD_PREFIX}:last_content=${NEW_PREFIX}"
+
+if ! grep -qF "$EXPECTED" "$LOG_PATH"; then
+  printf 'TEST:FAIL:abi_stamps_drift_canary:expected_marker_missing:%s\n' "$EXPECTED"
+  cat "$LOG_PATH"
+  exit 1
+fi
+
+printf 'TEST:PASS:abi_stamps_drift_canary\n'
+exit 0

--- a/tools/validate_abi_stamps.py
+++ b/tools/validate_abi_stamps.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""validate_abi_stamps.py — issue #297
+
+Asserts that every `docs/abi/*.md` (other than `capability-registry.md`,
+which has its own provenance discipline per #234) carries a
+`Last verified against commit: <sha>` line whose recorded SHA is at least
+as recent as the file's most-recent *content-changing* commit.
+
+A "content-changing" commit is any commit that touches the file with at
+least one non-stamp-line diff hunk (so a stamp-only bump like #258
+does not itself reset the freshness window).
+
+Output contract (mirrors `validate_capability_registry.py` and #234):
+
+* On success per file: prints `ABI_STAMP:PASS:<rel-path>:<sha>` to stdout.
+* On failure per file: prints
+  `ABI_STAMP:FAIL:<rel-path>:stamp=<sha>:last_content=<sha>` to stderr.
+* Exit codes:
+    0  every in-scope file is fresh.
+    1  one or more `ABI_STAMP:FAIL:*` markers emitted.
+    2  environment / usage error (file missing, not a git checkout,
+       no stamp line at all in a file we expected to have one).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+STAMP_RE = re.compile(r"^Last verified against commit:\s*([0-9a-fA-F]{7,40})\s*$")
+
+# Files in docs/abi/ that participate in the convention.
+# `capability-registry.md` is exempt — its stamp says
+# "regenerated on each touch" and is CI-validated via
+# validate_capability_registry.{sh,ps1} (#234).
+DEFAULT_EXEMPT = {"capability-registry.md"}
+
+
+def git(args: list[str], root: Path) -> str:
+    res = subprocess.run(
+        ["git", "-C", str(root)] + args,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (rc={res.returncode}): {res.stderr.strip()}"
+        )
+    return res.stdout
+
+
+def find_stamp(path: Path) -> Optional[str]:
+    """Return the SHA recorded in the `Last verified against commit:` line, or None."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        m = STAMP_RE.match(line.strip())
+        if m:
+            return m.group(1).lower()
+    return None
+
+
+def last_content_commit(rel_path: str, root: Path) -> Optional[str]:
+    """Find the most-recent commit that touched <rel_path> with at least one
+    non-stamp-line diff. Returns the full SHA or None if no such commit
+    exists (file was never edited beyond stamp bumps, or never committed).
+    """
+    log = git(["log", "--format=%H", "--", rel_path], root).split()
+    for sha in log:
+        # Show the diff for this file at this commit and look for any
+        # +/- line that is not a stamp-line edit.
+        diff = git(
+            ["show", "--no-color", "--format=", sha, "--", rel_path], root
+        )
+        for line in diff.splitlines():
+            if not line:
+                continue
+            if line.startswith("+++") or line.startswith("---"):
+                continue
+            if line[0] not in ("+", "-"):
+                continue
+            body = line[1:].lstrip()
+            if STAMP_RE.match(body):
+                continue
+            # First non-stamp +/- line in this commit's diff for the
+            # file => this commit is content-changing.
+            return sha
+    return None
+
+
+def sha_is_ancestor(ancestor: str, descendant: str, root: Path) -> bool:
+    """Return True if `ancestor` is an ancestor of (or equal to) `descendant`."""
+    if ancestor.lower() == descendant.lower():
+        return True
+    res = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "--is-ancestor", ancestor, descendant],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return res.returncode == 0
+
+
+def resolve(sha: str, root: Path) -> str:
+    return git(["rev-parse", sha], root).strip().lower()
+
+
+def iter_in_scope(abi_dir: Path, exempt: Iterable[str]) -> list[Path]:
+    exempt_set = set(exempt)
+    out = []
+    for entry in sorted(abi_dir.iterdir()):
+        if entry.suffix != ".md":
+            continue
+        if entry.name in exempt_set:
+            continue
+        out.append(entry)
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, help="Repository root.")
+    parser.add_argument(
+        "--abi-dir",
+        default=None,
+        help="Override docs/abi directory (defaults to <root>/docs/abi).",
+    )
+    parser.add_argument(
+        "--exempt",
+        action="append",
+        default=[],
+        help="Additional filenames (under abi-dir) to exempt. Repeatable.",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    abi_dir = Path(args.abi_dir).resolve() if args.abi_dir else (root / "docs" / "abi")
+
+    if not abi_dir.is_dir():
+        print(f"ABI_STAMP:FAIL:abi_dir_missing:{abi_dir}", file=sys.stderr)
+        return 2
+
+    # Cheap sanity: ensure we're inside a git checkout.
+    try:
+        git(["rev-parse", "--git-dir"], root)
+    except RuntimeError as exc:
+        print(f"ABI_STAMP:FAIL:not_a_git_checkout:{exc}", file=sys.stderr)
+        return 2
+
+    exempt = DEFAULT_EXEMPT | set(args.exempt)
+    files = iter_in_scope(abi_dir, exempt)
+    if not files:
+        print("ABI_STAMP:FAIL:no_files_in_scope", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for path in files:
+        rel = os.path.relpath(path, root)
+        stamp = find_stamp(path)
+        if stamp is None:
+            # Not all docs/abi/*.md participate in the provenance
+            # convention (e.g. spec-only contracts that pre-date the
+            # `Last verified` header). Per README §Provenance the line
+            # is required when present; missing line is out-of-scope.
+            print(f"ABI_STAMP:SKIP:{rel}:no_stamp_line")
+            continue
+
+        try:
+            stamp_full = resolve(stamp, root)
+        except RuntimeError:
+            print(
+                f"ABI_STAMP:FAIL:{rel}:stamp_sha_unknown_to_git:{stamp}",
+                file=sys.stderr,
+            )
+            failures += 1
+            continue
+
+        last = last_content_commit(rel, root)
+        if last is None:
+            # File has no non-stamp content history (e.g. brand-new file
+            # in this PR). Accept — the stamp itself is the freshness
+            # baseline.
+            print(f"ABI_STAMP:PASS:{rel}:{stamp_full[:10]}")
+            continue
+
+        if sha_is_ancestor(last, stamp_full, root):
+            print(f"ABI_STAMP:PASS:{rel}:{stamp_full[:10]}")
+        else:
+            print(
+                f"ABI_STAMP:FAIL:{rel}:stamp={stamp_full[:10]}:last_content={last[:10]}",
+                file=sys.stderr,
+            )
+            failures += 1
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_abi_stamps.py
+++ b/tools/validate_abi_stamps.py
@@ -155,6 +155,24 @@ def main() -> int:
         print(f"ABI_STAMP:FAIL:not_a_git_checkout:{exc}", file=sys.stderr)
         return 2
 
+    # Refuse to run against a shallow clone: `git log -- <path>` on a
+    # shallow checkout returns only the visible tip, which would make
+    # every file appear to have been (re)introduced in that one commit
+    # and silently inflate freshness failures. CI is responsible for
+    # `fetch-depth: 0` (see .github/workflows/pr-build.yml); fail loudly
+    # if that ever regresses rather than emitting confusing FAIL markers.
+    try:
+        shallow = git(["rev-parse", "--is-shallow-repository"], root).strip()
+    except RuntimeError:
+        shallow = "false"
+    if shallow == "true":
+        print(
+            "ABI_STAMP:FAIL:shallow_clone:"
+            "need_full_history_for_per_file_log",
+            file=sys.stderr,
+        )
+        return 2
+
     exempt = DEFAULT_EXEMPT | set(args.exempt)
     files = iter_in_scope(abi_dir, exempt)
     if not files:


### PR DESCRIPTION
Implements #297.

## Summary

Adds a validator that fails CI when any `docs/abi/*.md` (other than the already-validated `capability-registry.md`) carries a `Last verified against commit:` stamp that predates the file's most recent **content-changing** commit — i.e. the exact regression that the "Out of scope" section of #257 deferred and that has already recurred twice on `main` (PR #286 on `manifest.md`, PR #294 on `ipc-wire.md`).

## What "content-changing" means

A commit is content-changing for a file iff its diff for that file contains at least one `+` / `-` line that is **not** a `Last verified against commit:` line. Stamp-only bumps (like #258) therefore do not themselves reset the freshness window — the validator looks past them to the underlying prose commit.

## Files / shape

- `tools/validate_abi_stamps.py` — Python validator. Output mirrors `validate_capability_registry.py` (#234):
  - stdout: `ABI_STAMP:PASS:<rel>:<sha>` per fresh file
  - stdout: `ABI_STAMP:SKIP:<rel>:no_stamp_line` for in-`docs/abi/` files that don't carry the convention (e.g. `capability-deny-contract.md`)
  - stderr: `ABI_STAMP:FAIL:<rel>:stamp=<sha>:last_content=<sha>` per stale file
  - exit `0` / `1` / `2`
- `build/scripts/validate_abi_stamps.sh` + `.ps1` — thin wrappers (#156 `.sh ↔ .ps1` parity rule)
- `build/scripts/test.sh` + `test.ps1` — `validate_abi_stamps` and `abi_stamps_drift` dispatch arms + usage strings
- `build/scripts/validate_bundle.sh` — `validate_abi_stamps` added to `TEST_TARGETS` so the standard bundle gates on it
- `tests/harness/abi_stamps_drift_test.sh` — negative canary (mirrors `capability_registry_drift_test.sh` from #234 / canary discipline from #213). Builds a sandbox repo whose `docs/abi/syscalls.md` stamp is older than its last prose commit, runs the real validator against it, asserts the `ABI_STAMP:FAIL:*` marker fires.

## Stamp bumps in this PR

The validator would otherwise fail on this PR itself. Both files were re-read against current `main`; normative prose still matches the implementation, so a stamp-only bump (no prose delta) is appropriate per `docs/abi/README.md` §Provenance — same discipline as #258.

| File | Old stamp | New stamp | Unstamped commit that caused the drift |
|---|---|---|---|
| `docs/abi/manifest.md` | `9b2089b…` | `7f303d7…` | `cb09978` (#286, "manifest schema persistence enum", 2026-05-24) |
| `docs/abi/ipc-wire.md` | `76b3fff…` | `7f303d7…` | `be21329` (#294, "wire aspace_contains into ipc_send/recv with IPC_ERR_BOUNDS", 2026-05-24) |

## Validation performed

```
$ bash build/scripts/test.sh validate_abi_stamps
ABI_STAMP:PASS:docs/abi/README.md:9b2089bbcf
ABI_STAMP:PASS:docs/abi/capabilities.md:9b2089bbcf
ABI_STAMP:SKIP:docs/abi/capability-deny-contract.md:no_stamp_line
ABI_STAMP:PASS:docs/abi/ipc-wire.md:7f303d7e90
ABI_STAMP:PASS:docs/abi/manifest.md:7f303d7e90
ABI_STAMP:PASS:docs/abi/syscalls.md:9b2089bbcf
ABI_STAMP:PASS:docs/abi/versioning.md:9b2089bbcf

$ bash build/scripts/test.sh abi_stamps_drift
TEST:START:abi_stamps_drift_canary
TEST:PASS:abi_stamps_drift_canary

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 80 entries)
```

## Out of scope / follow-ups

- Widening the convention to other doc trees — only `docs/abi/` uses `Last verified against commit:` today (per `docs/abi/README.md` §Provenance).
- Anything about `capability-registry.{md,json}`. Those have stronger coverage via #234 already.
- Backfilling a stamp into `docs/abi/capability-deny-contract.md` (the new validator emits `SKIP` for it; the file itself notes it is currently a spec-only DRAFT).

Filed by the hourly issue-work cron — single agent session, branch `issue-297-validate-abi-stamps`.
