### PR TITLE
docs(roadmap): wire BUILD_ROADMAP §5.5 to existing m5_owner_delete_cascade_allow_qemu TEST:PASS markers (refs #313)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -388,8 +388,45 @@ Deliver:
 
 Validate:
 
-- deleting Launcher removes owned app modules/resources
-- delegated caps derived from deleted owner become invalid
+- deleting Launcher removes owned app modules/resources — satisfied
+  end-to-end by the substrate-tier marker
+  `TEST:PASS:m5_owner_delete_cascade_allow_qemu` plus sub-checks
+  `:subtree_revoked_before_destroy_qemu` and `:delegated_caps_invalid`
+  (see `tests/m5_owner_delete_cascade_allow_qemu_test.c`, run via
+  `build/scripts/test.sh m5_owner_delete_cascade_allow_qemu` /
+  `build/scripts/test_m5_owner_delete_cascade_allow_qemu.sh`). The
+  load-bearing cap-handle subtree revoke under cascade is
+  separately pinned host-side by
+  `TEST:PASS:broker_svc_cascade_revokes_minted_handle` plus its six
+  pre/post gate + count sub-checks
+  (`tests/broker_svc_cascade_revokes_minted_handle_test.c`, run via
+  `build/scripts/test.sh broker_svc_cascade_revokes_minted_handle`).
+  The audit-side `audit_cascade_recorded` /
+  `audit_cascade_done_recorded` sub-checks emit explicit
+  `TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded`
+  and
+  `TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded`
+  markers gated on the cascade-audit wiring follow-up #98
+  (`cap.revoked.cascade` + `cap.cascade.done` event classes), so the
+  validator distinguishes "not asserted" from "asserted and passed"
+  — same SKIP discipline §5.4 uses for `audit_*_recorded_qemu`.
+- delegated caps derived from deleted owner become invalid — covered
+  by the `:delegated_caps_invalid` sub-check above, which asserts
+  that an `ipc_send_h` on the recipient's delegated handle returns
+  `IPC_ERR_CAP_DENIED` after the cascade. The deny-side substrate
+  peer `m5_owner_delete_cascade_deny_qemu` (BUILD_ROADMAP §5.5
+  fourth-marker peer per the M2/M3/M4 substrate-plan precedent) is
+  tracked by #326 and is in flight; this section will grow a
+  matching `TEST:PASS:m5_owner_delete_cascade_deny_qemu` reference
+  when that PR merges.
+
+These markers are anchored by the M5 substrate plan #313
+(M5 ownership graph + cascading deletion re-platformed onto merged
+M1 substrate) and the canonical M5 plan #118, with the allow-tier
+`_qemu` peer landed by #344 and the underlying cap-handle subtree
+revoke walker landed by #327 (closes #323). The M5-SUBSTRATE-005
+GFX/WM session-teardown leg (plan #355, slices 005a/005b/005c) is
+tracked by #350 and stacks additively on top of these markers.
 
 ## 5.6 M6: Public SDK + external app template
 


### PR DESCRIPTION
Doc-only change. Mirrors the §5.2 (#256) / §5.3 (#284) / §5.4 (#315) discipline of binding the BUILD_ROADMAP `Validate` bullets in §5.5 (M5 ownership graph + cascading deletion) to the concrete TEST:PASS / TEST:SKIP marker spellings already emitted on `main`.

## What changed

`BUILD_ROADMAP.md` §5.5 grows from two bare bullets into the same shape §5.4 uses, naming:

- **Allow leg** — `TEST:PASS:m5_owner_delete_cascade_allow_qemu` plus the two PASS sub-checks `:subtree_revoked_before_destroy_qemu` and `:delegated_caps_invalid`, with the source file (`tests/m5_owner_delete_cascade_allow_qemu_test.c`) and runner (`build/scripts/test_m5_owner_delete_cascade_allow_qemu.sh`) called out by name.
- **Host-side cap-handle revoke pin** — `TEST:PASS:broker_svc_cascade_revokes_minted_handle` plus its six pre/post gate + count sub-checks, citing `tests/broker_svc_cascade_revokes_minted_handle_test.c` and runner script.
- **Audit SKIPs** — the two explicit `TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_*` markers, called out as gated on follow-up #98 (`cap.revoked.cascade` + `cap.cascade.done` event classes) — same SKIP discipline §5.4 uses for `audit_*_recorded_qemu` (issue #311).
- **Plan anchors** — links back to plan issues #313, #118, the M5 substrate plan + canonical M5 plan; merge PRs #344 (allow `_qemu` peer) and #327 (subtree revoke walker, closes #323); and the WM session-teardown follow-on plan #355 / issue #350.
- **Deny-tier peer placeholder** — explicitly notes the deny-side `m5_owner_delete_cascade_deny_qemu` marker is in flight via #326 / PR #362 and will be wired here once that PR merges (same growth pattern §5.4 used).

## Validation

```
$ bash build/scripts/test.sh m5_owner_delete_cascade_allow_qemu
TEST:PASS:m5_owner_delete_cascade_allow_qemu:subtree_revoked_before_destroy_qemu
TEST:PASS:m5_owner_delete_cascade_allow_qemu:delegated_caps_invalid
TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded
TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded
TEST:PASS:m5_owner_delete_cascade_allow_qemu

$ bash build/scripts/test.sh broker_svc_cascade_revokes_minted_handle
TEST:PASS:broker_svc_cascade_pre_revoke_recipient_gate
TEST:PASS:broker_svc_cascade_pre_revoke_owner_gate
TEST:PASS:broker_svc_cascade_delete_owner_ok
TEST:PASS:broker_svc_cascade_post_revoke_recipient_gate
TEST:PASS:broker_svc_cascade_post_revoke_owner_gate
TEST:PASS:broker_svc_cascade_count
TEST:PASS:broker_svc_cascade_revokes_minted_handle
```

All marker spellings cited in the new §5.5 text are byte-identical to those emitted by the binaries on `main`.

## Non-goals / ABI

- No code change. No header, no kernel, no test source touched.
- No `OS_ABI_VERSION` bump. No `docs/abi/*` change. No `capability-registry.json` change.
- No new TEST markers introduced — purely references markers already on `main`.

## Follow-ups (not in this PR)

- When **PR #362** (`fix #326: m5_owner_delete_cascade_deny_qemu`) merges, grow §5.5 with its `TEST:PASS:m5_owner_delete_cascade_deny_qemu` + sub-check references, identical to how §5.4 grew its deny + revoke marker references.
- When **PR #363** (`fix #350: broker_svc step 3.5 — WM session teardown`) + slice 005c land, add the WM-session-cascade `_qemu` peer marker.
- When **#98** lands (audit-ring cascade event classes), flip the two `audit_cascade_*` SKIPs to PASS in both the test source and this roadmap text.

Refs #313. Parity references: #256 (§5.2), #284 (§5.3), #315 (§5.4).

_— secureos-hourly-issue-work cron, run e4c62e32, 2026-05-27 08:58 UTC_