### PR TITLE
fix: add PS/2 keyboard driver and VGA cursor for graphics mode

### DIFF
--- a/build/scripts/build_kernel_entry.sh
+++ b/build/scripts/build_kernel_entry.sh
@@ -30,11 +30,13 @@ clang $CFLAGS -c kernel/cap/cap_table.c -o artifacts/kernel/cap_table.o
 clang $CFLAGS -c kernel/event/event_bus.c -o artifacts/kernel/event_bus.o
 clang $CFLAGS -c kernel/hal/network_hal.c -o artifacts/kernel/network_hal.o
 clang $CFLAGS -c kernel/hal/serial_hal.c -o artifacts/kernel/serial_hal.o
+clang $CFLAGS -c kernel/hal/input_hal.c -o artifacts/kernel/input_hal.o
 clang $CFLAGS -c kernel/hal/storage_hal.c -o artifacts/kernel/storage_hal.o
 clang $CFLAGS -c kernel/hal/video_hal.c -o artifacts/kernel/video_hal.o
 clang $CFLAGS -c kernel/drivers/disk/ramdisk.c -o artifacts/kernel/ramdisk.o
 clang $CFLAGS -c kernel/drivers/network/virtio_net.c -o artifacts/kernel/virtio_net.o
 clang $CFLAGS -c kernel/drivers/serial/pc_com.c -o artifacts/kernel/pc_com.o
+clang $CFLAGS -c kernel/drivers/input/ps2_keyboard.c -o artifacts/kernel/ps2_keyboard.o
 clang $CFLAGS -c kernel/drivers/video/vga_text.c -o artifacts/kernel/vga_text.o
 clang $CFLAGS -c kernel/drivers/video/framebuffer_text_stub.c -o artifacts/kernel/framebuffer_text_stub.o
 clang $CFLAGS -c kernel/drivers/video/gpio_text_stub.c -o artifacts/kernel/gpio_text_stub.o
@@ -56,7 +58,7 @@ clang $CFLAGS -c kernel/hal/clock_hal.c -o artifacts/kernel/clock_hal.o
 ld.lld -m elf_x86_64 -T kernel/arch/x86/boot/linker.ld \
   -Map=artifacts/kernel/kernel.map \
   -o artifacts/kernel/kernel.elf \
-  artifacts/kernel/entry.o artifacts/kernel/kmain.o artifacts/kernel/console.o artifacts/kernel/session_manager.o artifacts/kernel/boot_banner.o artifacts/kernel/scheduler.o artifacts/kernel/ata_pio.o artifacts/kernel/debug_exit.o artifacts/kernel/serial.o artifacts/kernel/vga.o artifacts/kernel/cap_table.o artifacts/kernel/event_bus.o artifacts/kernel/network_hal.o artifacts/kernel/serial_hal.o artifacts/kernel/storage_hal.o artifacts/kernel/video_hal.o artifacts/kernel/ramdisk.o artifacts/kernel/virtio_net.o artifacts/kernel/pc_com.o artifacts/kernel/vga_text.o artifacts/kernel/framebuffer_text_stub.o artifacts/kernel/gpio_text_stub.o artifacts/kernel/sha512.o artifacts/kernel/ed25519.o artifacts/kernel/cert.o artifacts/kernel/sof.o artifacts/kernel/fs_service.o artifacts/kernel/native_net_service.o artifacts/kernel/launcher_exec.o artifacts/kernel/ipc_port.o artifacts/kernel/console_svc.o artifacts/kernel/fs_svc.o artifacts/kernel/broker_svc.o artifacts/kernel/cmos_rtc.o artifacts/kernel/clock_service.o artifacts/kernel/clock_hal.o
+  artifacts/kernel/entry.o artifacts/kernel/kmain.o artifacts/kernel/console.o artifacts/kernel/session_manager.o artifacts/kernel/boot_banner.o artifacts/kernel/scheduler.o artifacts/kernel/ata_pio.o artifacts/kernel/debug_exit.o artifacts/kernel/serial.o artifacts/kernel/vga.o artifacts/kernel/cap_table.o artifacts/kernel/event_bus.o artifacts/kernel/network_hal.o artifacts/kernel/serial_hal.o artifacts/kernel/input_hal.o artifacts/kernel/storage_hal.o artifacts/kernel/video_hal.o artifacts/kernel/ramdisk.o artifacts/kernel/virtio_net.o artifacts/kernel/pc_com.o artifacts/kernel/ps2_keyboard.o artifacts/kernel/vga_text.o artifacts/kernel/framebuffer_text_stub.o artifacts/kernel/gpio_text_stub.o artifacts/kernel/sha512.o artifacts/kernel/ed25519.o artifacts/kernel/cert.o artifacts/kernel/sof.o artifacts/kernel/fs_service.o artifacts/kernel/native_net_service.o artifacts/kernel/launcher_exec.o artifacts/kernel/ipc_port.o artifacts/kernel/console_svc.o artifacts/kernel/fs_svc.o artifacts/kernel/broker_svc.o artifacts/kernel/cmos_rtc.o artifacts/kernel/clock_service.o artifacts/kernel/clock_hal.o
 
 if command -v llvm-objdump >/dev/null 2>&1; then
   llvm-objdump -h artifacts/kernel/kernel.elf > artifacts/kernel/kernel.sections.txt

