### PR TITLE
fix #348: register CAP_GFX_FRAMEBUFFER + CAP_INPUT_{KEYBOARD,MOUSE}

### DIFF
--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -178,4 +178,4 @@ fixture or fail this test loudly with a per-line diff. Updating the
 fixture is allowed only under an explicit audit-ABI bump per
 BUILD_ROADMAP §7.
 
-Last verified against commit: 9b2089bbcfac9813eda86503e076f11f85ca4ab6
+Last verified against commit: e11df9e1ac

--- a/docs/abi/capabilities.md
+++ b/docs/abi/capabilities.md
@@ -32,6 +32,10 @@ implementation history and per-CAP-NNN deltas, see
 | 13 | `CAP_IPC_SEND` | `ipc_send` / `ipc_call` send leg (M1 sync IPC) |
 | 14 | `CAP_IPC_RECV` | `ipc_recv` (M1 sync IPC) |
 | 15 | `CAP_SYSCALL` | M1 syscall entry stub (reserved; see [syscalls.md](syscalls.md)). |
+| 16 | `CAP_CLOCK_SET` | `clock_service_set_time` (system clock mutation). |
+| 17 | `CAP_INPUT_MOUSE` | PS/2 mouse byte queue + `mouse_hal_*` consumers (renamed from `CAP_MOUSE`; numeric id unchanged). Enforcement follow-up: #349. |
+| 18 | `CAP_GFX_FRAMEBUFFER` | per-session virtual framebuffer + VGA front-buffer writes (window-manager / `vfb_font` path). Enforcement follow-up: #349. |
+| 19 | `CAP_INPUT_KEYBOARD` | PS/2 keyboard byte queue + keyboard HAL consumers. Enforcement follow-up: #349. |
 
 Rules (all enforced today):
 

