### PR TITLE
docs(roadmap): wire BUILD_ROADMAP §5.4 to existing broker_share TEST:PASS markers (fix #314)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -308,8 +308,76 @@ Deliver:
 
 Validate:
 
-- allow flow succeeds and logs audited transfer
-- deny flow issues no cap and app handles gracefully
+- allow flow succeeds and logs audited transfer — satisfied by
+  `TEST:PASS:broker_share_allow` plus sub-checks
+  `:owner_holds_cap`, `:request_returns_pending_share_id`,
+  `:approve_grants_recipient`, `:scope_is_resource_bound`, and
+  `:scope_is_capability_bound` (see `tests/broker_share_allow_test.c`,
+  run via `build/scripts/test.sh broker_share_allow`). The `_qemu`
+  substrate peer asserts the same contract end-to-end with the
+  `_qemu`-suffixed marker spellings
+  `TEST:PASS:m4_broker_share_allow_qemu` plus sub-checks
+  `:owner_holds_cap_qemu`, `:request_returns_pending_share_id_qemu`,
+  `:approve_grants_recipient_qemu`, `:scope_is_resource_bound_qemu`, and
+  `:scope_is_capability_bound_qemu` (see
+  `tests/m4_broker_share_allow_qemu_test.c`, run via
+  `build/scripts/test.sh m4_broker_share_allow_qemu` /
+  `build/scripts/test_m4_broker_share_allow_qemu.sh`). The audit-side
+  `audit_grant_recorded` assertion is currently gated behind the
+  broker→audit wiring follow-up #311 (depends on #84 / #98) and the
+  host slice asserts the explicit
+  `TEST:SKIP:broker_share_allow:audit_grant_recorded:broker_audit_unwired_pending_issue_98`
+  marker so the validator distinguishes "not asserted" from
+  "asserted and passed".
+- deny flow issues no cap and app handles gracefully — satisfied by
+  `TEST:PASS:broker_share_deny` plus sub-checks
+  `:owner_holds_cap`, `:request_returns_pending_share_id`, `:deny_path`,
+  `:no_recipient_grant`, `:cannot_be_re_approved`, and
+  `:bystander_cannot_mutate` (see `tests/broker_share_deny_test.c`,
+  run via `build/scripts/test.sh broker_share_deny`). The `_qemu`
+  substrate peer asserts the same contract under QEMU with markers
+  `TEST:PASS:m4_broker_share_deny_qemu` plus sub-checks
+  `:request_returns_pending_share_id_qemu`, `:deny_blocks_recipient_qemu`,
+  `:cannot_be_re_approved_qemu`, `:bystander_cannot_mutate_qemu`,
+  `:scope_is_resource_bound_qemu`, and `:scope_is_capability_bound_qemu`
+  (see `tests/m4_broker_share_deny_qemu_test.c`, run via
+  `build/scripts/test.sh m4_broker_share_deny_qemu` /
+  `build/scripts/test_m4_broker_share_deny_qemu.sh`). Both host and
+  `_qemu` slices currently emit
+  `TEST:SKIP:broker_share_deny:audit_deny_recorded:broker_audit_unwired_pending_issue_98`
+  and
+  `TEST:SKIP:m4_broker_share_deny_qemu:audit_deny_recorded_qemu:broker_audit_unwired_pending_issue_98`
+  respectively, gated on the broker→audit wiring follow-up #311.
+- revoke flow restores the deny posture and is idempotent — satisfied
+  by `TEST:PASS:broker_share_revoke` plus sub-checks
+  `:setup_grants_recipient`, `:owner_revoke_takes_effect`,
+  `:underlying_table_revoked`, `:double_revoke_is_idempotent`, and
+  `:recipient_self_revoke` (see `tests/broker_share_revoke_test.c`,
+  run via `build/scripts/test.sh broker_share_revoke`). The `_qemu`
+  substrate peer asserts the same contract under QEMU with markers
+  `TEST:PASS:m4_broker_share_revoke_qemu` plus sub-checks
+  `:setup_grants_recipient_qemu`, `:owner_revoke_takes_effect_qemu`,
+  `:underlying_table_revoked_qemu`, `:double_revoke_is_idempotent_qemu`,
+  `:order_observed_qemu`, `:recipient_self_revoke_qemu`, and
+  `:process_destroy_recycle_revokes` (see
+  `tests/m4_broker_share_revoke_qemu_test.c`, run via
+  `build/scripts/test.sh m4_broker_share_revoke_qemu` /
+  `build/scripts/test_m4_broker_share_revoke_qemu.sh`). Both host and
+  `_qemu` slices emit
+  `TEST:SKIP:broker_share_revoke:audit_revoke_recorded:broker_audit_unwired_pending_issue_98`
+  and
+  `TEST:SKIP:m4_broker_share_revoke_qemu:audit_revoke_recorded_qemu:broker_audit_unwired_pending_issue_98`
+  respectively, gated on the broker→audit wiring follow-up #311.
+
+These markers are anchored by the M4 host-fixture acceptance work in
+#115 (broker_share_{allow,deny,revoke} + 16 sub-checks) and the
+substrate plan #299 (M4 capability broker re-platformed onto merged M1
+substrate + M2/M3 service-module precedent), with the `_qemu` peers
+landed by #304 (allow + deny) and #305 (revoke), matching how §5.2
+references plan #259 and §5.3 references plan #277 + its closed slice
+issues. The currently-SKIPped `audit_*_recorded` markers will be
+turned into PASS by the broker→audit wiring follow-up #311 (which
+depends on the audit-ring wiring tracked in #84 / #98).
 
 ## 5.5 M5: Ownership graph + cascading deletion
 


