### PR TITLE
doc(manifest): optional capabilities.ownership_role enum (refs #368)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -428,6 +428,25 @@ revoke walker landed by #327 (closes #323). The M5-SUBSTRATE-005
 GFX/WM session-teardown leg (plan #355, slices 005a/005b/005c) is
 tracked by #350 and stacks additively on top of these markers.
 
+Manifest schema ownership-role declaration:
+
+- The manifest schema (`manifests/schema/v0.json`, docs/abi/manifest.md
+  §5.5) carries an optional `capabilities.ownership_role` enum
+  (`"owner"` | `"delegate"` | `"none"`, default `"none"`) so a
+  module/app can declare what role it plays in the M5 ownership
+  graph above. The default `"none"` preserves today's behavior
+  exactly — no ownership edge is registered — so the field is
+  additive and does **not** bump `OS_ABI_VERSION`. Positive
+  examples live at `manifests/examples/helloapp.ownership_owner.json`
+  and `manifests/examples/helloapp.ownership_delegate.json`;
+  positive + negative coverage of the enum (and the backward-compat
+  case where the field is omitted) is pinned by
+  `TEST:PASS:manifest_ownership_role_enum` (run via
+  `build/scripts/test.sh manifest_ownership_role_enum`, mirror of the
+  §5.3 `manifest_persistence_enum` and §5.4 `manifest_broker_role_enum`
+  markers). Schema-only at v0; the launcher / broker_svc runtime
+  wiring lands in later M5-SUBSTRATE slices.
+
 ## 5.6 M6: Public SDK + external app template
 
 Deliver:

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -53,7 +53,7 @@ run_script() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|m5_owner_delete_cascade_allow_qemu|m5_owner_delete_cascade_deny_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail|session_manager_first_for_subject|sosh_cap_allow|sosh_cap_deny|win_gfx_gates|validate_sosh_capability_contract|sosh_contract_registry_drift]
+Usage: $(basename "$0") [hello_boot|hello_boot_negative|harness_negative|cap_api_contract|capability_table|cap_table_skeleton|cap_handle_repr|cap_handle_revoke_subject|cap_handle_revoke_subtree|process_table|process_create_table_full_deny_marker|process_find_aspace_by_subject|proc_sched|proc_sched_aspace_invariant|aspace_carve|aspace_bounds|aspace_invariant|capability_gate|console_svc_port_alloc|fs_svc_port_alloc|broker_svc_port_alloc|broker_svc_delete_owner_authority_check|broker_svc_cascade_revokes_minted_handle|capability_audit|capability_audit_fixture|capability_audit_log|cap_broker|cap_deny_marker_shape|broker_share_allow|broker_share_deny|broker_share_revoke|workflow_rule|launcher_console|launcher_spawn_handoff|launcher_fs_spawn_handoff|launcher_broker_spawn_handoff|event_bus|scheduler|sof_format|sof_verify_at_rest|ed25519|cert_chain|codesign|tls|https|netlib_url_scheme|bearssl_compile|fs_service|launcher_fs|fs_service_persist_allow|fs_service_persist_deny|fs_service_ephemeral_reset|m3_fs_persist_allow_qemu|m3_fs_persist_deny_qemu|m3_fs_ephemeral_reset_qemu|m4_broker_share_allow_qemu|m4_broker_share_deny_qemu|m4_broker_share_revoke_qemu|m5_owner_delete_cascade_allow_qemu|m5_owner_delete_cascade_deny_qemu|app_runtime|helloapp_allow|helloapp_deny|m2_helloapp_allow_qemu|m2_helloapp_deny_qemu|m2_launcher_console_qemu|kernel_console|kernel_filedemo|kernel_persistence|kernel_sessions|validator_report|abi_version|validate_manifests_abi_major|manifest_required_fields|manifest_persistence_enum|manifest_broker_role_enum|manifest_ownership_role_enum|ipc_sync_v0|ipc_port_lifecycle|ipc_handle_gate|ipc_bounds|m1_ipc_demo|syscall_entry_stub|validate_capability_registry|capability_registry_drift|validate_abi_stamps|abi_stamps_drift|parity|harness_defense|canary_must_fail|session_manager_first_for_subject|sosh_cap_allow|sosh_cap_deny|win_gfx_gates|validate_sosh_capability_contract|sosh_contract_registry_drift]
 
 Runs SecureOS test targets. Subordinate scripts are dispatched via bash so
 the executable bit is not required. Harness errors (missing/unreadable
@@ -344,6 +344,15 @@ case "$TEST_NAME" in
     # (which omits the field) still validates, and that a bad enum value
     # is rejected with a deterministic MANIFEST_VALIDATE:* marker.
     run_script "$ROOT_DIR/build/scripts/test_manifest_broker_role_enum.sh"
+    ;;
+  manifest_ownership_role_enum)
+    # Issue #368: positive + negative coverage for the optional
+    # `capabilities.ownership_role` enum (owner|delegate|none, default
+    # none) added to manifests/schema/v0.json. Asserts the checked-in
+    # owner/delegate examples validate, the pre-existing helloapp.json
+    # (which omits the field) still validates, and that a bad enum value
+    # is rejected with a deterministic MANIFEST_VALIDATE:* marker.
+    run_script "$ROOT_DIR/build/scripts/test_manifest_ownership_role_enum.sh"
     ;;
   ipc_sync_v0)
     run_script "$ROOT_DIR/build/scripts/test_ipc_sync_v0.sh"

