### PR TITLE
feat(validators): sosh-contract→capability-registry drift check (refs #351)

### DIFF
--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -53,7 +53,7 @@ run_script() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|validate_sosh_capability_contract|sosh_contract_registry_drift|parity|harness_defense|canary_must_fail]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -386,6 +386,22 @@ case "$TEST_NAME" in
     # commit and asserts the ABI_STAMP:FAIL:<file>:stamp=...:last_content=...
     # marker fires. Mirrors the canary discipline from #213 / #234.
     run_script "$ROOT_DIR/tests/harness/abi_stamps_drift_test.sh"
+    ;;
+  validate_sosh_capability_contract)
+    # Issue #351 (drift validator slice): cross-check that every CAP_*
+    # cited in §4 of docs/abi/sosh-capability-contract.md round-trips
+    # against docs/abi/capability-registry.json — both that the cap id
+    # exists (or is annotated `(if defined)`) and that the deny-marker
+    # name segment matches the registry entry. Mirrors #234 / #297.
+    run_script "$ROOT_DIR/build/scripts/validate_sosh_capability_contract.sh"
+    ;;
+  sosh_contract_registry_drift)
+    # Issue #351 (drift validator slice): negative-canary self-test —
+    # builds a sandbox repo whose sosh-capability-contract.md §4 cites a
+    # CAP_* missing from the registry and asserts the
+    # SOSH_CONTRACT:FAIL:cap_missing_from_registry:<cap_id> marker fires.
+    # Mirrors the canary discipline from #213 / #234 / #297.
+    run_script "$ROOT_DIR/tests/harness/sosh_contract_registry_drift_test.sh"
     ;;
   parity)
     run_script "$ROOT_DIR/build/scripts/test_shell_parity.sh"

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -49,6 +49,7 @@ TEST_TARGETS=(
     proc_sched
     m1_ipc_demo
     validate_abi_stamps
+    validate_sosh_capability_contract
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/build/scripts/validate_sosh_capability_contract.sh
+++ b/build/scripts/validate_sosh_capability_contract.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# build/scripts/validate_sosh_capability_contract.sh
+#
+# Thin wrapper around tools/validate_sosh_capability_contract.py so the
+# sosh-contract drift validator runs through the same build/scripts/*.sh
+# entrypoint as every other validator (issue #234 pattern, #297 mirror).
+#
+# Asserts every CAP_* cited in §4 of docs/abi/sosh-capability-contract.md
+# round-trips against docs/abi/capability-registry.json. This protects the
+# in-flight enforcement slice (PR #358 + follow-ups) from quietly gating
+# against a capability id that does not exist in the registry, and from
+# the inverse drift mode where the registry renames a cap but the
+# contract still cites the old marker spelling.
+#
+# Exit codes are passed through from the Python implementation:
+#   0  every §4 row passes both the existence and marker-name checks
+#   1  one or more SOSH_CONTRACT:FAIL markers emitted
+#   2  environment / usage error (missing input file, malformed JSON,
+#      contract doc lacks a §4 table)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "SOSH_CONTRACT:FAIL:python3_not_found" >&2
+  exit 2
+fi
+
+exec "$PY" "$ROOT_DIR/tools/validate_sosh_capability_contract.py" --root "$ROOT_DIR" "$@"

--- a/tests/harness/sosh_contract_registry_drift_test.sh
+++ b/tests/harness/sosh_contract_registry_drift_test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/harness/sosh_contract_registry_drift_test.sh
+#
+# Negative canary for the sosh-contract drift validator
+# (issue #351, drift-validator slice).
+#
+# Why this exists:
+#   build/scripts/validate_sosh_capability_contract.sh claims that a
+#   `CAP_*` cited in §4 of docs/abi/sosh-capability-contract.md but
+#   missing from docs/abi/capability-registry.json is a hard failure.
+#   This canary proves that claim is real — not a silent no-op from a
+#   stale dispatcher arm, a typo in the regex, or a doc-parse path that
+#   walks off the end of §4 without consuming any rows. Mirrors the
+#   discipline in #213 (validator harness self-test) and the
+#   #234 / capability_registry_drift + #297 / abi_stamps_drift canaries.
+#
+# Mechanics:
+#   1. Build a throwaway repo skeleton containing:
+#        - docs/abi/capability-registry.json with ONE registered cap
+#          (CAP_CONSOLE_WRITE) using the canonical deny-marker shape.
+#        - docs/abi/sosh-capability-contract.md with a §4 table that
+#          cites BOTH that cap AND a fake `CAP_TOTALLY_FAKE` that is
+#          deliberately absent from the registry — the drift the
+#          validator must catch.
+#   2. Run validate_sosh_capability_contract.py against that sandbox
+#      and assert:
+#        - exit code 1
+#        - stderr contains
+#          SOSH_CONTRACT:FAIL:cap_missing_from_registry:CAP_TOTALLY_FAKE
+#        - stdout still contains a PASS line for CAP_CONSOLE_WRITE
+#          (proving the validator did walk the table and was not
+#          fail-fast on the first row).
+#   3. Bonus check: also exercise the marker-name drift path by
+#      rewriting the row for CAP_CONSOLE_WRITE to cite a marker name
+#      ("console_yell") that does not match the registry entry, and
+#      assert SOSH_CONTRACT:FAIL:marker_name_mismatch:CAP_CONSOLE_WRITE
+#      fires. This proves the second check arm is wired, mirroring the
+#      multi-check coverage of capability_registry_drift_test.sh.
+#
+# Contract:
+#   On success: TEST:PASS:sosh_contract_registry_drift_canary, exit 0.
+#   On failure: TEST:FAIL:sosh_contract_registry_drift_canary:<reason>, exit 1.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '$TMP_DIR'" EXIT
+
+printf 'TEST:START:sosh_contract_registry_drift_canary\n'
+
+SANDBOX="$TMP_DIR/repo"
+mkdir -p "$SANDBOX/docs/abi" "$SANDBOX/tools"
+
+cp "$ROOT_DIR/tools/validate_sosh_capability_contract.py" \
+   "$SANDBOX/tools/validate_sosh_capability_contract.py" \
+  || { printf 'TEST:FAIL:sosh_contract_registry_drift_canary:tool_copy_failed\n'; exit 1; }
+
+# Sandbox registry — only ONE cap registered; CAP_TOTALLY_FAKE absent.
+cat > "$SANDBOX/docs/abi/capability-registry.json" <<'EOF'
+{
+  "$schema_version": 0,
+  "description": "sandbox registry for sosh_contract_registry_drift canary",
+  "frozen_marker_grammar": "^CAP:DENY:[0-9]+:[a-z][a-z0-9_]*:[\\x20-\\x39\\x3B-\\x7E]+$",
+  "capabilities": [
+    {
+      "cap_id": "CAP_CONSOLE_WRITE",
+      "numeric_id": 1,
+      "subject_kinds": ["app"],
+      "deny_marker": "CAP:DENY:<actor_subject_id>:console_write:-",
+      "allow_test_target": "helloapp_allow",
+      "deny_test_target": "helloapp_deny",
+      "owning_plan": null,
+      "frozen_since_abi": "0.0"
+    }
+  ]
+}
+EOF
+
+# Sandbox §4 table that drifts in two ways at once: it cites a
+# CAP_TOTALLY_FAKE the registry has never heard of, AND it spells the
+# CAP_CONSOLE_WRITE deny-marker name wrong ("console_yell"). The
+# validator should catch BOTH and still emit one PASS line for the
+# fake-`(if defined)` row to prove it did not abort mid-walk.
+CONTRACT="$SANDBOX/docs/abi/sosh-capability-contract.md"
+cat > "$CONTRACT" <<'EOF'
+# sosh capability contract (sandbox)
+
+## 4. Side-effecting builtins + required capabilities
+
+| sosh surface | syscall | Required cap | Deny marker |
+| ------------ | ------- | ------------ | ----------- |
+| `echo`       | `os_console_write` | `CAP_CONSOLE_WRITE` | `CAP:DENY:<sid>:console_yell:-` |
+| `cat`        | `os_fs_read_file`  | `CAP_TOTALLY_FAKE`  | `CAP:DENY:<sid>:totally_fake:-` |
+| `export`     | env set            | `CAP_ENV_WRITE` (if defined) | `CAP:DENY:<sid>:env_write:<var>` |
+EOF
+
+PY="${PYTHON:-python3}"
+OUT="$TMP_DIR/stdout"
+ERR="$TMP_DIR/stderr"
+
+set +e
+"$PY" "$SANDBOX/tools/validate_sosh_capability_contract.py" --root "$SANDBOX" \
+  > "$OUT" 2> "$ERR"
+RC=$?
+set -e
+
+if [[ "$RC" -ne 1 ]]; then
+  printf 'TEST:FAIL:sosh_contract_registry_drift_canary:unexpected_exit_code:%d\n' "$RC"
+  printf '----- stdout -----\n' >&2; cat "$OUT" >&2
+  printf '----- stderr -----\n' >&2; cat "$ERR" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'SOSH_CONTRACT:FAIL:cap_missing_from_registry:CAP_TOTALLY_FAKE' "$ERR"; then
+  printf 'TEST:FAIL:sosh_contract_registry_drift_canary:missing_cap_marker_absent\n'
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'SOSH_CONTRACT:FAIL:marker_name_mismatch:CAP_CONSOLE_WRITE:doc=console_yell:registry=console_write' "$ERR"; then
+  printf 'TEST:FAIL:sosh_contract_registry_drift_canary:marker_mismatch_marker_absent\n'
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'SOSH_CONTRACT:PASS:CAP_ENV_WRITE:if_defined_absent_ok' "$OUT"; then
+  printf 'TEST:FAIL:sosh_contract_registry_drift_canary:if_defined_pass_absent\n'
+  cat "$OUT" >&2
+  exit 1
+fi
+
+printf 'TEST:PASS:sosh_contract_registry_drift_canary\n'
+exit 0

--- a/tools/validate_sosh_capability_contract.py
+++ b/tools/validate_sosh_capability_contract.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""validate_sosh_capability_contract.py — issue #351 (drift validator slice)
+
+Asserts that every `CAP_*` id referenced in §4 of
+`docs/abi/sosh-capability-contract.md` ("Side-effecting builtins +
+required capabilities") is consistent with the canonical
+`docs/abi/capability-registry.json`. This is the same pattern the rest
+of the validators use (#234 registry validator, #297 ABI-stamp drift):
+fail loudly the moment the doc drifts from the registry so an
+enforcement-slice PR (e.g. PR #358) cannot quietly land a gate against a
+cap that does not exist.
+
+What it checks:
+
+  1. Every `CAP_*` appearing in a §4 table row is one of:
+        a. present in `capability-registry.json`, OR
+        b. annotated `(if defined)` on the same row — the contract
+           §4 footnote explicitly carves this out (today this is only
+           `CAP_ENV_WRITE`), in which case the validator MUST tolerate
+           the cap being absent from the registry, but if it IS in the
+           registry it still has to round-trip (the annotation does not
+           give the doc a free pass to misspell the id).
+  2. The deny-marker `name` field on each row (the second segment of
+     the `CAP:DENY:<sid>:<name>:<resource>` literal) matches the
+     `deny_marker` template recorded in the registry entry for the
+     same cap. Catches the drift mode where a renamed capability gets
+     updated in the registry but the contract still cites the old
+     marker spelling (or vice versa).
+
+Output contract (mirrors `validate_capability_registry.py` markers
+exactly so the existing test-marker scrapers and #234 grep harness can
+classify failures without parsing English text):
+
+  * On success per row: `SOSH_CONTRACT:PASS:<cap_id>:<marker_name>`
+  * On overall pass:    `SOSH_CONTRACT:PASS:overall`
+  * On per-row failure: `SOSH_CONTRACT:FAIL:<reason>:<cap_id>[:<detail>]`
+
+Exit codes:
+  0  every §4 row passes both checks
+  1  one or more `SOSH_CONTRACT:FAIL:*` markers emitted
+  2  environment / usage error (missing input file, malformed JSON,
+     contract doc lacks a §4 table)
+
+Wired by:
+  * `build/scripts/validate_sosh_capability_contract.sh`  (parity wrapper)
+  * `build/scripts/test.sh sosh_contract_registry_drift`  (#156 parity)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# A §4 table row carries pipe-delimited cells. We only look at rows that
+# actually cite a CAP_* id in the "Required cap" column (3rd cell). The
+# first regex pulls the cap id; the second pulls the canonical marker
+# template from the "Deny marker" column (4th cell). We use simple text
+# scans rather than a markdown parser so the validator stays
+# dependency-free (matches the rest of tools/*.py).
+CAP_ID_IN_CELL_RE = re.compile(r"\bCAP_[A-Z][A-Z0-9_]*\b")
+MARKER_IN_CELL_RE = re.compile(r"`CAP:DENY:[^`]+`")
+IF_DEFINED_RE = re.compile(r"\(if\s+defined\)", re.IGNORECASE)
+SECTION_4_HEADER_RE = re.compile(
+    r"^##\s*4\.\s*Side-effecting builtins", re.IGNORECASE)
+NEXT_SECTION_RE = re.compile(r"^##\s*\d+\.")
+TABLE_ROW_RE = re.compile(r"^\|")
+TABLE_SEPARATOR_RE = re.compile(r"^\|\s*-+")
+# Marker template in the registry is "CAP:DENY:<actor_subject_id>:<name>:<resource>".
+# We only care about the <name> segment (the lowercase identifier between
+# the second and third colons).
+MARKER_TEMPLATE_NAME_RE = re.compile(
+    r"^CAP:DENY:[^:]+:([a-z][a-z0-9_]*):")
+
+
+def emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def err(line: str) -> None:
+    print(line, file=sys.stderr, flush=True)
+
+
+def load_registry(path: Path) -> Dict[str, dict]:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        err(f"SOSH_CONTRACT:FAIL:registry_missing:{path}")
+        sys.exit(2)
+    except json.JSONDecodeError as exc:
+        err(f"SOSH_CONTRACT:FAIL:registry_malformed:{path}:{exc}")
+        sys.exit(2)
+    caps = data.get("capabilities", [])
+    out: Dict[str, dict] = {}
+    for entry in caps:
+        cap_id = entry.get("cap_id")
+        if isinstance(cap_id, str):
+            out[cap_id] = entry
+    return out
+
+
+def extract_section_4_rows(doc_path: Path) -> List[str]:
+    """Return the raw text of every table row inside §4 of the contract.
+
+    Excludes the header row and the `|---|---|` separator row so the
+    caller can iterate cleanly.
+    """
+    try:
+        text = doc_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        err(f"SOSH_CONTRACT:FAIL:doc_missing:{doc_path}")
+        sys.exit(2)
+
+    lines = text.splitlines()
+    in_section = False
+    rows: List[str] = []
+    header_consumed = False
+    separator_consumed = False
+    saw_table = False
+
+    for raw in lines:
+        if SECTION_4_HEADER_RE.match(raw):
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if NEXT_SECTION_RE.match(raw):
+            break
+        if not TABLE_ROW_RE.match(raw):
+            # A blank line or prose line between rows means the table
+            # is over; stop collecting (notes/footnotes follow).
+            if rows and raw.strip() == "":
+                # Allow trailing prose; stop scanning rows once we have
+                # at least one row and hit a non-table line.
+                break
+            continue
+        saw_table = True
+        if not header_consumed:
+            header_consumed = True
+            continue
+        if not separator_consumed and TABLE_SEPARATOR_RE.match(raw):
+            separator_consumed = True
+            continue
+        rows.append(raw)
+
+    if not saw_table:
+        err(f"SOSH_CONTRACT:FAIL:doc_no_section_4_table:{doc_path}")
+        sys.exit(2)
+    return rows
+
+
+def parse_row(row: str) -> Tuple[List[str], bool, Optional[str]]:
+    """Split a table row into (cap_ids, if_defined, marker_name).
+
+    `cap_ids` is every CAP_* literal cited anywhere in the row (we
+    want all of them — e.g. `CAP_FS_READ` appears in the same cell as
+    `os_fs_read_file` in some rows). `if_defined` reflects whether the
+    row contains the `(if defined)` annotation. `marker_name` is the
+    <name> segment of the deny-marker literal in the 4th cell (or
+    None if no marker literal is present).
+    """
+    cap_ids = CAP_ID_IN_CELL_RE.findall(row)
+    if_defined = bool(IF_DEFINED_RE.search(row))
+    marker_match = MARKER_IN_CELL_RE.search(row)
+    marker_name: Optional[str] = None
+    if marker_match:
+        literal = marker_match.group(0).strip("`")
+        parts = literal.split(":")
+        # parts == ['CAP', 'DENY', '<sid>', '<name>', '<resource>'...]
+        if len(parts) >= 4:
+            marker_name = parts[3]
+    return cap_ids, if_defined, marker_name
+
+
+def registry_marker_name(entry: dict) -> Optional[str]:
+    template = entry.get("deny_marker", "")
+    match = MARKER_TEMPLATE_NAME_RE.match(template)
+    return match.group(1) if match else None
+
+
+def check(root: Path) -> int:
+    doc_path = root / "docs" / "abi" / "sosh-capability-contract.md"
+    registry_path = root / "docs" / "abi" / "capability-registry.json"
+
+    registry = load_registry(registry_path)
+    rows = extract_section_4_rows(doc_path)
+
+    failures = 0
+    checked = 0
+    for row in rows:
+        cap_ids, if_defined, marker_name = parse_row(row)
+        if not cap_ids:
+            # Rows without any CAP_* are not capability-bearing and
+            # therefore have nothing to drift-check against the
+            # registry (defensive: today every §4 row cites at least
+            # one cap, but we don't want to fail on a future
+            # documentation-only row).
+            continue
+        for cap_id in cap_ids:
+            checked += 1
+            entry = registry.get(cap_id)
+            if entry is None:
+                if if_defined:
+                    emit(f"SOSH_CONTRACT:PASS:{cap_id}:if_defined_absent_ok")
+                    continue
+                err(f"SOSH_CONTRACT:FAIL:cap_missing_from_registry:{cap_id}")
+                failures += 1
+                continue
+            # Cap IS in the registry. Check the marker-name round-trip
+            # only when this row actually cites a marker literal — some
+            # rows (e.g. the env_write row when CAP_ENV_WRITE is
+            # tentative) still want to be drift-checked even if the
+            # marker shape is provisional.
+            if marker_name is None:
+                emit(f"SOSH_CONTRACT:PASS:{cap_id}:row_no_marker")
+                continue
+            registry_name = registry_marker_name(entry)
+            if registry_name is None:
+                err(
+                    f"SOSH_CONTRACT:FAIL:registry_marker_malformed:"
+                    f"{cap_id}:{entry.get('deny_marker', '')}")
+                failures += 1
+                continue
+            if marker_name != registry_name:
+                err(
+                    f"SOSH_CONTRACT:FAIL:marker_name_mismatch:"
+                    f"{cap_id}:doc={marker_name}:registry={registry_name}")
+                failures += 1
+                continue
+            emit(f"SOSH_CONTRACT:PASS:{cap_id}:{marker_name}")
+
+    if checked == 0:
+        err("SOSH_CONTRACT:FAIL:no_cap_ids_extracted_from_section_4")
+        return 1
+    if failures:
+        return 1
+    emit("SOSH_CONTRACT:PASS:overall")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", default=".",
+        help="Repository root (defaults to current directory).")
+    args = parser.parse_args()
+    return check(Path(args.root).resolve())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Drift-validator slice for #351. Adds a deterministic check that every `CAP_*` cited in §4 of `docs/abi/sosh-capability-contract.md` round-trips against `docs/abi/capability-registry.json`. Non-conflicting with the in-flight enforcement PRs on the same issue (#358 echo gate, #360 manifest example) — touches no sosh source or ABI docs.

## What

Two validator arms:

1. **cap-existence** — every `CAP_*` in a §4 row must exist in the registry, unless the row carries the documented `(if defined)` annotation (today only `CAP_ENV_WRITE`).
2. **marker-name round-trip** — the `<name>` segment of the row's `CAP:DENY:` literal must match the registry entry's `deny_marker` template (catches the rename-on-one-side drift mode).

Same `SOSH_CONTRACT:{PASS,FAIL}:*` marker discipline as `REGISTRY_VALIDATE:*` (#234) and `ABI_STAMP:*` (#297).

## Files

- `tools/validate_sosh_capability_contract.py` — dependency-free validator.
- `build/scripts/validate_sosh_capability_contract.sh` — wrapper matching the #234 / #297 entrypoint pattern.
- `tests/harness/sosh_contract_registry_drift_test.sh` — negative canary: sandboxes a repo whose §4 cites a `CAP_TOTALLY_FAKE` AND drifts `CAP_CONSOLE_WRITE`'s marker name to `console_yell`; asserts both `SOSH_CONTRACT:FAIL` markers fire and the validator still emits the `(if defined)` PASS for `CAP_ENV_WRITE` (i.e. it walks the full table, no fail-fast). Mirrors `capability_registry_drift` / `abi_stamps_drift` discipline.
- `build/scripts/test.sh` — two new dispatch targets: `validate_sosh_capability_contract` + `sosh_contract_registry_drift`.
- `build/scripts/validate_bundle.sh` — adds `validate_sosh_capability_contract` to `TEST_TARGETS` so future drift is caught in CI.

## Why now / why this slice

The §4 table is the normative wiring spec for the enforcement slices listed in §7 of the contract (echo / cat / source / ls / exists / write / external-exec / export). Without a drift validator, a follow-up enforcement PR can quietly land a `cap_gate_check_handle(CAP_XYZ, ...)` against a `CAP_XYZ` that does not exist in the registry, or that disagrees with the registry on marker spelling — and the only signal would be a runtime miss far from the source of drift. This catches it at lint time, before any runtime test runs.

Scope discipline: **no** change to `docs/abi/sosh-capability-contract.md`, `docs/abi/capability-registry.json`, `docs/abi/capability-deny-contract.md`, `kernel/cap/capability.h`, the sosh interpreter, or `OS_ABI_VERSION`. Does not touch `user/libs/soshlib/sosh_{eval,builtins}.{c,h}`, so it cannot conflict with **PR #358** (echo gate) or **PR #360** (manifest example) on the #351 surface.

## Validation

```
$ bash build/scripts/test.sh validate_sosh_capability_contract
SOSH_CONTRACT:PASS:CAP_CONSOLE_WRITE:console_write
SOSH_CONTRACT:PASS:CAP_CONSOLE_WRITE:console_write
SOSH_CONTRACT:PASS:CAP_FS_READ:fs_read
SOSH_CONTRACT:PASS:CAP_FS_READ:fs_read
SOSH_CONTRACT:PASS:CAP_FS_READ:fs_read
SOSH_CONTRACT:PASS:CAP_FS_READ:fs_read
SOSH_CONTRACT:PASS:CAP_FS_WRITE:fs_write
SOSH_CONTRACT:PASS:CAP_APP_EXEC:app_exec
SOSH_CONTRACT:PASS:CAP_ENV_WRITE:if_defined_absent_ok
SOSH_CONTRACT:PASS:overall

$ bash build/scripts/test.sh sosh_contract_registry_drift
TEST:START:sosh_contract_registry_drift_canary
TEST:PASS:sosh_contract_registry_drift_canary
```

## Follow-ups (out of scope)

- The §4 `CAP_ENV_WRITE` row footnote says enforcement must either add a registry entry or make `export` a host-only no-op. The validator tolerates either outcome today via the `(if defined)` annotation; whichever the env-write enforcement PR chooses, that PR can drop the annotation and the validator will start hard-requiring registry presence — no change needed here.
- A future revision of the contract that adds new `CAP_*` rows will now fail this validator until `capability-registry.json` learns about them. That is the intended forcing function.

Refs #351.