### PR TITLE
fix #338 (PR1): bump per-session VFB default to 320x240

### DIFF
--- a/kernel/core/session_manager.c
+++ b/kernel/core/session_manager.c
@@ -33,8 +33,10 @@
 enum {
   SESSION_MAX = 8,
   SESSION_VFB_WIDTH = 320,
-  SESSION_VFB_HEIGHT = 200,
-  SESSION_VFB_SIZE = 64000, /* 320 * 200 */
+  SESSION_VFB_HEIGHT = 240,
+  SESSION_VFB_SIZE = 76800, /* 320 * 240 */
+  SESSION_VFB_WIDTH_MAX = 320,
+  SESSION_VFB_HEIGHT_MAX = 240,
   /* Text grid dimensions for VFB text rendering.
    * Must match the window content area so scrolling triggers at the right time.
    * Window content: 216px wide (36*6), 128px tall (16*8). */
@@ -64,7 +66,7 @@ typedef struct {
   int gfx_mode;                     /* 0 = text, 1 = graphics */
   unsigned char *vfb;               /* Allocated via kmalloc when needed */
   unsigned int vfb_width;           /* Pixel width (set by WM or default 320) */
-  unsigned int vfb_height;          /* Pixel height (set by WM or default 200) */
+  unsigned int vfb_height;          /* Pixel height (set by WM or default 240) */
   /* Text cursor for kernel-side text rendering into VFB */
   int vfb_cursor_col;
   int vfb_cursor_row;
@@ -669,8 +671,8 @@ void session_manager_set_vfb_size(unsigned int session_id,
     return;
   }
   /* Cap at maximum to avoid excessive allocation */
-  if (width > 320) width = 320;
-  if (height > 200) height = 200;
+  if (width > SESSION_VFB_WIDTH_MAX) width = SESSION_VFB_WIDTH_MAX;
+  if (height > SESSION_VFB_HEIGHT_MAX) height = SESSION_VFB_HEIGHT_MAX;
   g_sessions[session_id].vfb_width = width;
   g_sessions[session_id].vfb_height = height;
 }

--- a/kernel/core/session_manager.h
+++ b/kernel/core/session_manager.h
@@ -85,7 +85,7 @@ void session_manager_get_virtual_mouse(unsigned int session_id,
                                        unsigned char *out_buttons);
 
 /**
- * Get a pointer to the session's virtual framebuffer (320x200).
+ * Get a pointer to the session's virtual framebuffer (default 320x240).
  * Returns NULL if session doesn't exist or has no VFB allocated.
  * Allocates a VFB from the pool if the session is WM-managed and doesn't
  * have one yet.
@@ -102,7 +102,7 @@ void session_manager_set_vfb_size(unsigned int session_id,
 
 /**
  * Get the VFB pixel dimensions for a session.
- * Returns defaults (320x200) if not explicitly set.
+ * Returns defaults (320x240) if not explicitly set.
  */
 void session_manager_get_vfb_size(unsigned int session_id,
                                   unsigned int *out_width,


### PR DESCRIPTION
PR1 of the two-PR split outlined on #338 (per the prior cron-comment design discussion). This is the **per-session VFB** half; the physical-display bump to 640×480 (PR2) requires a maintainer pick between VBE LFB and mode 12h and is left for a follow-up.

## What changes

- `kernel/core/session_manager.c`
  - `SESSION_VFB_HEIGHT` 200 → 240 (width unchanged at 320)
  - `SESSION_VFB_SIZE` 64000 → 76800 (320 × 240)
  - new `SESSION_VFB_WIDTH_MAX` / `SESSION_VFB_HEIGHT_MAX` constants, replacing the hard-coded 320/200 clamp in `session_manager_set_vfb_size()`
- `kernel/core/session_manager.h`: header comments updated to 320×240

## Why this is safe before PR2 lands

- Physical display is still VGA mode 13h (320×200) per `vga_gfx.{c,h}`. The compositor (`user/apps/win/compositor.c`) still clamps per-window VFB blits to 200 rows, so the **extra 40 rows in each session's VFB are simply not displayed yet**. PR2 will widen those clamps.
- VFB allocation is already heap-sized via `vw * vh` — no `session_record_t` layout change. Worst-case 8 sessions × 76800 ≈ 600 KB inside the 2 MiB `KHEAP_ARENA_SIZE`, well within budget.
- `user/apps/win/main.c` sets its initial window to `(256, 160)`, well under the cap.
- `launcher_exec.c` calls `mouse_hal_set_bounds(VGA_GFX_WIDTH, VGA_GFX_HEIGHT)` (320/200) — physical mouse bounds, unchanged.
- `OS_GFX_WIDTH` / `OS_GFX_HEIGHT` in `user/include/secureos_api.h` are *physical-screen* constants and stay at 320/200 until PR2.

## Validation

```
gcc -c -ffreestanding -fno-builtin -nostdlib -Wall -Wextra -Werror \
    -Ikernel -Ikernel/core -Iuser/include \
    kernel/core/session_manager.c -o /tmp/sm.o
```
Clean (no warnings/errors). No Docker toolchain available in this cron sandbox; full CI build will exercise the kernel link. No new test target — there is no existing session-VFB host harness; the bump is a constant change covered transitively by every WM-managed-session test.

⚠️ Note: CI is currently red on the `build-and-validate` workflow for **all** open PRs due to #332 / #333 (`ld.lld: command not found` because the workflow still invokes `build/scripts/build.sh` on the bare runner rather than the Docker toolchain). Once #333 merges, a re-run unblocks this PR along with the rest of the queue.

## Follow-ups (out of scope)

- **PR2** — physical resolution bump to 640×480. The issue thread documents the trade-off (VBE LFB at 32bpp vs mode 12h planar at 16-color) in detail; awaiting maintainer pick before opening.
- Once PR2 lands, the compositor `>= 200` clamps widen to expose the full 320×240 (or scaled 640×480) area per session.

Refs #338.