--- a/build/scripts/test_manifest_ownership_role_enum.sh
+++ b/build/scripts/test_manifest_ownership_role_enum.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# build/scripts/test_manifest_ownership_role_enum.sh
+#
+# Issue #368: positive + negative coverage for the optional
+# `capabilities.ownership_role` enum (owner|delegate|none, default
+# "none") added to manifests/schema/v0.json.
+#
+# Asserts:
+#
+#   1. The checked-in positive examples
+#      (manifests/examples/helloapp.ownership_owner.json and
+#      manifests/examples/helloapp.ownership_delegate.json) validate
+#      against the schema and are reported as MANIFEST_VALIDATE:PASS
+#      by the standard validator wrapper.
+#   2. A synthesized manifest that sets `capabilities.ownership_role`
+#      to a value outside the enum (e.g. "everyone") is REJECTED by
+#      the validator wrapper, with a deterministic
+#      MANIFEST_VALIDATE:(ERROR|FAIL) marker on stderr, and the
+#      offending field name surfaces in the error text. This is the
+#      regression that keeps a typo'd / drifted enum from silently
+#      leaking back in.
+#   3. The pre-existing `helloapp.json` (which omits `ownership_role`
+#      entirely) still validates, proving the field is additive and
+#      backward-compatible (default = "none", today's behavior).
+#
+# Exit codes:
+#   0  - all checks passed
+#   1  - regression: validator accepted a bad enum, or rejected a good one
+#   78 - harness error (env/tool missing)
+#
+# Markers emitted on this script's own success path:
+#   TEST:PASS:manifest_ownership_role_enum
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
+POS_OWNER="$ROOT_DIR/manifests/examples/helloapp.ownership_owner.json"
+POS_DELEGATE="$ROOT_DIR/manifests/examples/helloapp.ownership_delegate.json"
+POS_OMITTED="$ROOT_DIR/manifests/examples/helloapp.json"
+
+if [[ ! -r "$WRAPPER" ]]; then
+  echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
+  exit 78
+fi
+for f in "$POS_OWNER" "$POS_DELEGATE" "$POS_OMITTED"; do
+  if [[ ! -r "$f" ]]; then
+    echo "TEST:FAIL:harness_missing_positive_example:$f" >&2
+    exit 78
+  fi
+done
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_python" >&2
+  exit 78
+fi
+if ! "$PY" -c "import jsonschema" >/dev/null 2>&1; then
+  echo "TEST:FAIL:harness_missing_jsonschema" >&2
+  exit 78
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Positives: each must validate and emit MANIFEST_VALIDATE:PASS. ---
+check_positive() {
+  local label="$1"
+  local path="$2"
+  local out="$TMP/${label}.log"
+  set +e
+  bash "$WRAPPER" "$path" >"$out" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    echo "TEST:FAIL:manifest_ownership_role_enum:${label}_rejected" >&2
+    sed 's/^/  | /' "$out" >&2
+    exit 1
+  fi
+  if ! grep -q "MANIFEST_VALIDATE:PASS" "$out"; then
+    echo "TEST:FAIL:manifest_ownership_role_enum:${label}_missing_pass_marker" >&2
+    sed 's/^/  | /' "$out" >&2
+    exit 1
+  fi
+}
+
+check_positive "owner_example" "$POS_OWNER"
+check_positive "delegate_example" "$POS_DELEGATE"
+check_positive "omitted_field_backcompat" "$POS_OMITTED"
+
+# --- Negative: synthesize an out-of-enum value and assert rejection. ---
+TAMPERED="$TMP/ownership_role_bad.json"
+cat >"$TAMPERED" <<'EOF'
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "ownership_role": "everyone"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}
+EOF
+
+NEG_OUT="$TMP/neg.log"
+set +e
+bash "$WRAPPER" "$TAMPERED" >"$NEG_OUT" 2>&1
+NEG_RC=$?
+set -e
+
+if [[ "$NEG_RC" -eq 0 ]]; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:bad_enum_accepted" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:missing_deterministic_marker" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+if ! grep -q "ownership_role" "$NEG_OUT"; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:field_name_not_in_error" >&2
+  sed 's/^/  | /' "$NEG_OUT" >&2
+  exit 1
+fi
+
+echo "TEST:PASS:manifest_ownership_role_enum"

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -138,6 +138,27 @@ Field semantics we are committing to at v0:
   declared, and `"none"` exactly preserves the current spawn path,
   adding it is additive and does **not** bump `OS_ABI_VERSION`
   (same precedent as `capabilities.persistence` in #285/#286).
+- `capabilities.ownership_role` is an optional enum
+  (`"owner"` | `"delegate"` | `"none"`) that declares what role this
+  app plays in the M5 ownership graph named in BUILD_ROADMAP §5.5
+  (see issue #368 and plan #313). The default is `"none"`, which
+  preserves today's behavior exactly: the launcher registers no
+  ownership edge for the subject and `BROKER_OP_DELETE_OWNER` will
+  not cascade through it. `"owner"` marks an app that is registered
+  as an owner node — its minted handles cascade-revoke when the
+  owner is deleted (see `tests/broker_svc_cascade_revokes_minted_handle_test.c`
+  and the substrate-tier `m5_owner_delete_cascade_allow_qemu` peer).
+  `"delegate"` marks an app that receives delegated handles from a
+  parent owner; deleting the parent invalidates these per §5.5
+  (`:delegated_caps_invalid` sub-check). Like `persistence` and
+  `broker_role`, this field is schema-only at v0 — the launcher and
+  broker_svc runtime wiring lands in later M5-SUBSTRATE slices.
+  Because the field is **optional**, has a non-`"none"` value only
+  when explicitly declared, and `"none"` exactly preserves the
+  current spawn / ownership-edge path, adding it is additive and
+  does **not** bump `OS_ABI_VERSION` (same precedent as
+  `capabilities.persistence` in #285/#286 and
+  `capabilities.broker_role` in #312).
 - `provides[]` lists IPC endpoints the app exposes (see
   [`ipc-wire.md`](./ipc-wire.md)). Endpoint names use a narrow
   reverse-DNS-ish pattern.
@@ -194,6 +215,27 @@ spawn) — the field's runtime meaning is wired up in a later slice
 `broker_role` and so continue to behave as `broker_role: "none"`,
 proving that the addition is backward-compatible.
 
+Two additional fixtures exercise the optional
+`capabilities.ownership_role` enum added in #368:
+
+- **Ownership owner** —
+  [`helloapp.ownership_owner.json`](../../manifests/examples/helloapp.ownership_owner.json):
+  same as `helloapp.json` but with `capabilities.ownership_role:
+  "owner"`. Demonstrates an M5 owner-node declaration.
+- **Ownership delegate** —
+  [`helloapp.ownership_delegate.json`](../../manifests/examples/helloapp.ownership_delegate.json):
+  same as `helloapp.json` but with `capabilities.ownership_role:
+  "delegate"`. Demonstrates a delegated-handle declaration.
+
+These fixtures are schema-only at v0: the launcher still registers
+no ownership edge for the subject at spawn (today's behavior) —
+the field's runtime meaning is wired up in later M5-SUBSTRATE
+slices. The pre-existing `helloapp.json` / `helloapp.deny.json` /
+`helloapp.persistent.json` / `helloapp.broker_*.json` examples omit
+`ownership_role` and so continue to behave as
+`ownership_role: "none"`, proving that the addition is backward-
+compatible.
+
 ## Compatibility policy
 
 `manifest_version` and `os_abi_version` are two intentionally separate
@@ -227,4 +269,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: c21242acde8c3cc30e584463eddba25b00214159
+Last verified against commit: HEAD

--- a/manifests/examples/helloapp.ownership_delegate.json
+++ b/manifests/examples/helloapp.ownership_delegate.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "ownership_role": "delegate"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/examples/helloapp.ownership_owner.json
+++ b/manifests/examples/helloapp.ownership_owner.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "ownership_role": "owner"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -79,6 +79,12 @@
           "type": "string",
           "enum": ["provider", "consumer", "none"],
           "default": "none"
+        },
+        "ownership_role": {
+          "description": "M5 ownership-graph role this app participates in (BUILD_ROADMAP §5.5, issue #368). 'owner' registers the module as an owner node in the M5 graph whose handles cascade-revoke on BROKER_OP_DELETE_OWNER; 'delegate' marks a module that receives delegated handles from a parent owner and whose handles are invalidated when the parent is deleted (§5.5); 'none' (default) preserves today's behavior — no ownership edge is registered. Schema-only / additive at v0 — runtime wiring lands in later M5-SUBSTRATE slices; this field does not bump OS_ABI_VERSION (same precedent as 'persistence' in #285 and 'broker_role' in #312).",
+          "type": "string",
+          "enum": ["owner", "delegate", "none"],
+          "default": "none"
         }
       }
     },


