### PR TITLE
docs(abi): bump stamps for #353 (README + sosh-capability-contract)

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -46,4 +46,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: fb6ed647530b1f8ed097ea821ec51ae014854932
+Last verified against commit: 323c36ec7201bda119bccf01ef685c8ede16660b

--- a/docs/abi/sosh-capability-contract.md
+++ b/docs/abi/sosh-capability-contract.md
@@ -259,4 +259,4 @@ their normative source:
 "or an explicit ADR explaining why sosh reuses existing caps" branch
 of #351's last done-when bullet is satisfied by §3.
 
-Last verified against commit: 54ddac9512fb9fbb121da268226c58e73c01b121
+Last verified against commit: 323c36ec7201bda119bccf01ef685c8ede16660b


### PR DESCRIPTION
Stamp-only refresh. PR #353 (323c36e) touched `docs/abi/README.md` and `docs/abi/sosh-capability-contract.md` content-wise without bumping their `Last verified against commit:` lines, so `validate_abi_stamps` is failing on **every** open PR's `build-and-validate` leg:

```
ABI_STAMP:FAIL:docs/abi/README.md:stamp=fb6ed64753:last_content=323c36ec72
ABI_STAMP:FAIL:docs/abi/sosh-capability-contract.md:stamp=54ddac9512:last_content=323c36ec72
```

Both stamps bumped to `323c36ec7201bda119bccf01ef685c8ede16660b`.

`build/scripts/validate_abi_stamps.sh` now PASSes locally for all in-scope docs.

Unblocks (at minimum):
- #354 (broker_svc DELETE_OWNER — diff-clean otherwise; flagged by previous hourly review)
- #357, #358 (open PRs with the same red leg)

Caught by the hourly PR-review cron on #354.

🤖 Filed by hourly PR-review cron 2026-05-27.