### PR TITLE
docs(abi): add capability-handle.md stub for §7 surface (refs #181, #233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For full contributor setup/build/run guidance, see `CONTRIBUTING.md`.
 - Milestone/task registry: `docs/test-plans/` (M0/M1/M2 status + closing PRs)
 - Task DAG schema: `manifests/task-dag.schema.json` (walk-through in `docs/test-plans/task-schema.md`)
 - Coding conventions: `docs/CODING_CONVENTIONS.md`
-- ABI reference: `docs/abi/` (syscalls, capabilities, manifest, ipc-wire, versioning)
+- ABI reference: `docs/abi/` (syscalls, capabilities, capability-handle, manifest, ipc-wire, versioning)
 - ADRs: `docs/architecture/decisions/` (start at `0001-boot-protocol-multiboot-long-mode.md`)
 - Toolchain container: `build/docker/`
 - Build wrappers: `build/scripts/`

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -41,4 +41,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: f73b31b6a8cf992923e3b6d82e67644bcf9059ee
+Last verified against commit: ddd678e1add3ee82f260a44612a498913be17eac

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -16,6 +16,11 @@ changes are deliberate and reviewable rather than emergent.
   representation, grant/revoke semantics, admin-gate, non-delegability, and
   audit/sequence guarantees. Cross-references the deeper architecture notes
   in `docs/architecture/CAPABILITIES.md`.
+- [capability-handle.md](capability-handle.md) — Dedicated stub for the
+  `cap_handle_t` 32-bit layout, revocation generation contract, and
+  `cap_gate_check_handle()` ABI. To be filled by
+  [#233](https://github.com/rwrife/SecureOS/issues/233) (M1-CAPTBL-002);
+  carved out per the four §7 surfaces in #181.
 - [manifest.md](manifest.md) — Launcher manifest schema: how an app declares
   the capabilities it needs and how the launcher mediates grants today.
 - [ipc-wire.md](ipc-wire.md) — IPC wire format (`ipc_msg_v0`) + error
@@ -36,4 +41,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6
+Last verified against commit: f73b31b6a8cf992923e3b6d82e67644bcf9059ee

--- a/docs/abi/capability-handle.md
+++ b/docs/abi/capability-handle.md
@@ -1,0 +1,51 @@
+# SecureOS Capability Handle ABI
+
+> **Owner:** kernel / capability subsystem (handle layer)
+> **Status:** draft `v0` — stub; normative layout pending M1-CAPTBL-002
+> **Last reviewed:** 2026-05-25
+> **Applies to:** `OS_ABI_VERSION = 0`
+> **Tracking issue:** [#233](https://github.com/rwrife/SecureOS/issues/233)
+> (parent plan: [#197](https://github.com/rwrife/SecureOS/issues/197))
+
+This document is the canonical ABI home for the **capability handle**
+surface called out by [`BUILD_ROADMAP.md` §7](../../BUILD_ROADMAP.md) —
+"capability handle representation + revocation". It is intentionally
+separated from the broader [`capabilities.md`](capabilities.md) (which
+covers the `capability_id_t` enum, gate semantics, audit, and the
+launcher-mediated grant model) so that the handle bit-layout and
+`cap_gate_check_handle()` contract can be frozen independently as part of
+M1-CAPTBL-002.
+
+## Scope
+
+This file will, once #233 lands, normatively specify:
+
+- The **32-bit handle layout** (`cap_handle_t`): generation / index /
+  reserved-bit split, invalid-handle sentinel, and packing rules.
+- The **revocation contract**: how a freed slot bumps its generation so
+  that stale handles cap-deny with a stable `CAP:DENY:` marker rather
+  than aliasing a new grant.
+- The **`cap_gate_check_handle()` signature and error model**: inputs,
+  outputs, and which `ipc_result_t` / capability error codes it
+  surfaces (cross-reference [`ipc-wire.md`](ipc-wire.md) §error model).
+- The **ABI freeze status**: handles are intended to be ABI-frozen
+  before `OS_ABI_VERSION` advances past `0`; until then, layout changes
+  must update this file and bump
+  [`versioning.md`](versioning.md) accordingly.
+
+## To be filled by
+
+[#233 — M1 capability handle layer (M1-CAPTBL-002): 32-bit handle +
+`cap_gate_check_handle`, ABI-frozen (from plan #197)](https://github.com/rwrife/SecureOS/issues/233).
+
+Until that issue lands, treat
+[`capabilities.md`](capabilities.md) and
+[`docs/architecture/CAPABILITIES.md`](../architecture/CAPABILITIES.md)
+as the de-facto source of truth for capability semantics; this file is a
+placeholder so that #233's ABI text has an unambiguous landing slot and
+so that the four §7 surfaces (syscalls, IPC wire, capability handle,
+manifest) each have a dedicated page per #181.
+
+## Provenance
+
+Last verified against commit: f73b31b6a8cf992923e3b6d82e67644bcf9059ee

--- a/docs/abi/capability-handle.md
+++ b/docs/abi/capability-handle.md
@@ -48,4 +48,4 @@ manifest) each have a dedicated page per #181.
 
 ## Provenance
 
-Last verified against commit: f73b31b6a8cf992923e3b6d82e67644bcf9059ee
+Last verified against commit: ddd678e1add3ee82f260a44612a498913be17eac


### PR DESCRIPTION
## Summary

BUILD_ROADMAP §7 ("ABI and Interface Freeze Plan") calls out four ABI surfaces that must be defined and versioned early:

1. syscall ABI — `docs/abi/syscalls.md` ✅
2. IPC wire format — `docs/abi/ipc-wire.md` ✅
3. **capability handle representation + revocation** — was folded into the broader `capabilities.md` ⚠️
4. manifest schema — `docs/abi/manifest.md` ✅

This PR carves out a dedicated `docs/abi/capability-handle.md` stub so that #233 (M1-CAPTBL-002) has an unambiguous landing slot for the `cap_handle_t` 32-bit layout, revocation generation contract, and `cap_gate_check_handle()` ABI — completing the last item on #181's done-when list ("each of the four surfaces has a stub markdown file").

## Changes

- New `docs/abi/capability-handle.md` with the standard Owner / Status / Last reviewed / Tracking issue header, scope outline, "To be filled by #233" pointer, and a `Last verified against commit` line.
- `docs/abi/README.md`: index entry + bumped `Last verified against commit`.
- `README.md`: top-level ABI-reference bullet now lists `capability-handle`.

No code changes. Pure docs scaffold; safe to land while the ed25519/fs-test PR chain is still red (per #179).

## Validation

- `git diff --stat` shows docs-only changes.
- No code or build artifacts touched, so no `build/scripts/test.sh` run is applicable for this scaffold-only change.

## Follow-ups

- #233 fills in the normative bit-layout, revocation, and `cap_gate_check_handle()` text in the new stub.
- #181 can close once maintainers confirm all four §7 surfaces are now individually landed (this PR completes the fourth).