### PR DESCRIPTION
Fixes #314.

Mirrors the §5.2 (#256) / §5.3 (#284 → PR #288) marker-wiring pattern onto §5.4 (M4 Capability Broker + share workflow) so the roadmap's English "Validate" bullets reference the concrete `TEST:PASS:` / `TEST:SKIP:` markers (and sub-checks) that are already green on `main`, plus the matching `_qemu` substrate peers.

## Wiring summary

- **allow flow** → `TEST:PASS:broker_share_allow` + 5 sub-checks (`tests/broker_share_allow_test.c`, `build/scripts/test.sh broker_share_allow`), and the `_qemu` peer `TEST:PASS:m4_broker_share_allow_qemu` + 5 `_qemu` sub-checks (`tests/m4_broker_share_allow_qemu_test.c`, `build/scripts/test_m4_broker_share_allow_qemu.sh`).
- **deny flow** → `TEST:PASS:broker_share_deny` + 6 sub-checks (`tests/broker_share_deny_test.c`, `build/scripts/test.sh broker_share_deny`), and the `_qemu` peer `TEST:PASS:m4_broker_share_deny_qemu` + 6 `_qemu` sub-checks (`tests/m4_broker_share_deny_qemu_test.c`, `build/scripts/test_m4_broker_share_deny_qemu.sh`).
- **revoke flow** → `TEST:PASS:broker_share_revoke` + 5 sub-checks (`tests/broker_share_revoke_test.c`, `build/scripts/test.sh broker_share_revoke`), and the `_qemu` peer `TEST:PASS:m4_broker_share_revoke_qemu` + 7 `_qemu` sub-checks (`tests/m4_broker_share_revoke_qemu_test.c`, `build/scripts/test_m4_broker_share_revoke_qemu.sh`).
- **audit SKIPs** → each of the three `audit_*_recorded` markers is shown verbatim with its `:broker_audit_unwired_pending_issue_98` reason, for both the host slice and the `_qemu` peer, and linked to the broker→audit wiring follow-up #311 (which depends on #84 / #98).

## Cross-links added

- #115 — host-fixture acceptance tests (broker_share_{allow,deny,revoke} + 16 sub-checks).
- #299 — substrate plan (M4 capability broker re-platformed onto merged M1 substrate).
- #304 / #305 — `_qemu` peer slices (allow + deny, revoke).
- #311 — broker→audit wiring follow-up that converts the SKIPs to PASS.

## Validation

- Docs-only change; no code touched.
- Every marker spelling cited was grep-verified to appear verbatim in either a test source file under `tests/` or a runner script under `build/scripts/` (per issue #314's "no invented markers" acceptance criterion).

## Follow-ups (out of scope for this PR)

- §5.5 / §5.6 marker wiring waits until those milestones ship code.
- #311 will let us replace the `audit_*_recorded` SKIP lines here with PASS spellings.