### PR TITLE
ci(bundle): wire M4 broker_svc + M5 cascade _qemu peers into validate_bundle TEST_TARGETS (refs #299, #313)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -49,6 +49,23 @@ TEST_TARGETS=(
     proc_sched
     m1_ipc_demo
     validate_abi_stamps
+    # M4 capability-broker substrate (umbrella #299, plan
+    # plans/2026-05-25-m4-broker-on-m1-substrate.md): host-side broker_svc
+    # checks + the three `_qemu` peers (slices 003/004) are all green on
+    # main but had not been wired into the bundle gate. Adding them so a
+    # future M4 substrate regression flips the bundle to FAIL.
+    broker_svc_port_alloc
+    broker_svc_delete_owner_authority_check
+    broker_svc_cascade_revokes_minted_handle
+    m4_broker_share_allow_qemu
+    m4_broker_share_deny_qemu
+    m4_broker_share_revoke_qemu
+    # M5 ownership-graph cascade (umbrella #313, plan
+    # plans/2026-05-25-m5-ownership-on-m1-substrate.md): allow-side
+    # `_qemu` peer (slice 003). The deny-side peer
+    # (`m5_owner_delete_cascade_deny_qemu`, #326 / PR #362) lands
+    # alongside its source PR.
+    m5_owner_delete_cascade_allow_qemu
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /


### PR DESCRIPTION
Follow-up to the merged M4 (#299) and in-flight M5 (#313) substrate trilogies, addressing the explicit gap called out in **PR #362's Follow-ups**:

> Wire both M5 cascade targets into `build/scripts/validate_bundle.sh` `TEST_TARGETS`. Neither the allow (#325/#344) nor deny (#326/this PR) target is listed there yet — happy to fold into a follow-up so the bundle starts asserting M5 markers.

The same gap exists for the entire M4-on-M1 substrate: all four slices merged (#306/#307/#308/#329) and the host-side broker_svc + the three `_qemu` peers are green on `main`, but none of them gate the bundle. So `BUILD_ROADMAP.md` §6.3 (\"no merge on failing boot or capability regression tests\") is not actually being enforced against M4/M5 substrate regressions — this is the same shape of orphan that #129 caught for `scheduler`/`tls`/`https`.

## Change

`build/scripts/validate_bundle.sh` `TEST_TARGETS` grows by 7 entries, each currently green on `main`:

| Target | Slice | Landed via |
| --- | --- | --- |
| `broker_svc_port_alloc` | M4-SUBSTRATE-001 | #306 |
| `broker_svc_delete_owner_authority_check` | M5 step 2 | #324 / PR #354 |
| `broker_svc_cascade_revokes_minted_handle` | M5 step 3 | #327 / PR #344 stack |
| `m4_broker_share_allow_qemu` | M4-SUBSTRATE-003 | #308 |
| `m4_broker_share_deny_qemu` | M4-SUBSTRATE-003 | #308 |
| `m4_broker_share_revoke_qemu` | M4-SUBSTRATE-004 | #329 |
| `m5_owner_delete_cascade_allow_qemu` | M5-SUBSTRATE-003 | #344 |

## Deliberately NOT in this PR

- **`m5_owner_delete_cascade_deny_qemu`** — in flight as **PR #362**. That PR can grow `TEST_TARGETS` in the same commit that lands the test source (same pattern §5.4 used when the M4 revoke peer landed). Leaving this out so the two PRs don't conflict on the same line.
- **`m2_*_qemu` / `m3_*_qemu` peers** — currently **red on `main`** (host-side: `CAP:DENY:3:console_write:bounds` / `CAP:DENY:3:fs_write:bounds` / `CAP:DENY:3:fs_read:bounds` killing the helloapp send path). Wiring them into the bundle today would flip every PR red. They merit a separate triage issue.
- **`canary_must_fail`** — already declared in `EXPECTED_FAIL_TARGETS`.

## Validation

```
$ bash -n build/scripts/validate_bundle.sh   # syntax OK

$ for t in broker_svc_port_alloc broker_svc_delete_owner_authority_check \
           broker_svc_cascade_revokes_minted_handle \
           m4_broker_share_allow_qemu m4_broker_share_deny_qemu \
           m4_broker_share_revoke_qemu m5_owner_delete_cascade_allow_qemu; do
    bash build/scripts/test.sh \"$t\" >/dev/null 2>&1 && echo \"PASS $t\" || echo \"FAIL $t\"
  done
PASS broker_svc_port_alloc
PASS broker_svc_delete_owner_authority_check
PASS broker_svc_cascade_revokes_minted_handle
PASS m4_broker_share_allow_qemu
PASS m4_broker_share_deny_qemu
PASS m4_broker_share_revoke_qemu
PASS m5_owner_delete_cascade_allow_qemu
```

The full `validate_bundle.sh` invocation will rebuild the boot image + run all targets; that path is exercised by `build-and-validate` CI on this PR.

## ABI / scope

- CI-config only. No code, no test source, no ABI header, no manifest schema, no plan-dir churn.
- `OS_ABI_VERSION` unchanged.
- Comment block matches the inline-NOTE discipline #129 / PR #130 set (call out deliberately-excluded targets and *why*).

## Follow-ups (not in this PR)

- File an issue covering the M2/M3 `_qemu` peer regression (the `CAP:DENY:<sid>:console_write:bounds` / `:fs_*:bounds` failures). They look like a substrate IPC-scratch bounds-check landing without the corresponding helloapp pointer setup; needs a focused triage pass.
- When **PR #362** merges, add `m5_owner_delete_cascade_deny_qemu` to `TEST_TARGETS` in that PR's tip.

Refs #299. Refs #313. Refs #362. Refs #129.

_— secureos-hourly-issue-work cron, run e4c62e32, 2026-05-27 12:19 UTC_