### PR TITLE
fix #138: wire sof_verify_at_rest into validate_bundle + test.ps1

### DIFF
--- a/build/scripts/test.ps1
+++ b/build/scripts/test.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "common.ps1")
 
 function Show-Usage {
-  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|canary_must_fail]"
+  Write-Host "Usage: test.ps1 [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|capability_gate|capability_audit|capability_audit_fixture|cap_broker|cap_deny_marker_shape|workflow_rule|event_bus|scheduler|sof_format|sof_verify_at_rest|tls|https|bearssl_compile|fs_service|launcher_fs|app_runtime|ed25519|cert_chain|codesign|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|process_table|proc_sched|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|canary_must_fail]"
   Write-Host ""
   Write-Host "Runs SecureOS test targets inside the pinned toolchain container."
 }
@@ -53,6 +53,7 @@ $testScript = switch ($TestName) {
   "event_bus" { "./build/scripts/test_event_bus.sh" }
   "scheduler" { "./build/scripts/test_scheduler.sh" }
   "sof_format" { "./build/scripts/test_sof_format.sh" }
+  "sof_verify_at_rest" { "./build/scripts/test_sof_verify_at_rest.sh" }
   "fs_service" { "./build/scripts/test_fs_service.sh" }
   "launcher_fs" { "./build/scripts/test_launcher_fs.sh" }
   "app_runtime" { "./build/scripts/test_app_runtime.sh" }

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -29,6 +29,7 @@ TEST_TARGETS=(
     event_bus
     scheduler
     sof_format
+    sof_verify_at_rest
     tls
     https
     fs_service


### PR DESCRIPTION
Refs #138.

## What this fixes

PR #204 added the `sof_verify_at_rest` test target (`tests/sof_verify_at_rest_test.c` + `build/scripts/test_sof_verify_at_rest.sh`) and exposed it through `build/scripts/test.sh`. But two integration gaps remained — both invisible to a green local `test.sh sof_verify_at_rest` run, both directly relevant to the regression #138 was filed to defend against:

1. **`validate_bundle.sh` did not run it.** The PR-build CI workflow (`.github/workflows/pr-build.yml`) invokes `validate_bundle.sh`, whose `TEST_TARGETS` list did not include `sof_verify_at_rest`. So the write-→-read-→-verify guard that was the whole point of #138 was effectively dormant on every PR build.
2. **`test.ps1` could not dispatch the target.** The bare script `test_sof_verify_at_rest` was already in `.shell_parity_allowlist` (added by #204's follow-up per the 2026-05-22 comment), but the PowerShell switch in `build/scripts/test.ps1` had no case for `sof_verify_at_rest`. Windows contributors had no way to run the bundle's at-rest verifier through the documented dispatcher.

## Change

- `build/scripts/validate_bundle.sh` — add `sof_verify_at_rest` to `TEST_TARGETS` (placed adjacent to `sof_format` for grep affinity).
- `build/scripts/test.ps1` — add the dispatch case + usage banner entry.

No code changes outside the dispatcher / bundle plumbing. No new tests added; this PR closes the loop on the test that #204 already shipped.

## Validation

Local, on this branch:

```
$ bash build/scripts/test.sh sof_verify_at_rest
...
Results: 26 passed, 0 failed
TEST:PASS:sof_verify_at_rest

$ bash build/scripts/check_shell_parity.sh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 80 entries)
```

The container-based `validate_bundle.sh` full run was not exercised locally (no docker / qemu in this hourly-cron sandbox); CI's `build-and-validate` job will catch any plumbing miss before merge.

## Done-when status of #138 after this PR

- [x] Audit list of `sof_build_signed` call sites (prior comments on #138; no committed signed artifacts).
- [x] Positive + negative at-rest test exercising `sof_build_signed` → fwrite → fread → `sof_verify_signature` with single-byte flips — delivered by #204.
- [x] `tools/sof_wrap/sof_wrap` rebuild discipline — covered by merged #170 (closes #101).
- [x] **`sof_verify_at_rest` runs on every PR build** — this PR.
- [ ] kernel_filedemo / kernel_persistence / kernel_console / kernel_sessions / app_runtime demonstrated to still pass — those targets are already in `validate_bundle.sh`'s green set on `main` (kernel_sessions remains out per #129); no regression is introduced by this dispatcher-only change.

## Follow-ups

None required. The `test_sof_verify_at_rest` allowlist entry stays in place until #156's phased rollout retires it as part of the parity sweep.

— cron:secureos-hourly-issue-work, 2026-05-25 04:15 UTC