### PR DESCRIPTION
Refs #368 — M5-SUBSTRATE-DOC: manifest schema v0 additive 'capabilities.ownership_role' enum (BUILD_ROADMAP §5.5).

## What

Mirrors the M3-SUBSTRATE-DOC (`persistence`, #285) and M4-SUBSTRATE-DOC (`broker_role`, #312) patterns. Adds an optional `capabilities.ownership_role` enum to `manifests/schema/v0.json` so a module can declare what role it plays in the M5 ownership graph (§5.5).

Enum values:

- `none` (default) — no ownership edge registered; today's behavior preserved exactly.
- `owner` — owner node; minted handles cascade-revoke on `BROKER_OP_DELETE_OWNER` (see `tests/broker_svc_cascade_revokes_minted_handle_test.c` + `m5_owner_delete_cascade_allow_qemu`).
- `delegate` — receives delegated handles from a parent owner; invalidated on parent delete (§5.5 `:delegated_caps_invalid` sub-check).

Schema-only / additive at v0. Default `none` matches today's behavior, so this does **not** bump `OS_ABI_VERSION` (same precedent as `persistence` in #285/#286 and `broker_role` in #312).

## Files

- `manifests/schema/v0.json` — new optional enum (`additionalProperties: false` preserved).
- `manifests/examples/helloapp.ownership_owner.json`, `helloapp.ownership_delegate.json` — positive fixtures.
- `docs/abi/manifest.md` — field semantics + worked-example references.
- `BUILD_ROADMAP.md` §5.5 — references the new field and `TEST:PASS:manifest_ownership_role_enum` marker.
- `build/scripts/test_manifest_ownership_role_enum.sh` — positive (owner/delegate/omitted-field backcompat) + negative (out-of-enum value rejected with deterministic `MANIFEST_VALIDATE:(ERROR|FAIL)` marker; field name surfaces in error).
- `build/scripts/test.sh` — dispatch + usage entry for `manifest_ownership_role_enum`.

## Done-when checklist (from #368)

- [x] `docs/abi/manifest.md` gains normative `capabilities.ownership_role` field with three values + default `none`.
- [x] Validator rejects unknown enum values; accepts absent field as `none` (covered by `test_manifest_ownership_role_enum.sh` positive omitted-field case + negative `everyone` case).
- [x] Example manifests declare `ownership_role: owner` and `ownership_role: delegate`.
- [x] Host fixture asserts accept/reject for each enum value + unknown-value reject path (test_manifest_ownership_role_enum.sh — repo convention is shell-driven validator harness, mirroring `manifest_broker_role_enum` and `manifest_persistence_enum` rather than a separate C fixture).
- [x] BUILD_ROADMAP §5.5 acceptance bullets reference the new field.
- [x] No `OS_ABI_VERSION` bump; field is additive + optional.

## Validation

```
$ build/scripts/test.sh manifest_ownership_role_enum
TEST:PASS:manifest_ownership_role_enum

$ build/scripts/test.sh manifest_broker_role_enum         # regression — still PASS
$ build/scripts/test.sh manifest_persistence_enum         # regression — still PASS
$ build/scripts/test.sh manifest_required_fields          # regression — still PASS
$ build/scripts/validate_manifests.sh                     # 9/9 PASS (including 2 new examples)
```

## Follow-ups

- Runtime enforcement (launcher / broker_svc wiring of `ownership_role` at spawn / `BROKER_OP_DELETE_OWNER` paths) is intentionally out of scope per #368; planner can re-file once a runtime gap appears.
- Cascade audit upgrade (`cap.revoked.cascade` + `cap.cascade.done` SKIP→PASS) is tracked separately by #370.