### PR TITLE
feat(session_manager): subject enumerator predicate for M5 WM cascade (M5-SUBSTRATE-005a, refs #350)

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -53,7 +53,7 @@ run_script() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|m5_owner_delete_cascade_allow_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|session_manager_first_for_subject|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|m5_owner_delete_cascade_allow_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -95,6 +95,14 @@ case "$TEST_NAME" in
     ;;
   cap_handle_revoke_subtree)
     run_script "$ROOT_DIR/build/scripts/test_cap_handle_revoke_subtree.sh"
+    ;;
+  session_manager_first_for_subject)
+    # Issue #350 / plan plans/2026-05-26-m5-wm-cascade-on-substrate.md
+    # (M5-SUBSTRATE-005a). Host-side unit tests for the
+    # session_manager_first_session_for_subject enumerator predicate
+    # the cascade orchestrator will drive in step 3.5 of
+    # broker_svc_delete_owner.
+    run_script "$ROOT_DIR/build/scripts/test_session_manager_first_for_subject.sh"
     ;;
   process_table)
     run_script "$ROOT_DIR/build/scripts/test_process_table.sh"

--- a/build/scripts/test_session_manager_first_for_subject.sh
+++ b/build/scripts/test_session_manager_first_for_subject.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# build/scripts/test_session_manager_first_for_subject.sh
+#
+# Compiles and runs tests/session_manager_first_for_subject_test.c
+# against the M5-SUBSTRATE-005a enumerator predicate
+# `session_manager_first_session_for_subject` added in
+# kernel/core/session_manager.c (issue #350, plan
+# plans/2026-05-26-m5-wm-cascade-on-substrate.md).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT_DIR/artifacts/tests"
+
+mkdir -p "$OUT_DIR"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -DSECUREOS_HOST_TEST=1 \
+  "$ROOT_DIR/kernel/core/session_manager.c" \
+  "$ROOT_DIR/tests/session_manager_first_for_subject_test.c" \
+  -o "$OUT_DIR/session_manager_first_for_subject_test"
+
+LOG_PATH="$OUT_DIR/session_manager_first_for_subject_test.log"
+"$OUT_DIR/session_manager_first_for_subject_test" | tee "$LOG_PATH"
+
+grep -q "TEST:PASS:session_manager_first_for_subject:no_sessions" "$LOG_PATH"
+grep -q "TEST:PASS:session_manager_first_for_subject:single" "$LOG_PATH"
+grep -q "TEST:PASS:session_manager_first_for_subject:drain" "$LOG_PATH"
+grep -q "TEST:PASS:session_manager_first_for_subject:owner_isolation" "$LOG_PATH"
+grep -q "TEST:PASS:session_manager_first_for_subject:null_out_param" "$LOG_PATH"
+grep -q "TEST:PASS:session_manager_first_for_subject$" "$LOG_PATH"

--- a/kernel/core/session_manager.c
+++ b/kernel/core/session_manager.c
@@ -874,3 +874,42 @@ int session_manager_is_blocked(unsigned int session_id) {
   }
   return g_sessions[session_id].blocked;
 }
+
+/*
+ * M5-SUBSTRATE-005a (issue #350, plan
+ * plans/2026-05-26-m5-wm-cascade-on-substrate.md).
+ *
+ * Deterministic slot-order scan. Returns 0 + the lowest matching
+ * session id on hit, -1 on miss. See header doc-block for the full
+ * contract (bounds, idempotence, cascade loop usage).
+ *
+ * Implementation notes:
+ *   - The scan walks every slot in g_sessions[] in index order; we
+ *     match the first one whose in_use bit is set and whose subject_id
+ *     equals the requested owner. This makes the predicate stable
+ *     under concurrent destroy-and-rescan from broker_svc's cascade
+ *     loop (destroy clears in_use, so the next call advances past the
+ *     freed slot deterministically).
+ *   - We do NOT touch *out_session_id on a miss so callers can keep
+ *     a sentinel value (e.g. SESSION_MAX) across the cascade loop
+ *     without an extra reset.
+ */
+int session_manager_first_session_for_subject(cap_subject_id_t subject,
+                                              unsigned int *out_session_id) {
+  size_t i = 0u;
+
+  for (i = 0u; i < SESSION_MAX; ++i) {
+    if (!g_sessions[i].in_use) {
+      continue;
+    }
+    if (g_sessions[i].subject_id != subject) {
+      continue;
+    }
+    if (out_session_id != 0) {
+      *out_session_id = (unsigned int)i;
+    }
+    return 0;
+  }
+
+  return -1;
+}