--- a/docs/abi/capability-deny-contract.md
+++ b/docs/abi/capability-deny-contract.md
@@ -117,6 +117,9 @@ that mode.
 | `os_net_http_get` / `os_net_https_get` | `CAP_NETWORK` | sync | Wrapper returns `OS_STATUS_DENIED`; scheme gate (#79) is the trigger. |
 | broker `share` / `revoke` | `CAP_CAPABILITY_ADMIN` | sync | Returns `OS_STATUS_DENIED`; no grant/revoke side effect.          |
 | `os_event_*`         | `CAP_EVENT_*`      | async (fallback) | Subscription denial drops events silently for the subject; one `CAP:DENY:` is emitted at subscribe time, not per dropped event. |
+| virtual-graphics framebuffer write | `CAP_GFX_FRAMEBUFFER` | sync (reserved) | Registered at v0 by #348; HAL gate enforcement lands in #349. Until enforcement ships, no `CAP:DENY:gfx_framebuffer:` line is emitted. |
+| PS/2 keyboard byte queue | `CAP_INPUT_KEYBOARD` | sync (reserved) | Registered at v0 by #348; driver gate enforcement lands in #349. |
+| PS/2 mouse byte queue | `CAP_INPUT_MOUSE` | sync (reserved) | Numeric id 17 — renamed from `CAP_MOUSE` by #348 with id preserved (append-only). Driver gate enforcement lands in #349. |
 
 Default for new services: **sync**. Async fallback is reserved for
 push-style services where blocking the caller would be incorrect; adding

--- a/docs/abi/capability-registry.json
+++ b/docs/abi/capability-registry.json
@@ -152,6 +152,46 @@
       "deny_test_target": "syscall_entry_stub",
       "owning_plan": "plans/2026-05-20-m1-kernel-capability-table.md",
       "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_CLOCK_SET",
+      "numeric_id": 16,
+      "subject_kinds": ["kernel", "app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:clock_set:-",
+      "allow_test_target": null,
+      "deny_test_target": null,
+      "owning_plan": "plans/2026-03-16-system-clock-rtc.md",
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_INPUT_MOUSE",
+      "numeric_id": 17,
+      "subject_kinds": ["app", "window_manager"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:input_mouse:-",
+      "allow_test_target": null,
+      "deny_test_target": null,
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_GFX_FRAMEBUFFER",
+      "numeric_id": 18,
+      "subject_kinds": ["app", "window_manager"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:gfx_framebuffer:-",
+      "allow_test_target": null,
+      "deny_test_target": null,
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    },
+    {
+      "cap_id": "CAP_INPUT_KEYBOARD",
+      "numeric_id": 19,
+      "subject_kinds": ["app", "window_manager"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:input_keyboard:-",
+      "allow_test_target": null,
+      "deny_test_target": null,
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
     }
   ]
 }

--- a/kernel/cap/cap_deny_marker.c
+++ b/kernel/cap/cap_deny_marker.c
@@ -84,6 +84,10 @@ static const cdm_cap_name_entry_t cdm_cap_names[] = {
     {CAP_IPC_SEND, "ipc_send"},
     {CAP_IPC_RECV, "ipc_recv"},
     {CAP_SYSCALL, "syscall"},
+    {CAP_CLOCK_SET, "clock_set"},
+    {CAP_INPUT_MOUSE, "input_mouse"},
+    {CAP_GFX_FRAMEBUFFER, "gfx_framebuffer"},
+    {CAP_INPUT_KEYBOARD, "input_keyboard"},
 };
 
 const char *cap_deny_marker_name(capability_id_t cap_id) {

--- a/kernel/cap/cap_table.c
+++ b/kernel/cap/cap_table.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 #define CAP_ID_MIN CAP_CONSOLE_WRITE
-#define CAP_ID_MAX CAP_CLOCK_SET
+#define CAP_ID_MAX CAP_INPUT_KEYBOARD
 
 #define CAPABILITY_COUNT ((uint32_t)(CAP_ID_MAX - CAP_ID_MIN + 1u))
 #define CAP_WORD_BITS 8u

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -35,7 +35,26 @@ typedef enum {
    */
   CAP_SYSCALL = 15,
   CAP_CLOCK_SET = 16,
-  CAP_MOUSE = 17,
+  /*
+   * CAP_INPUT_MOUSE / CAP_INPUT_KEYBOARD / CAP_GFX_FRAMEBUFFER:
+   * zero-trust gate registry entries for the M5/M6 graphics + input
+   * surfaces introduced by the merged window-manager + virtual-graphics
+   * + PS/2 mouse/keyboard stack (PRs #321/#322/#328/#334/#340).
+   *
+   * Tracking: issue #348. The HAL/driver enforcement follow-up is
+   * tracked separately (#349); these ids exist now so the registry,
+   * deny-marker grammar, and manifest schema have stable numeric
+   * anchors before the M6 SDK freeze (BUILD_ROADMAP §5.6 / §7).
+   *
+   * `CAP_INPUT_MOUSE` is the rename of the original `CAP_MOUSE` slot
+   * (#340) into the canonical `input.*` naming. The numeric id is
+   * unchanged at 17 — the append-only contract pins numbers, not
+   * symbolic names. No call site emitted a `CAP:DENY:mouse:` marker
+   * before this rename, so no on-wire string drifts.
+   */
+  CAP_INPUT_MOUSE = 17,
+  CAP_GFX_FRAMEBUFFER = 18,
+  CAP_INPUT_KEYBOARD = 19,
 } capability_id_t;
 
 typedef enum {

--- a/kernel/ipc/ipc_port.c
+++ b/kernel/ipc/ipc_port.c
@@ -114,7 +114,9 @@ static bool capability_id_known(capability_id_t cap) {
     case CAP_IPC_RECV:
     case CAP_SYSCALL:
     case CAP_CLOCK_SET:
-    case CAP_MOUSE:
+    case CAP_INPUT_MOUSE:
+    case CAP_GFX_FRAMEBUFFER:
+    case CAP_INPUT_KEYBOARD:
       return true;
   }
   return false;

--- a/manifests/examples/win.json
+++ b/manifests/examples/win.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "win",
+    "version": "0.1.0",
+    "subject_id": 3,
+    "binary": "apps/win.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": [
+      "CAP_GFX_FRAMEBUFFER",
+      "CAP_INPUT_KEYBOARD",
+      "CAP_INPUT_MOUSE"
+    ],
+    "optional": []
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": [
+      "CAP_GFX_FRAMEBUFFER",
+      "CAP_INPUT_KEYBOARD",
+      "CAP_INPUT_MOUSE"
+    ],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/win.bin.sig"
+  }
+}


### PR DESCRIPTION
Closes part of #348 (capability-registry side; HAL/driver enforcement is the #349 follow-up).

## Summary
Register the new zero-trust capability ids that gate the merged
window-manager / virtual-graphics / PS/2 mouse+keyboard stack
(#321/#322/#328/#334/#340), so the registry, deny-marker grammar, and
manifest schema have stable numeric anchors before the M6 SDK freeze
(BUILD_ROADMAP §5.6 / §7).

## Changes
- `kernel/cap/capability.h`: rename `CAP_MOUSE` → `CAP_INPUT_MOUSE`
  (**numeric id 17 preserved** — append-only rule pins numbers, not
  symbolic names; no on-wire `CAP:DENY:mouse:` marker existed yet, so
  no string drifts). Add `CAP_GFX_FRAMEBUFFER = 18` and
  `CAP_INPUT_KEYBOARD = 19`.
- `kernel/cap/cap_table.c`: bump `CAP_ID_MAX` to `CAP_INPUT_KEYBOARD`.
- `kernel/cap/cap_deny_marker.c`: extend the cap_id → lowercase name
  table with `clock_set`, `input_mouse`, `gfx_framebuffer`,
  `input_keyboard` (the `cap_deny_marker_shape` driver table now
  covers them via the existing format-roundtrip path).
- `kernel/ipc/ipc_port.c`: list the new caps in the `is_valid_cap_id`
  whitelist.
- `docs/abi/capability-registry.json`: add registry rows for
  `CAP_CLOCK_SET` (previously missing) and the three new caps with
  `subject_kinds`, `deny_marker` matching `frozen_marker_grammar`,
  and `frozen_since_abi: "0.0"`.
- `docs/abi/capabilities.md`: append rows 16-19 to the ABI capability
  table with the rename note.
- `docs/abi/capability-deny-contract.md`: add the new caps to the §5
  delivery table marked `sync (reserved)` pending #349 enforcement.
- `manifests/examples/win.json`: example window-app manifest declaring
  `CAP_GFX_FRAMEBUFFER` + `CAP_INPUT_KEYBOARD` + `CAP_INPUT_MOUSE`.

## Validation
```
build/scripts/test.sh validate_capability_registry  → PASS (enum_registry_bijection, test_targets_resolved, deny_marker_shape, owning_plan_resolves)
build/scripts/test.sh capability_registry_drift     → PASS
build/scripts/test.sh cap_api_contract              → PASS
build/scripts/test.sh capability_table              → PASS
build/scripts/test.sh capability_gate               → PASS
build/scripts/test.sh cap_deny_marker_shape         → PASS
build/scripts/test.sh capability_audit              → PASS
build/scripts/test.sh manifest_required_fields      → PASS
build/scripts/test.sh validate_manifests_abi_major  → PASS
build/scripts/test.sh manifest_persistence_enum     → PASS
build/scripts/test.sh manifest_broker_role_enum     → PASS
```

## Done-when checklist (from #348)
- [x] `kernel/cap/capability.h` declares the three caps with stable, append-only numeric ids.
- [x] `docs/abi/capability-registry.json` has one row per new cap with all required fields.
- [x] `docs/abi/capabilities.md` + `capability-deny-contract.md` updated.
- [x] `build/scripts/validate_capability_registry.sh` passes.
- [x] `manifests/examples/win.json` shows the gfx.framebuffer + input.* declarations.

## Follow-ups
- #349 — wire `cap_gate_check` calls into the virtual-graphics HAL /
  PS/2 driver paths and add allow/deny QEMU peers. Out of scope here by
  design (issue body §Out of scope).