--- a/kernel/core/console.c
+++ b/kernel/core/console.c
@@ -36,6 +36,7 @@
 #include "../cap/cap_table.h"
 #include "../event/event_bus.h"
 #include "../fs/fs_service.h"
+#include "../hal/input_hal.h"
 #include "../hal/serial_hal.h"
 #include "../hal/video_hal.h"
 #include "../user/launcher_exec.h"
@@ -1085,7 +1086,7 @@ static void console_history_recall_down(void) {
 static char console_wait_for_yes_no(void) {
   for (;;) {
     char input = '\0';
-    if (!serial_hal_try_read_char(&input)) {
+    if (!input_hal_try_read_char(&input)) {
       console_idle_wait();
       continue;
     }
@@ -1607,7 +1608,7 @@ void console_run(void) {
   for (;;) {
     char input = '\0';
 
-    if (!serial_hal_try_read_char(&input)) {
+    if (!input_hal_try_read_char(&input)) {
       console_idle_wait();
       continue;
     }

--- a/kernel/core/kmain.c
+++ b/kernel/core/kmain.c
@@ -37,6 +37,7 @@
 #include "../drivers/clock/cmos_rtc.h"
 #include "../drivers/disk/ata_pio.h"
 #include "../drivers/disk/ramdisk.h"
+#include "../drivers/input/ps2_keyboard.h"
 #include "../drivers/network/virtio_net.h"
 #include "../drivers/video/framebuffer_text_stub.h"
 #include "../drivers/video/gpio_text_stub.h"
@@ -44,6 +45,7 @@
 #include "../drivers/video/vga_text.h"
 #include "../clock/clock_service.h"
 #include "../hal/network_hal.h"
+#include "../hal/input_hal.h"
 #include "../hal/serial_hal.h"
 #include "../hal/video_hal.h"
 #include "../event/event_bus.h"
@@ -62,12 +64,14 @@ static const cap_subject_id_t FILEDEMO_SUBJECT = 1u;
 __attribute__((used))
 void kmain(void) {
   (void)pc_com_serial_init_primary();
+  (void)ps2_keyboard_init();
   if (!vga_text_init_primary()) {
     if (!framebuffer_text_stub_init_primary()) {
       (void)gpio_text_stub_init_primary();
     }
   }
   video_hal_clear();
+  input_hal_init();
   cap_table_init();
   event_bus_reset_for_tests();
   if (!ata_pio_init_primary()) {

--- a/kernel/drivers/input/ps2_keyboard.c
+++ b/kernel/drivers/input/ps2_keyboard.c
@@ -1,0 +1,219 @@
+/**
+ * @file ps2_keyboard.c
+ * @brief PS/2 keyboard driver for x86 8042 controller.
+ *
+ * Purpose:
+ *   Implements keyboard input by polling the PS/2 keyboard controller at
+ *   I/O ports 0x60 (data) and 0x64 (status). Translates scan code set 1
+ *   key-press events into ASCII characters. Handles shift state for
+ *   uppercase letters and shifted symbols.
+ *
+ * Interactions:
+ *   - hal/input_hal.c: the input HAL calls ps2_keyboard_try_read_char()
+ *     as one of its input sources.
+ *   - core/kmain.c: calls ps2_keyboard_init() at boot time.
+ *
+ * Launched by:
+ *   Invoked during kernel startup. Not a standalone process; compiled into
+ *   the kernel image.
+ */
+
+#include "ps2_keyboard.h"
+
+#define PS2_DATA_PORT   0x60u
+#define PS2_STATUS_PORT 0x64u
+#define PS2_CMD_PORT    0x64u
+
+/* Status register bits */
+#define PS2_STATUS_OUTPUT_FULL 0x01u
+
+/* Scan code set 1 key codes */
+#define SC_LSHIFT_PRESS   0x2Au
+#define SC_RSHIFT_PRESS   0x36u
+#define SC_LSHIFT_RELEASE 0xAAu
+#define SC_RSHIFT_RELEASE 0xB6u
+#define SC_CAPSLOCK_PRESS 0x3Au
+#define SC_CTRL_PRESS     0x1Du
+#define SC_CTRL_RELEASE   0x9Du
+#define SC_BACKSPACE      0x0Eu
+#define SC_ENTER          0x1Cu
+#define SC_TAB            0x0Fu
+#define SC_ESCAPE         0x01u
+#define SC_UP_ARROW       0x48u
+#define SC_DOWN_ARROW     0x50u
+
+static int g_shift_held;
+static int g_caps_lock;
+static int g_ctrl_held;
+
+/* Multi-char output buffer for escape sequences (e.g. arrow keys) */
+#define PS2_SEQ_BUF_MAX 4
+static char g_seq_buf[PS2_SEQ_BUF_MAX];
+static int g_seq_len;
+static int g_seq_pos;
+
+static inline void ps2_outb(unsigned short port, unsigned char value) {
+  __asm__ __volatile__("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static inline unsigned char ps2_inb(unsigned short port) {
+  unsigned char value;
+  __asm__ __volatile__("inb %1, %0" : "=a"(value) : "Nd"(port));
+  return value;
+}
+
+/* Scan code set 1 -> ASCII lookup (unshifted) */
+static const char sc_to_ascii[128] = {
+  0,    0x1B, '1',  '2',  '3',  '4',  '5',  '6',   /* 0x00-0x07 */
+  '7',  '8',  '9',  '0',  '-',  '=',  '\b', '\t',  /* 0x08-0x0F */
+  'q',  'w',  'e',  'r',  't',  'y',  'u',  'i',   /* 0x10-0x17 */
+  'o',  'p',  '[',  ']',  '\n', 0,    'a',  's',   /* 0x18-0x1F */
+  'd',  'f',  'g',  'h',  'j',  'k',  'l',  ';',   /* 0x20-0x27 */
+  '\'', '`',  0,    '\\', 'z',  'x',  'c',  'v',   /* 0x28-0x2F */
+  'b',  'n',  'm',  ',',  '.',  '/',  0,    '*',   /* 0x30-0x37 */
+  0,    ' ',  0,    0,    0,    0,    0,    0,      /* 0x38-0x3F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x40-0x47 */
+  0,    0,    '-',  0,    0,    0,    '+',  0,      /* 0x48-0x4F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x50-0x57 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x58-0x5F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x60-0x67 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x68-0x6F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x70-0x77 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x78-0x7F */
+};
+
+/* Scan code set 1 -> ASCII lookup (shifted) */
+static const char sc_to_ascii_shift[128] = {
+  0,    0x1B, '!',  '@',  '#',  '$',  '%',  '^',   /* 0x00-0x07 */
+  '&',  '*',  '(',  ')',  '_',  '+',  '\b', '\t',  /* 0x08-0x0F */
+  'Q',  'W',  'E',  'R',  'T',  'Y',  'U',  'I',   /* 0x10-0x17 */
+  'O',  'P',  '{',  '}',  '\n', 0,    'A',  'S',   /* 0x18-0x1F */
+  'D',  'F',  'G',  'H',  'J',  'K',  'L',  ':',   /* 0x20-0x27 */
+  '"',  '~',  0,    '|',  'Z',  'X',  'C',  'V',   /* 0x28-0x2F */
+  'B',  'N',  'M',  '<',  '>',  '?',  0,    '*',   /* 0x30-0x37 */
+  0,    ' ',  0,    0,    0,    0,    0,    0,      /* 0x38-0x3F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x40-0x47 */
+  0,    0,    '-',  0,    0,    0,    '+',  0,      /* 0x48-0x4F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x50-0x57 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x58-0x5F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x60-0x67 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x68-0x6F */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x70-0x77 */
+  0,    0,    0,    0,    0,    0,    0,    0,      /* 0x78-0x7F */
+};
+
+int ps2_keyboard_init(void) {
+  g_shift_held = 0;
+  g_caps_lock = 0;
+  g_ctrl_held = 0;
+  g_seq_len = 0;
+  g_seq_pos = 0;
+
+  /* Flush any pending data in the controller output buffer */
+  int flush_count = 0;
+  while ((ps2_inb(PS2_STATUS_PORT) & PS2_STATUS_OUTPUT_FULL) &&
+         flush_count < 64) {
+    (void)ps2_inb(PS2_DATA_PORT);
+    flush_count++;
+  }
+
+  return 1;
+}
+
+static void ps2_queue_sequence(const char *seq, int len) {
+  int i;
+  for (i = 0; i < len && i < PS2_SEQ_BUF_MAX; i++) {
+    g_seq_buf[i] = seq[i];
+  }
+  g_seq_len = len;
+  g_seq_pos = 0;
+}
+
+int ps2_keyboard_try_read_char(char *out_char) {
+  if (out_char == 0) {
+    return 0;
+  }
+
+  /* Drain any pending multi-char sequence first */
+  if (g_seq_pos < g_seq_len) {
+    *out_char = g_seq_buf[g_seq_pos++];
+    return 1;
+  }
+
+  /* Check if data is available */
+  if (!(ps2_inb(PS2_STATUS_PORT) & PS2_STATUS_OUTPUT_FULL)) {
+    return 0;
+  }
+
+  unsigned char scancode = ps2_inb(PS2_DATA_PORT);
+
+  /* Handle modifier keys */
+  if (scancode == SC_LSHIFT_PRESS || scancode == SC_RSHIFT_PRESS) {
+    g_shift_held = 1;
+    return 0;
+  }
+  if (scancode == SC_LSHIFT_RELEASE || scancode == SC_RSHIFT_RELEASE) {
+    g_shift_held = 0;
+    return 0;
+  }
+  if (scancode == SC_CTRL_PRESS) {
+    g_ctrl_held = 1;
+    return 0;
+  }
+  if (scancode == SC_CTRL_RELEASE) {
+    g_ctrl_held = 0;
+    return 0;
+  }
+  if (scancode == SC_CAPSLOCK_PRESS) {
+    g_caps_lock = !g_caps_lock;
+    return 0;
+  }
+
+  /* Ignore key release events (bit 7 set) */
+  if (scancode & 0x80u) {
+    return 0;
+  }
+
+  /* Handle arrow keys - emit ANSI escape sequences */
+  if (scancode == SC_UP_ARROW) {
+    ps2_queue_sequence("\x1B[A", 3);
+    *out_char = g_seq_buf[g_seq_pos++];
+    return 1;
+  }
+  if (scancode == SC_DOWN_ARROW) {
+    ps2_queue_sequence("\x1B[B", 3);
+    *out_char = g_seq_buf[g_seq_pos++];
+    return 1;
+  }
+
+  /* Translate scancode to ASCII */
+  char ch;
+  int use_shift = g_shift_held;
+
+  if (use_shift) {
+    ch = sc_to_ascii_shift[scancode];
+  } else {
+    ch = sc_to_ascii[scancode];
+  }
+
+  /* Apply caps lock to letters */
+  if (g_caps_lock && ch >= 'a' && ch <= 'z') {
+    ch = ch - 'a' + 'A';
+  } else if (g_caps_lock && ch >= 'A' && ch <= 'Z' && !g_shift_held) {
+    ch = ch - 'A' + 'a';
+  }
+
+  /* Handle Ctrl+key combinations */
+  if (g_ctrl_held && ch >= 'a' && ch <= 'z') {
+    ch = (char)(ch - 'a' + 1);
+  } else if (g_ctrl_held && ch >= 'A' && ch <= 'Z') {
+    ch = (char)(ch - 'A' + 1);
+  }
+
+  if (ch == 0) {
+    return 0;
+  }
+
+  *out_char = ch;
+  return 1;
+}

--- a/kernel/drivers/input/ps2_keyboard.h
+++ b/kernel/drivers/input/ps2_keyboard.h
@@ -1,0 +1,34 @@
+#ifndef SECUREOS_PS2_KEYBOARD_H
+#define SECUREOS_PS2_KEYBOARD_H
+
+/**
+ * @file ps2_keyboard.h
+ * @brief PS/2 keyboard driver interface.
+ *
+ * Purpose:
+ *   Declares the initialization and polling API for the PS/2 keyboard
+ *   controller. Translates scan codes from the 8042 controller into ASCII
+ *   characters that can be consumed by the input HAL.
+ *
+ * Interactions:
+ *   - hal/input_hal.c: registers this driver as an input source.
+ *   - core/kmain.c: calls ps2_keyboard_init() during boot.
+ *
+ * Launched by:
+ *   Invoked during kernel startup. Not a standalone process; compiled into
+ *   the kernel image.
+ */
+
+/**
+ * Initialize the PS/2 keyboard controller.
+ * Returns 1 on success, 0 on failure.
+ */
+int ps2_keyboard_init(void);
+
+/**
+ * Try to read one ASCII character from the keyboard buffer.
+ * Returns 1 if a character was read, 0 if no key is available.
+ */
+int ps2_keyboard_try_read_char(char *out_char);
+
+#endif

--- a/kernel/drivers/video/vga_text.c
+++ b/kernel/drivers/video/vga_text.c
@@ -27,8 +27,26 @@
 #define VGA_TEXT_HEIGHT 25
 #define VGA_TEXT_ATTR 0x07
 
+/* VGA CRT controller ports for hardware cursor */
+#define VGA_CRTC_INDEX 0x3D4u
+#define VGA_CRTC_DATA  0x3D5u
+#define VGA_CURSOR_HIGH 0x0Eu
+#define VGA_CURSOR_LOW  0x0Fu
+
 static int g_row;
 static int g_col;
+
+static inline void vga_crtc_outb(unsigned short port, unsigned char value) {
+  __asm__ __volatile__("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static void vga_text_update_cursor(void) {
+  unsigned short pos = (unsigned short)(g_row * VGA_TEXT_WIDTH + g_col);
+  vga_crtc_outb(VGA_CRTC_INDEX, VGA_CURSOR_HIGH);
+  vga_crtc_outb(VGA_CRTC_DATA, (unsigned char)(pos >> 8));
+  vga_crtc_outb(VGA_CRTC_INDEX, VGA_CURSOR_LOW);
+  vga_crtc_outb(VGA_CRTC_DATA, (unsigned char)(pos & 0xFF));
+}
 
 static inline unsigned short vga_text_entry(char value) {
   return (unsigned short)(VGA_TEXT_ATTR << 8) | (unsigned char)value;
@@ -56,6 +74,7 @@ static void vga_text_clear(void) {
 
   g_row = 0;
   g_col = 0;
+  vga_text_update_cursor();
 }
 
 static void vga_text_scroll(void) {
@@ -85,6 +104,11 @@ static void vga_text_advance_row(void) {
 static void vga_text_putc(char value) {
   if (value == '\n') {
     vga_text_advance_row();
+  } else if (value == '\b') {
+    if (g_col > 0) {
+      --g_col;
+      VGA_TEXT_BUFFER[g_row * VGA_TEXT_WIDTH + g_col] = vga_text_entry(' ');
+    }
   } else {
     VGA_TEXT_BUFFER[g_row * VGA_TEXT_WIDTH + g_col] = vga_text_entry(value);
     ++g_col;
@@ -92,11 +116,17 @@ static void vga_text_putc(char value) {
       vga_text_advance_row();
     }
   }
+  vga_text_update_cursor();
 }
 
 static void vga_text_putc_color(char value, uint8_t attr) {
   if (value == '\n') {
     vga_text_advance_row();
+  } else if (value == '\b') {
+    if (g_col > 0) {
+      --g_col;
+      VGA_TEXT_BUFFER[g_row * VGA_TEXT_WIDTH + g_col] = vga_text_entry(' ');
+    }
   } else {
     VGA_TEXT_BUFFER[g_row * VGA_TEXT_WIDTH + g_col] =
         vga_text_entry_color(value, attr);
@@ -105,6 +135,7 @@ static void vga_text_putc_color(char value, uint8_t attr) {
       vga_text_advance_row();
     }
   }
+  vga_text_update_cursor();
 }
 
 static void vga_text_write(const char *message) {

--- a/kernel/hal/input_hal.c
+++ b/kernel/hal/input_hal.c
@@ -1,0 +1,49 @@
+/**
+ * @file input_hal.c
+ * @brief Hardware Abstraction Layer for character input devices.
+ *
+ * Purpose:
+ *   Multiplexes all available character input sources (PS/2 keyboard,
+ *   serial port) into a single polling interface. The console calls
+ *   input_hal_try_read_char() which checks each source in priority order
+ *   and returns the first available character.
+ *
+ * Interactions:
+ *   - drivers/input/ps2_keyboard.c: polled for keyboard scancodes.
+ *   - hal/serial_hal.c: polled for serial input (used in console mode).
+ *   - core/console.c: calls input_hal_try_read_char() in main loop.
+ *
+ * Launched by:
+ *   input_hal_init() is called from kmain during boot after keyboard
+ *   and serial drivers are initialized. Not a standalone process.
+ */
+
+#include "input_hal.h"
+
+#include "../drivers/input/ps2_keyboard.h"
+#include "serial_hal.h"
+
+static int g_input_initialized;
+
+int input_hal_init(void) {
+  g_input_initialized = 1;
+  return 1;
+}
+
+int input_hal_try_read_char(char *out_char) {
+  if (out_char == 0 || !g_input_initialized) {
+    return 0;
+  }
+
+  /* Try PS/2 keyboard first (needed for graphics mode) */
+  if (ps2_keyboard_try_read_char(out_char)) {
+    return 1;
+  }
+
+  /* Fall back to serial input (works in console mode) */
+  if (serial_hal_try_read_char(out_char)) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/kernel/hal/input_hal.h
+++ b/kernel/hal/input_hal.h
@@ -1,0 +1,38 @@
+#ifndef SECUREOS_INPUT_HAL_H
+#define SECUREOS_INPUT_HAL_H
+
+/**
+ * @file input_hal.h
+ * @brief Hardware Abstraction Layer for character input devices.
+ *
+ * Purpose:
+ *   Provides a unified input interface that multiplexes all available
+ *   character input sources (serial port, PS/2 keyboard, etc.) into a
+ *   single polling API. The console and other kernel subsystems call
+ *   input_hal_try_read_char() to get the next available character from
+ *   any connected input device.
+ *
+ * Interactions:
+ *   - hal/serial_hal.c: serial input source.
+ *   - drivers/input/ps2_keyboard.c: keyboard input source.
+ *   - core/console.c: primary consumer of input characters.
+ *
+ * Launched by:
+ *   input_hal_init() is called from kmain during boot.
+ *   Not a standalone process; compiled into kernel image.
+ */
+
+/**
+ * Initialize the input HAL. Call after serial and keyboard drivers are ready.
+ * Returns 1 on success.
+ */
+int input_hal_init(void);
+
+/**
+ * Try to read one character from any available input source.
+ * Checks keyboard first (for graphics mode), then serial.
+ * Returns 1 if a character was read into *out_char, 0 otherwise.
+ */
+int input_hal_try_read_char(char *out_char);
+
+#endif


### PR DESCRIPTION
In graphics mode (-graphics flag), the QEMU window captures keyboard input via the PS/2 controller rather than the serial port. Previously, the console only read from serial, making the graphics window unresponsive to typing.

Changes:
- Add PS/2 keyboard driver (kernel/drivers/input/ps2_keyboard.c) that translates scan code set 1 into ASCII with shift/caps/ctrl support
- Add input HAL (kernel/hal/input_hal.c) that multiplexes PS/2 keyboard and serial input into a single polling interface
- Update console.c to use input_hal_try_read_char() instead of serial_hal_try_read_char() directly
- Add VGA hardware cursor tracking to vga_text.c so the blinking cursor follows the current write position (was stuck at 0,0)
- Handle backspace in VGA text output
- Wire up initialization in kmain.c and build scripts