--- a/kernel/core/session_manager.h
+++ b/kernel/core/session_manager.h
@@ -144,4 +144,35 @@ int session_manager_tick_yield(void);
  */
 int session_manager_is_blocked(unsigned int session_id);
 
+/**
+ * M5-SUBSTRATE-005a (issue #350, plan
+ * plans/2026-05-26-m5-wm-cascade-on-substrate.md):
+ *
+ * Deterministic slot-order enumerator predicate that returns the
+ * lowest-indexed in-use session owned by `subject`. The cascade
+ * orchestrator in `broker_svc_delete_owner` (step 3.5) will call this
+ * in a bounded loop, destroying each match, until the predicate misses
+ * -- mirroring the M5 cap_handle bulk-revoke discipline.
+ *
+ * Returns:
+ *   0  on hit; writes the session id into *out_session_id when non-NULL.
+ *  -1  on miss (no in-use session has subject_id == subject); the out
+ *      param is left untouched.
+ *
+ * Bounds:
+ *   - Pure read of g_sessions[]. No allocation, no recursion, no IPC.
+ *   - O(SESSION_MAX) per call; the cascade drives at most one destroy
+ *     per call, so the outer loop is O(SESSION_MAX^2) in the worst case,
+ *     which is fine for the v0 SESSION_MAX = 8.
+ *
+ * Idempotence:
+ *   After destroying a returned session id, re-calling this with the
+ *   same subject immediately advances to the next live slot (the freed
+ *   slot's in_use bit is cleared, so the scan skips it). When no more
+ *   sessions are owned by `subject`, the predicate returns -1 and the
+ *   cascade loop exits cleanly.
+ */
+int session_manager_first_session_for_subject(cap_subject_id_t subject,
+                                              unsigned int *out_session_id);
+
 #endif

