### PR TITLE
feat(manifests): add sosh.json example matching contract §5.3 (refs #351)

### DIFF
--- a/manifests/examples/sosh.json
+++ b/manifests/examples/sosh.json
@@ -1,0 +1,39 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "sosh",
+    "version": "0.1.0",
+    "subject_id": 5,
+    "binary": "apps/sosh.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": [
+      "CAP_CONSOLE_WRITE",
+      "CAP_FS_READ",
+      "CAP_FS_WRITE",
+      "CAP_APP_EXEC"
+    ],
+    "optional": [
+      "CAP_FS_WRITE",
+      "CAP_APP_EXEC"
+    ]
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": [
+      "CAP_CONSOLE_WRITE",
+      "CAP_FS_READ"
+    ],
+    "require_user_confirm": [
+      "CAP_FS_WRITE",
+      "CAP_APP_EXEC"
+    ]
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/sosh.bin.sig"
+  }
+}


### PR DESCRIPTION
Tiny additive slice of #351 — ships the host-process-mode sosh manifest example that `docs/abi/sosh-capability-contract.md` §5.3 calls out as 'to be added by the enforcement follow-up slice'.

## What

`manifests/examples/sosh.json` — mirrors the JSON block in the contract doc verbatim:

- `app.subject_id = 5` (next unallocated low subject id; sosh is host-process-mode authority per §5.1)
- `capabilities.request` = `CAP_CONSOLE_WRITE`, `CAP_FS_READ`, `CAP_FS_WRITE`, `CAP_APP_EXEC`
- `capabilities.optional` = `CAP_FS_WRITE`, `CAP_APP_EXEC` (script may run without write/exec)
- `launcher.auto_grant_at_launch` = read-only set (CONSOLE_WRITE + FS_READ — boot-script use case)
- `launcher.require_user_confirm` = mutating set (FS_WRITE + APP_EXEC) — disjoint from auto_grant per the schema rule
- `signature` block points at the existing `secureos-dev-key-1` chain (#133 / #320)

## ABI / scope

- **No** `OS_ABI_VERSION` bump.
- **No** schema change — sosh.json validates against the unmodified `manifests/schema/v0.json`.
- **No** new `CAP_*` id (contract §3 ADR — sosh reuses existing caps).
- **No** `capability-registry.json` change.
- **No** code change. Pure data file.

## Validation

```
$ bash build/scripts/validate_manifests.sh
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.broker_consumer.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.broker_provider.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.deny.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.json
MANIFEST_VALIDATE:PASS:manifests/examples/helloapp.persistent.json
MANIFEST_VALIDATE:PASS:manifests/examples/sosh.json
MANIFEST_VALIDATE:PASS:manifests/examples/win.json
MANIFEST_VALIDATE:SUMMARY:pass 7/7
```

The pre-existing manifest enum regression scripts (`test_manifest_broker_role_enum`, `test_manifest_persistence_enum`, `test_manifest_required_fields`) remain unaffected — sosh.json omits both optional enums, exercising the schema defaults (`persistence=ephemeral`, `broker_role=none`).

## Note on ABI stamps

`docs/abi/README.md` and `docs/abi/sosh-capability-contract.md` currently fail `validate_abi_stamps.sh` on `main` (stale stamps from PR #353). That is a pre-existing failure being addressed by PR #359 — not introduced by this PR. This PR touches **no** `docs/abi/` file, so it does not add to the stamp churn.

## Refs

Refs #351. Does not close — enforcement slices (cat/source/ls/>/exec, kernel-host embedder shim, `_qemu` peers) and per-script-subject mode (§5.2) remain open. PR #358 covers the `echo` enforcement slice in parallel.

🤖 Filed by the SecureOS hourly issue-work cron (run e4c62e32, 2026-05-27 03:30 UTC).