### PR TITLE
docs: point README + BUILD_ROADMAP §7 at docs/abi/ as canonical ABI home (refs #181)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -448,7 +448,23 @@ Suggested policy:
 In-tree source of truth: `user/include/secureos_abi.h` defines
 `OS_ABI_VERSION_MAJOR`, `OS_ABI_VERSION_MINOR`, and the packed
 `OS_ABI_VERSION` constant; `os_get_abi_version()` exposes it at runtime.
-See `docs/abi/versioning.md` for the full policy and field layout.
+
+The canonical ABI documentation lives under [`docs/abi/`](docs/abi/README.md);
+each of the four §7 surfaces has a dedicated spec there:
+
+- syscall ABI — [`docs/abi/syscalls.md`](docs/abi/syscalls.md)
+- IPC wire format and error model — [`docs/abi/ipc-wire.md`](docs/abi/ipc-wire.md)
+- capability handle representation + revocation —
+  [`docs/abi/capability-handle.md`](docs/abi/capability-handle.md)
+  (see also [`docs/abi/capabilities.md`](docs/abi/capabilities.md))
+- module / launcher manifest schema + compatibility —
+  [`docs/abi/manifest.md`](docs/abi/manifest.md)
+- `OS_ABI_VERSION` policy and field layout —
+  [`docs/abi/versioning.md`](docs/abi/versioning.md)
+
+All new ABI-shaped surface (new syscall, new IPC opcode, new manifest
+field, new capability handle bit) must land its spec under `docs/abi/`
+in the same change that introduces it.
 
 ## 8) Immediate Next 14 Tasks (actionable backlog)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ For graphics mode with the VGA display:
 - `scripts/` — Host-side entry points (setup, build, boot, test)
 - `manifests/` — Capability manifests for processes
 - `docs/` — Architecture decisions, ABI reference, test plans
+  - `docs/abi/` — **canonical ABI reference** (`OS_ABI_VERSION = 0`):
+    syscall surface, IPC wire format, capability handle representation,
+    launcher manifest schema, and the `OS_ABI_VERSION` policy. See
+    [`docs/abi/README.md`](docs/abi/README.md) for the full index.
 - `plans/` — Planning documents for future work
 
 ## Design Principles

--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -41,4 +41,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: fa1653bb46e6d2c85724312c4cc59b41ebd84744
+Last verified against commit: 609a26216b4abbe8db0f138871b1168b15ce9137

--- a/docs/abi/capability-handle.md
+++ b/docs/abi/capability-handle.md
@@ -308,7 +308,7 @@ of which are frozen at v0.
 
 ## Provenance
 
-Last verified against commit: fa1653bb46e6d2c85724312c4cc59b41ebd84744
+Last verified against commit: 609a26216b4abbe8db0f138871b1168b15ce9137
 
 [#115]: https://github.com/rwrife/SecureOS/issues/115
 [#118]: https://github.com/rwrife/SecureOS/issues/118


### PR DESCRIPTION
Closes the final open done-when item on #181 (`docs/abi/` scaffold).

The directory and four §7 surface stubs already exist (landed via #184,
#191, #245, #309 and friends). What was still missing from #181's checklist:

> Top-level `README.md` or `BUILD_ROADMAP.md` reference updated to point
> at `docs/abi/` as the canonical location.

This PR does exactly that, and nothing else.

## Changes

- **README.md** – expand the `docs/` bullet under *Architecture* with a
  dedicated `docs/abi/` sub-bullet that names the four §7 surfaces
  (syscalls, IPC wire, capability handle, manifest) plus the
  `OS_ABI_VERSION` policy, and links `docs/abi/README.md`.
- **BUILD_ROADMAP.md §7** – replace the single `docs/abi/versioning.md`
  pointer with a full per-surface index covering `syscalls.md`,
  `ipc-wire.md`, `capability-handle.md`, `capabilities.md`,
  `manifest.md`, and `versioning.md`. Also codify the rule that any new
  ABI-shaped surface (new syscall, IPC opcode, manifest field, handle
  bit) must land its spec under `docs/abi/` in the same change that
  introduces it.

## Validation

Docs-only change; no code touched, no build scripts affected. Verified
links resolve to existing files in tree (`ls docs/abi/`).

## Follow-ups

- None for #181 itself; remaining ABI work is tracked under the
  per-surface issues already linked from `docs/abi/README.md`
  (#93, #150, #194, #233, etc.).

Refs #181.