--- a/tests/session_manager_first_for_subject_test.c
+++ b/tests/session_manager_first_for_subject_test.c
@@ -1,0 +1,245 @@
+/**
+ * @file session_manager_first_for_subject_test.c
+ * @brief Host-side unit tests for the M5-SUBSTRATE-005a enumerator
+ *        predicate `session_manager_first_session_for_subject`
+ *        (issue #350, plan
+ *        plans/2026-05-26-m5-wm-cascade-on-substrate.md).
+ *
+ * Cases:
+ *   1. No sessions live  -> predicate returns -1 (miss), out param
+ *      untouched (sentinel preserved).
+ *   2. One session live  -> hit returns 0 + correct session id.
+ *   3. Two sessions for same owner -> first call returns the
+ *      lowest-indexed slot; after destroying it, the next call
+ *      advances to the surviving slot; after destroying that one,
+ *      the predicate misses (cascade-loop termination property).
+ *   4. Two owners interleaved -> predicate returns only the matching
+ *      owner's slot; the other owner's slot stays untouched.
+ *   5. NULL out_session_id is accepted (hit returns 0, miss returns -1)
+ *      so callers that only want a "does this owner own anything"
+ *      boolean can pass NULL.
+ *
+ * Launched by:
+ *   build/scripts/test_session_manager_first_for_subject.sh (registered
+ *   with build/scripts/test.sh under the
+ *   `session_manager_first_for_subject` target).
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../kernel/cap/capability.h"
+#include "../kernel/core/session_manager.h"
+
+/* ------------------------------------------------------------------ */
+/* Host stubs                                                         */
+/* ------------------------------------------------------------------ */
+/* session_manager.c references a handful of kernel-only symbols. We
+ * stub them out here so the host link succeeds. The predicate itself
+ * only touches g_sessions[] state, so the stubs can be no-ops. */
+
+#include "../kernel/core/console.h"
+#include "../kernel/core/ctx_switch.h"
+
+void serial_hal_write(const char *s) { (void)s; }
+void *kmalloc(unsigned long n) { (void)n; return NULL; }
+void kfree(void *p) { (void)p; }
+
+int sched_spawn(const char *name, void (*entry)(void *), void *arg) {
+  (void)name; (void)entry; (void)arg;
+  return 0;
+}
+void sched_run_forever(void) { /* never called from these tests */ }
+
+int ctx_save(ctx_jmp_buf_t *buf) { (void)buf; return 0; }
+void ctx_resume(ctx_jmp_buf_t *buf, int value) {
+  (void)buf; (void)value;
+  /* Declared noreturn in the kernel header; we are never invoked from
+   * these unit tests, but we must not return. */
+  exit(99);
+}
+int ctx_resumes(ctx_jmp_buf_t *buf) { (void)buf; return 0; }
+void ctx_call_on_stack(void *stack_top, void (*func)(void)) {
+  (void)stack_top; (void)func;
+}
+
+void console_init(console_context_t *context, cap_subject_id_t subject_id) {
+  if (context) {
+    memset(context, 0, sizeof(*context));
+    context->subject_id = subject_id;
+  }
+}
+void console_bind_context(console_context_t *context) { (void)context; }
+void console_run(void) { }
+void console_process_injected(void) { }
+int console_try_read_injected(char *out_char) { (void)out_char; return 0; }
+void console_write(const char *s) { (void)s; }
+void console_idle_wait(void) { }
+
+/* vfb_font_draw_char is referenced by session_manager.c's text path. */
+void vfb_font_draw_char(unsigned char *buf, unsigned int w, unsigned int h,
+                        unsigned int x, unsigned int y, char ch,
+                        unsigned char fg, unsigned char bg) {
+  (void)buf; (void)w; (void)h; (void)x; (void)y;
+  (void)ch; (void)fg; (void)bg;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+static void fail(const char *reason) {
+  printf("TEST:FAIL:session_manager_first_for_subject:%s\n", reason);
+  exit(1);
+}
+
+#define SENTINEL_SID 0xDEADBEEFu
+
+/* Reset session table to a clean state by binding bootstrap subject 1
+ * and then destroying any leftover sessions from prior tests. We avoid
+ * session_manager_start (which calls sched_run_forever) and use
+ * session_manager_create directly, but we still need an initial seeded
+ * state; the simplest is to walk a destroy loop across all possible
+ * session ids and then proceed (the destroy is a no-op on free slots).
+ *
+ * NOTE: session_manager_destroy refuses to destroy the *active*
+ * session. The active id is initialized to 0 by C BSS zeroing and is
+ * only advanced inside session_manager_start (which we don't call),
+ * so as long as test sessions ids end up != 0, destroy works. We
+ * therefore seed a dummy bootstrap session at slot 0 (it stays the
+ * active session and is never enumerated against the test owners).
+ */
+
+static int g_bootstrap_seeded = 0;
+
+static void reset_session_table(void) {
+  /* The test never calls session_manager_start, so g_active_session_id
+   * stays at its BSS value of 0. We seed slot 0 *once* with a sentinel
+   * owner that no test uses; destroy() is a no-op on the active slot,
+   * so slot 0 persists across tests. Then we drain slots 1..31 (free
+   * slots no-op; in-use slots get torn down). */
+  if (!g_bootstrap_seeded) {
+    unsigned int seed = 0u;
+    if (!session_manager_create((cap_subject_id_t)0xFFFFu, &seed)) {
+      fail("seed_bootstrap_create");
+    }
+    if (seed != 0u) {
+      fail("seed_bootstrap_not_slot0");
+    }
+    g_bootstrap_seeded = 1;
+  }
+  for (unsigned int sid = 1u; sid < 32u; ++sid) {
+    session_manager_destroy(sid);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_no_sessions_for_owner(void) {
+  reset_session_table();
+  unsigned int sid = SENTINEL_SID;
+  int rc = session_manager_first_session_for_subject((cap_subject_id_t)42, &sid);
+  if (rc != -1) fail("no_sessions:expected_miss");
+  if (sid != SENTINEL_SID) fail("no_sessions:out_param_clobbered_on_miss");
+  printf("TEST:PASS:session_manager_first_for_subject:no_sessions\n");
+}
+
+static void test_single_owner_single_session(void) {
+  reset_session_table();
+  unsigned int created = 0u;
+  if (!session_manager_create((cap_subject_id_t)7, &created)) fail("single:create");
+  unsigned int found = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)7, &found) != 0)
+    fail("single:expected_hit");
+  if (found != created) fail("single:wrong_session_id");
+  printf("TEST:PASS:session_manager_first_for_subject:single\n");
+}
+
+static void test_multiple_sessions_same_owner_drain(void) {
+  reset_session_table();
+  unsigned int a = 0u, b = 0u;
+  if (!session_manager_create((cap_subject_id_t)3, &a)) fail("drain:create_a");
+  if (!session_manager_create((cap_subject_id_t)3, &b)) fail("drain:create_b");
+  if (a == b) fail("drain:duplicate_session_ids");
+
+  /* First hit must be the lowest-indexed slot. */
+  unsigned int first = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)3, &first) != 0)
+    fail("drain:miss_first");
+  unsigned int expected_first = (a < b) ? a : b;
+  unsigned int expected_second = (a < b) ? b : a;
+  if (first != expected_first) fail("drain:not_lowest_first");
+
+  /* Destroy it, next call must advance to the surviving slot. */
+  session_manager_destroy(first);
+  unsigned int second = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)3, &second) != 0)
+    fail("drain:miss_second");
+  if (second != expected_second) fail("drain:not_advancing");
+
+  /* Destroy the last one, predicate must now miss. */
+  session_manager_destroy(second);
+  unsigned int third = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)3, &third) != -1)
+    fail("drain:expected_miss_after_drain");
+  if (third != SENTINEL_SID) fail("drain:out_param_clobbered_after_drain");
+  printf("TEST:PASS:session_manager_first_for_subject:drain\n");
+}
+
+static void test_owner_isolation(void) {
+  reset_session_table();
+  unsigned int s_a = 0u, s_b = 0u;
+  if (!session_manager_create((cap_subject_id_t)11, &s_a)) fail("iso:create_a");
+  if (!session_manager_create((cap_subject_id_t)22, &s_b)) fail("iso:create_b");
+
+  unsigned int found_a = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)11, &found_a) != 0)
+    fail("iso:miss_a");
+  if (found_a != s_a) fail("iso:wrong_a_session");
+
+  unsigned int found_b = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)22, &found_b) != 0)
+    fail("iso:miss_b");
+  if (found_b != s_b) fail("iso:wrong_b_session");
+
+  /* Destroying owner 11's session must NOT affect owner 22. */
+  session_manager_destroy(found_a);
+  if (session_manager_first_session_for_subject((cap_subject_id_t)11, NULL) != -1)
+    fail("iso:expected_miss_after_destroy_a");
+
+  unsigned int b_after = SENTINEL_SID;
+  if (session_manager_first_session_for_subject((cap_subject_id_t)22, &b_after) != 0)
+    fail("iso:b_disappeared_with_a");
+  if (b_after != s_b) fail("iso:b_moved");
+  printf("TEST:PASS:session_manager_first_for_subject:owner_isolation\n");
+}
+
+static void test_null_out_param(void) {
+  reset_session_table();
+  unsigned int created = 0u;
+  if (!session_manager_create((cap_subject_id_t)55, &created)) fail("null:create");
+
+  /* Hit with NULL out param: must still return 0 and not crash. */
+  if (session_manager_first_session_for_subject((cap_subject_id_t)55, NULL) != 0)
+    fail("null:expected_hit_with_null_out");
+
+  /* Miss with NULL out param: must still return -1 and not crash. */
+  if (session_manager_first_session_for_subject((cap_subject_id_t)9999, NULL) != -1)
+    fail("null:expected_miss_with_null_out");
+  printf("TEST:PASS:session_manager_first_for_subject:null_out_param\n");
+}
+
+int main(void) {
+  printf("TEST:START:session_manager_first_for_subject\n");
+  test_no_sessions_for_owner();
+  test_single_owner_single_session();
+  test_multiple_sessions_same_owner_drain();
+  test_owner_isolation();
+  test_null_out_param();
+  printf("TEST:PASS:session_manager_first_for_subject\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements **slice 1 (M5-SUBSTRATE-005a)** of the M5 WM-cascade plan ([#355](https://github.com/rwrife/SecureOS/pull/355) / `plans/2026-05-26-m5-wm-cascade-on-substrate.md`) for issue #350.

Adds the tiny session-manager enumerator predicate the upcoming `broker_svc_delete_owner` **step 3.5** cascade loop will call to find and tear down per-launcher window-manager sessions owned by a deleted M5 subject.

```c
int session_manager_first_session_for_subject(cap_subject_id_t subject,
                                              unsigned int *out_session_id);
```

## Contract (matches §'Design surface / What changes' of the plan)

- Pure read of `g_sessions[]`; **no allocation, no recursion, no IPC**.
- Deterministic slot-order scan: returns `0` + lowest-indexed matching session id on hit, `-1` on miss.
- `out_session_id` left **untouched on miss** so callers can keep a sentinel value across the cascade drain loop.
- `NULL out_session_id` accepted (callers that only need a boolean 'does this owner own anything').
- **Idempotent under destroy+rescan**: the cascade loop drains deterministically and exits when no more sessions match.

## What this PR does NOT do (per the plan's non-goals)

- **No** `broker_svc` wiring — that's slice 005b, hard-depends on #324 (`broker_svc_delete_owner`) landing first.
- **No** new `_qemu` substrate test — that's slice 005c, depends on #344/#345 cascade-audit infrastructure.
- **No ABI surface change**: no `docs/abi/*` edits, no `OS_ABI_VERSION` bump, no new capability id, no manifest schema field.
- **No** changes to `session_record_t` or `session_manager_destroy` — the cascade reuses the existing destroy entrypoint unchanged.

## Validation

New host test target wired into `build/scripts/test.sh`:

```
$ bash build/scripts/test.sh session_manager_first_for_subject
TEST:START:session_manager_first_for_subject
TEST:PASS:session_manager_first_for_subject:no_sessions
TEST:PASS:session_manager_first_for_subject:single
TEST:PASS:session_manager_first_for_subject:drain
TEST:PASS:session_manager_first_for_subject:owner_isolation
TEST:PASS:session_manager_first_for_subject:null_out_param
TEST:PASS:session_manager_first_for_subject
```

Covers all five cases the plan's §'Validation surface' calls out for slice 005a:
1. miss-when-empty (sentinel preservation)
2. single owner / single session hit
3. multi-session drain (destroy+rescan terminates cleanly — proves the cascade loop's exit condition)
4. owner isolation (destroying owner A's session does not affect owner B's enumeration)
5. NULL out param accepted on hit and miss

Existing kernel-host tests spot-checked locally and still pass:
- `bash build/scripts/test.sh cap_handle_repr` → PASS
- `bash build/scripts/test.sh app_runtime` → PASS (29/29)

## Follow-ups (per the plan)

- **M5-SUBSTRATE-005b**: wire the predicate into `broker_svc_delete_owner` step 3.5 + emit additive `child_kind='SESSION'` audit value. Waits on #324.
- **M5-SUBSTRATE-005c**: `m5_owner_delete_cascade_window_qemu` substrate peer. Waits on #344 / #345.
- **M5-SUBSTRATE-005-DOC**: SKIP→PASS upgrades for cascade-audit markers once #98 / #349 land.

Refs #350, #355, #313, #324.

_Filed by secureos-hourly-issue-work cron, run e4c62e32, 2026-05-26 20:50 UTC._