### PR TITLE
docs(manifest): add optional capabilities.broker_role enum (closes #312)

### DIFF
--- a/build/scripts/.shell_parity_allowlist
+++ b/build/scripts/.shell_parity_allowlist
@@ -80,6 +80,7 @@ test_launcher_fs
 test_launcher_spawn_handoff
 test_launcher_fs_spawn_handoff
 test_launcher_broker_spawn_handoff
+test_manifest_broker_role_enum
 test_manifest_persistence_enum
 test_manifest_required_fields
 test_netlib_url_scheme

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -72,7 +72,7 @@ stop_secureos_instances
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -325,6 +325,15 @@ case "$TEST_NAME" in
     # example validates and that a bad enum value is rejected with a
     # deterministic MANIFEST_VALIDATE:* marker.
     run_script "$ROOT_DIR/build/scripts/test_manifest_persistence_enum.sh"
+    ;;
+  manifest_broker_role_enum)
+    # Issue #312: positive + negative coverage for the optional
+    # `capabilities.broker_role` enum (provider|consumer|none, default
+    # none) added to manifests/schema/v0.json. Asserts the checked-in
+    # provider/consumer examples validate, the pre-existing helloapp.json
+    # (which omits the field) still validates, and that a bad enum value
+    # is rejected with a deterministic MANIFEST_VALIDATE:* marker.
+    run_script "$ROOT_DIR/build/scripts/test_manifest_broker_role_enum.sh"
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"

--- a/build/scripts/test_manifest_broker_role_enum.sh
+++ b/build/scripts/test_manifest_broker_role_enum.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# build/scripts/test_manifest_broker_role_enum.sh
+#
+# Issue #312: positive + negative coverage for the optional
+# `capabilities.broker_role` enum (provider|consumer|none, default
+# "none") added to manifests/schema/v0.json.
+#
+# Asserts:
+#
+#   1. The checked-in positive examples
+#      (manifests/examples/helloapp.broker_provider.json and
+#      manifests/examples/helloapp.broker_consumer.json) validate
+#      against the schema and are reported as MANIFEST_VALIDATE:PASS
+#      by the standard validator wrapper.
+#   2. A synthesized manifest that sets `capabilities.broker_role` to
+#      a value outside the enum (e.g. "everyone") is REJECTED by the
+#      validator wrapper, with a deterministic MANIFEST_VALIDATE:(ERROR|FAIL)
+#      marker on stderr, and the offending field name surfaces in the
+#      error text. This is the regression that keeps a typo'd / drifted
+#      enum from silently leaking back in.
+#   3. The pre-existing `helloapp.json` (which omits `broker_role`
+#      entirely) still validates, proving the field is additive and
+#      backward-compatible (default = "none", today's behavior).
+#
+# Exit codes:
+#   0  - all checks passed
+#   1  - regression: validator accepted a bad enum, or rejected a good one
+#   78 - harness error (env/tool missing)
+#
+# Markers emitted on this script's own success path:
+#   TEST:PASS:manifest_broker_role_enum
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
+POS_PROVIDER="$ROOT_DIR/manifests/examples/helloapp.broker_provider.json"
+POS_CONSUMER="$ROOT_DIR/manifests/examples/helloapp.broker_consumer.json"
+POS_OMITTED="$ROOT_DIR/manifests/examples/helloapp.json"
+
+if [[ ! -r "$WRAPPER" ]]; then
+  echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
+  exit 78
+fi
+for f in "$POS_PROVIDER" "$POS_CONSUMER" "$POS_OMITTED"; do
+  if [[ ! -r "$f" ]]; then
+    echo "TEST:FAIL:harness_missing_positive_example:$f" >&2
+    exit 78
+  fi
+done
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_python" >&2
+  exit 78
+fi
+if ! "$PY" -c "import jsonschema" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_jsonschema" >&2
+  exit 78
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Positives: each must validate and emit MANIFEST_VALIDATE:PASS. ---
+check_positive() {
+  local label="$1"
+  local path="$2"
+  local out="$TMP/${label}.log"
+  set +e
+  bash "$WRAPPER" "$path" >"$out" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    echo "TEST:FAIL:manifest_broker_role_enum:${label}_rejected" >&2
+    sed 's/^/  | /' "$out" >&2
+    exit 1
+  fi
+  if ! grep -q "MANIFEST_VALIDATE:PASS" "$out"; then
+    echo "TEST:FAIL:manifest_broker_role_enum:${label}_missing_pass_marker" >&2
+    sed 's/^/  | /' "$out" >&2
+    exit 1
+  fi
+}
+
+check_positive "provider_example" "$POS_PROVIDER"
+check_positive "consumer_example" "$POS_CONSUMER"
+check_positive "omitted_field_backcompat" "$POS_OMITTED"
+
+# --- Negative: synthesize an out-of-enum value and assert rejection. ---
+TAMPERED="$TMP/broker_role_bad.json"
+cat >"$TAMPERED" <<'EOF'
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "broker_role": "everyone"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}
+EOF
+
+NEG_OUT="$TMP/neg.log"
+set +e
+bash "$WRAPPER" "$TAMPERED" >"$NEG_OUT" 2>&1
+NEG_RC=$?
+set -e
+
+if [[ "$NEG_RC" -eq 0 ]]; then
+  echo "TEST:FAIL:manifest_broker_role_enum:bad_enum_accepted" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_broker_role_enum:missing_deterministic_marker" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -q "broker_role" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_broker_role_enum:field_name_not_in_error" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:manifest_broker_role_enum"

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -227,4 +227,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 756ea5d5454843dba079abc5a358591ccddbdad8
+Last verified against commit: e72e1b90042f24d8d114a2aeda7441cda645704d

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -121,6 +121,23 @@ Field semantics we are committing to at v0:
   lands in issue #279 — so this is an additive, v0-compatible
   change and does **not** bump `OS_ABI_VERSION` (see Compatibility
   policy below).
