### PR TITLE
Revise help command to display categorized, multi-line output

### DIFF
--- a/user/apps/os/help/resources/help.txt
+++ b/user/apps/os/help/resources/help.txt
@@ -1,4 +1,15 @@
 usage: help [command]
+
+display help information for shell commands.
+
+  help          show all available commands grouped by category
+  help <cmd>    show detailed usage for a specific command
+
+adding help for new commands:
+  place a text file named <command>.txt in the help resources
+  directory. the file contents will be displayed when the user
+  runs "help <command>".
+
 examples:
   help
   help ls

--- a/user/apps/os/help/resources/index.txt
+++ b/user/apps/os/help/resources/index.txt
@@ -1,2 +1,41 @@
-commands: help, ping <host>, ifconfig, echo <text>, ls [dir], env [key[=value]|key value], cat <file>, write <file> <text>, append <file> <text>, mkdir <dir>, rm [-f] [-v] [-d] <path>, cd <dir>, clear, session [list|new|switch <id>], storage, apps, libs [loaded|use <h>|release <h>], loadlib <lib>, unload <handle>, about, http, run <app>, exit <pass|fail>
-tip: run "help <command>" for command-specific details.
+SecureOS Shell Commands
+=======================
+
+  Navigation & Files:
+    ls [dir]              list directory contents
+    cd <dir>              change working directory
+    cat <file>            display file contents
+    write <file> <text>   write text to a file
+    append <file> <text>  append text to a file
+    mkdir <dir>           create a directory
+    rm [-f] [-v] [-d] <path>  remove files or directories
+
+  System:
+    about [file]          show system or file information
+    env [key[=val]]       view or set environment variables
+    session [list|new|switch <id>]  manage sessions
+    storage               show storage information
+    clear                 clear the console
+    exit <pass|fail>      terminate the current session
+    date                  display the current date and time
+
+  Networking:
+    ping <host>           send an ICMP echo request
+    ifconfig              display network interfaces
+    http                  make HTTP requests
+
+  Applications & Libraries:
+    apps                  list installed applications
+    run <app>             launch an application
+    libs [loaded|use|release]  manage shared libraries
+    loadlib <lib>         load a shared library
+    unload <handle>       unload a shared library
+
+  Security:
+    auth-cache [list|reset]  manage authentication cache
+
+  Help:
+    help [command]        show this list or details for a command
+    echo <text>           print text to the console
+
+tip: run "help <command>" for detailed usage of any command.

--- a/user/os_commands/help.cmd
+++ b/user/os_commands/help.cmd
@@ -1,7 +1,42 @@
 # Display the top-level command index.
-print commands: help, ping <host>, ifconfig, echo <text>, ls [dir], env [key[=value]|key value]
-print commands: cat <file>, write <file> <text>, append <file> <text>, mkdir <dir>, rm [-f] [-v] [-d] <path>, cd <dir>, clear
-print commands: session [list|new|switch <id>], storage, apps, libs [loaded|use <h>|release <h>]
-print commands: loadlib <lib>, unload <handle>, about, http, run <app>, exit <pass|fail>
-print commands: auth-cache [list|reset]
-print tip: run help <command> for command-specific details.
+print SecureOS Shell Commands
+print =======================
+print
+print   Navigation & Files:
+print     ls [dir]              list directory contents
+print     cd <dir>              change working directory
+print     cat <file>            display file contents
+print     write <file> <text>   write text to a file
+print     append <file> <text>  append text to a file
+print     mkdir <dir>           create a directory
+print     rm [-f] [-v] [-d] <path>  remove files or directories
+print
+print   System:
+print     about [file]          show system or file information
+print     env [key[=val]]       view or set environment variables
+print     session [list|new|switch <id>]  manage sessions
+print     storage               show storage information
+print     clear                 clear the console
+print     exit <pass|fail>      terminate the current session
+print     date                  display the current date and time
+print
+print   Networking:
+print     ping <host>           send an ICMP echo request
+print     ifconfig              display network interfaces
+print     http                  make HTTP requests
+print
+print   Applications & Libraries:
+print     apps                  list installed applications
+print     run <app>             launch an application
+print     libs [loaded|use|release]  manage shared libraries
+print     loadlib <lib>         load a shared library
+print     unload <handle>       unload a shared library
+print
+print   Security:
+print     auth-cache [list|reset]  manage authentication cache
+print
+print   Help:
+print     help [command]        show this list or details for a command
+print     echo <text>           print text to the console
+print
+print tip: run "help <command>" for detailed usage of any command.


### PR DESCRIPTION
## Summary

Rewrites the help command output from a single long comma-separated line into a nicely formatted, categorized layout that fits the terminal.

## Changes

- **index.txt** - Commands grouped by category (Navigation & Files, System, Networking, Applications & Libraries, Security, Help) with aligned descriptions
- **help.cmd** - Fallback .cmd updated to match
- **help.txt** - Documents the extensible model: drop a command.txt in resources/ to add help for new commands

## Extensibility

Adding help for a new command requires only creating a text file at user/apps/os/help/resources/command.txt. The build system and main.c automatically pick it up.