+- `capabilities.broker_role` is an optional enum
+  (`"provider"` | `"consumer"` | `"none"`) that declares whether
+  this app participates in the broker-share contracts named in
+  BUILD_ROADMAP §5.4 (`DocumentProvider` / `AttachmentConsumer`,
+  see issue #312 and plan #299). The default is `"none"`, which
+  preserves today's behavior exactly: the launcher hands no broker
+  handle to the app at spawn time and `ipc_scratch[24..31]` is left
+  as it is in the pre-broker spawn path. `"provider"` marks an app
+  that exposes shareable handles via `broker_svc`; `"consumer"`
+  marks an app that expects to receive a broker-issued handle in
+  `ipc_scratch[24..31]` on spawn. Like `persistence`, this field is
+  schema-only at v0 — the launcher and `broker_svc` wiring lands
+  in a later slice (plan #299 follow-up). Because the field is
+  **optional**, has a non-`"none"` value only when explicitly
+  declared, and `"none"` exactly preserves the current spawn path,
+  adding it is additive and does **not** bump `OS_ABI_VERSION`
+  (same precedent as `capabilities.persistence` in #285/#286).
 - `provides[]` lists IPC endpoints the app exposes (see
   [`ipc-wire.md`](./ipc-wire.md)). Endpoint names use a narrow
   reverse-DNS-ish pattern.
@@ -157,6 +174,26 @@ into [`manifests/examples/`](../../manifests/examples/):
   capability-audit deny event is recorded (see #92 for the dedicated
   negative-path test and #84 for the audit assertion).
 
+Two additional fixtures exercise the optional
+`capabilities.broker_role` enum added in #312:
+
+- **Broker provider** —
+  [`helloapp.broker_provider.json`](../../manifests/examples/helloapp.broker_provider.json):
+  same as `helloapp.json` but with `capabilities.broker_role:
+  "provider"`. Demonstrates a `DocumentProvider` declaration.
+- **Broker consumer** —
+  [`helloapp.broker_consumer.json`](../../manifests/examples/helloapp.broker_consumer.json):
+  same as `helloapp.json` but with `capabilities.broker_role:
+  "consumer"`. Demonstrates an `AttachmentConsumer` declaration.
+
+Both fixtures are schema-only at v0: the launcher and `broker_svc`
+still behave as they do today (no broker handle is handed in on
+spawn) — the field's runtime meaning is wired up in a later slice
+(plan #299 follow-up). The existing `helloapp.json` /
+`helloapp.deny.json` / `helloapp.persistent.json` examples omit
+`broker_role` and so continue to behave as `broker_role: "none"`,
+proving that the addition is backward-compatible.
+
 ## Compatibility policy
 
 `manifest_version` and `os_abi_version` are two intentionally separate
@@ -190,4 +227,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 7f303d7e901d6707e6f223a2b1fa1b0621792963
+Last verified against commit: 756ea5d5454843dba079abc5a358591ccddbdad8

--- a/manifests/examples/helloapp.broker_consumer.json
+++ b/manifests/examples/helloapp.broker_consumer.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "broker_role": "consumer"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/examples/helloapp.broker_provider.json
+++ b/manifests/examples/helloapp.broker_provider.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "broker_role": "provider"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -73,6 +73,12 @@
           "type": "string",
           "enum": ["ephemeral", "persistent"],
           "default": "ephemeral"
+        },
+        "broker_role": {
+          "description": "Broker-share role this app participates in (BUILD_ROADMAP §5.4, issue #312). 'provider' is a DocumentProvider that produces shareable handles via broker_svc; 'consumer' is an AttachmentConsumer that receives broker-issued handles in ipc_scratch[24..31]; 'none' (default) keeps today's behavior of no broker handle on spawn. Schema-only / additive at v0 — launcher and broker_svc wiring lands in a later slice (plan #299 follow-up); this field does not bump OS_ABI_VERSION.",
+          "type": "string",
+          "enum": ["provider", "consumer", "none"],
+          "default": "none"
         }
       }
     },


### PR DESCRIPTION
Closes #312 — M4-SUBSTRATE-DOC follow-up from plan #299. Mirrors the M3 #285/#286 housekeeping shape.

## What changed

Docs + schema + fixtures only. No kernel / broker / launcher code touched.

- **`manifests/schema/v0.json`** — added optional `capabilities.broker_role` enum (`provider | consumer | none`), default `none` (= today's behavior: no broker handle handed in on spawn). Additive and default-preserves-behavior, so **no `OS_ABI_VERSION` bump** (same precedent #286 set for `capabilities.persistence`).
- **`docs/abi/manifest.md`** — describes the field, its default, and the BUILD_ROADMAP §5.4 `DocumentProvider` / `AttachmentConsumer` linkage; lists the two new example fixtures; `Last verified against commit` stamp refreshed (passes #297/#298 check).
- **`manifests/examples/helloapp.broker_provider.json`** and **`helloapp.broker_consumer.json`** — two new fixtures, one for each non-default role.
- **`build/scripts/test_manifest_broker_role_enum.sh`** — positive coverage for both new fixtures, a backward-compat check that the pre-existing `helloapp.json` (broker_role omitted) still validates, and negative coverage that an out-of-enum value (e.g. `"everyone"`) is rejected with a deterministic `MANIFEST_VALIDATE:*` marker and surfaces the field name in the error. Modeled directly on `test_manifest_persistence_enum.sh`.
- **`build/scripts/test.sh`** — new `manifest_broker_role_enum` target (in usage line + dispatcher).
- **`build/scripts/.shell_parity_allowlist`** — exempts the new test from the `.sh ↔ .ps1` parity gate alongside its persistence-enum peer (issue #156 retires both together).

## Validation performed

```
TEST:PASS:manifest_broker_role_enum
TEST:PASS:manifest_persistence_enum               # no regression
MANIFEST_VALIDATE:SUMMARY:pass 5/5                # all helloapp.*.json
ABI_STAMP:PASS:docs/abi/manifest.md:756ea5d545    # stamp fresh
PARITY:OK: build/scripts/ .sh ↔ .ps1 in sync (allowlist: 86 entries)
```

## Acceptance criteria (from #312)

- [x] `manifests/schema/v0.json` has `capabilities.broker_role` with enum + default documented.
- [x] `docs/abi/manifest.md` describes the field, default, and §5.4 linkage; `Last verified against commit` stamp updated and passes the #297/#298 CI check.
- [x] At least one new fixture exercises `broker_role: "provider"` and at least one exercises `"consumer"`.
- [x] Existing manifest-parsing tests still pass with the field absent (the `helloapp.json` validate-still-passes check in the new test is the explicit backward-compat proof).
- [x] No change to launcher / broker_svc behavior or boot order — schema + docs only.

## Out of scope (per #312)

- Wiring `broker_role` into the launcher's broker-cap handoff (M5 ownership slice).
- Adding `CAP_BROKER_REQ` (separate, ABI-bumping issue per plan #299).

## Follow-ups

- When the launcher / `broker_svc` wiring lands, the `Status` line in `docs/abi/manifest.md` for this field should flip from "schema-only at v0" to "load-bearing", and a runtime QEMU test should grow alongside.

Refs #312, #299, #285, #286, #297, #298.