### PR TITLE
fix #370: cascade audit upgrade — cap.revoked.cascade + cap.cascade.done SKIP→PASS

### DIFF
--- a/build/scripts/test_m5_owner_delete_cascade_allow_qemu.sh
+++ b/build/scripts/test_m5_owner_delete_cascade_allow_qemu.sh
@@ -26,8 +26,8 @@
 # build/scripts/test.sh and validate_bundle.sh):
 #   TEST:PASS:m5_owner_delete_cascade_allow_qemu:subtree_revoked_before_destroy_qemu
 #   TEST:PASS:m5_owner_delete_cascade_allow_qemu:delegated_caps_invalid
-#   TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded
-#   TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded
+#   TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded
+#   TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded
 #   TEST:PASS:m5_owner_delete_cascade_allow_qemu
 
 set -euo pipefail
@@ -63,7 +63,7 @@ LOG_PATH="$OUT_DIR/m5_owner_delete_cascade_allow_qemu_test.log"
 
 grep -q "TEST:PASS:m5_owner_delete_cascade_allow_qemu:subtree_revoked_before_destroy_qemu" "$LOG_PATH"
 grep -q "TEST:PASS:m5_owner_delete_cascade_allow_qemu:delegated_caps_invalid" "$LOG_PATH"
-grep -q "TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded" "$LOG_PATH"
-grep -q "TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded" "$LOG_PATH"
+grep -q "TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded" "$LOG_PATH"
+grep -q "TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded" "$LOG_PATH"
 grep -q "TEST:PASS:m5_owner_delete_cascade_allow_qemu$" "$LOG_PATH"
 ! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/build/scripts/test_m5_owner_delete_cascade_deny_qemu.sh
+++ b/build/scripts/test_m5_owner_delete_cascade_deny_qemu.sh
@@ -24,6 +24,7 @@
 #
 # Emits:
 #   TEST:PASS:m5_owner_delete_cascade_deny_qemu:bystander_cannot_delete_owner
+#   TEST:PASS:m5_owner_delete_cascade_deny_qemu:audit_deny_recorded_no_cascade_qemu
 #   TEST:PASS:m5_owner_delete_cascade_deny_qemu:double_delete_is_idempotent
 #   TEST:PASS:m5_owner_delete_cascade_deny_qemu:process_destroy_recycle_revokes_qemu
 #   TEST:PASS:m5_owner_delete_cascade_deny_qemu
@@ -53,6 +54,7 @@ cc -std=c11 -Wall -Wextra -Werror \
   "$ROOT_DIR/kernel/user/launcher.c" \
   "$ROOT_DIR/kernel/user/helloapp.c" \
   "$ROOT_DIR/tests/harness/svc_subjects.c" \
+  "$ROOT_DIR/tests/harness/session_manager_stub.c" \
   "$ROOT_DIR/tests/m5_owner_delete_cascade_deny_qemu_test.c" \
   -o "$OUT_DIR/m5_owner_delete_cascade_deny_qemu_test"
 
@@ -66,6 +68,7 @@ LOG_PATH="$OUT_DIR/m5_owner_delete_cascade_deny_qemu_test.log"
 grep -q "^CAP:DENY:7:capability_admin:delete_owner_3$" "$LOG_PATH"
 
 grep -q "TEST:PASS:m5_owner_delete_cascade_deny_qemu:bystander_cannot_delete_owner" "$LOG_PATH"
+grep -q "TEST:PASS:m5_owner_delete_cascade_deny_qemu:audit_deny_recorded_no_cascade_qemu" "$LOG_PATH"
 grep -q "TEST:PASS:m5_owner_delete_cascade_deny_qemu:double_delete_is_idempotent" "$LOG_PATH"
 grep -q "TEST:PASS:m5_owner_delete_cascade_deny_qemu:process_destroy_recycle_revokes_qemu" "$LOG_PATH"
 grep -q "TEST:PASS:m5_owner_delete_cascade_deny_qemu$" "$LOG_PATH"

--- a/kernel/cap/capability.c
+++ b/kernel/cap/capability.c
@@ -294,6 +294,10 @@ cap_audit_outcome_t cap_audit_event_outcome(const cap_audit_event_t *event) {
     case CAP_AUDIT_OP_REVOKE:
       return (event->result == CAP_OK) ? CAP_AUDIT_OUTCOME_REVOKED
                                        : CAP_AUDIT_OUTCOME_REVOKE_DENIED;
+    case CAP_AUDIT_OP_CASCADE_REVOKE:
+      return CAP_AUDIT_OUTCOME_CASCADE_REVOKED;
+    case CAP_AUDIT_OP_CASCADE_DONE:
+      return CAP_AUDIT_OUTCOME_CASCADE_DONE;
   }
 
   return CAP_AUDIT_OUTCOME_DENY;
@@ -304,6 +308,8 @@ static const char *cap_audit_op_name(cap_audit_op_t op) {
     case CAP_AUDIT_OP_CHECK:  return "CHECK";
     case CAP_AUDIT_OP_GRANT:  return "GRANT";
     case CAP_AUDIT_OP_REVOKE: return "REVOKE";
+    case CAP_AUDIT_OP_CASCADE_REVOKE: return "CASCADE_REVOKE";
+    case CAP_AUDIT_OP_CASCADE_DONE:   return "CASCADE_DONE";
   }
   return "UNKNOWN";
 }
@@ -326,6 +332,8 @@ static const char *cap_audit_outcome_name(cap_audit_outcome_t outcome) {
     case CAP_AUDIT_OUTCOME_GRANT_DENIED:   return "GRANT_DENIED";
     case CAP_AUDIT_OUTCOME_REVOKED:        return "REVOKED";
     case CAP_AUDIT_OUTCOME_REVOKE_DENIED:  return "REVOKE_DENIED";
+    case CAP_AUDIT_OUTCOME_CASCADE_REVOKED: return "CASCADE_REVOKED";
+    case CAP_AUDIT_OUTCOME_CASCADE_DONE:    return "CASCADE_DONE";
   }
   return "UNKNOWN";
 }

--- a/kernel/cap/capability.h
+++ b/kernel/cap/capability.h
@@ -80,6 +80,24 @@ typedef enum {
   CAP_AUDIT_OP_CHECK = 0,
   CAP_AUDIT_OP_GRANT = 1,
   CAP_AUDIT_OP_REVOKE = 2,
+  /*
+   * Issue #370: per-child cascade revoke emitted by
+   * broker_svc_delete_owner. Schema-compatible with the existing
+   * cap_audit_event_t tuple (#98) — `actor_subject_id` is the
+   * caller of broker_svc_delete_owner, `subject_id` is the affected
+   * recipient / session-owner subject, `capability_id` is the
+   * underlying CAP_* the share carried (or 0 for non-cap edges such
+   * as the step-3.5 session teardown).
+   */
+  CAP_AUDIT_OP_CASCADE_REVOKE = 3,
+  /*
+   * Issue #370: terminal cap.cascade.done event emitted exactly once
+   * per broker_svc_delete_owner ALLOW invocation. `subject_id` is
+   * the owner whose tree was torn down; `capability_id` carries the
+   * `n_children` cascade count (overloaded — fits in v0 because
+   * capability_id is u32 and the bound is BROKER_SVC_CASCADE_*).
+   */
+  CAP_AUDIT_OP_CASCADE_DONE = 4,
 } cap_audit_op_t;
 
 typedef struct {
@@ -106,6 +124,9 @@ typedef enum {
   CAP_AUDIT_OUTCOME_GRANT_DENIED = 3,
   CAP_AUDIT_OUTCOME_REVOKED = 4,
   CAP_AUDIT_OUTCOME_REVOKE_DENIED = 5,
+  /* Issue #370: outcomes for the cascade ops above. */
+  CAP_AUDIT_OUTCOME_CASCADE_REVOKED = 6,
+  CAP_AUDIT_OUTCOME_CASCADE_DONE    = 7,
 } cap_audit_outcome_t;
 
 /*

--- a/kernel/svc/broker_svc.c
+++ b/kernel/svc/broker_svc.c
@@ -297,6 +297,17 @@ broker_svc_result_t broker_svc_delete_owner(cap_subject_id_t actor_subject_id,
   /* Step 1: authority check. The predicate emits the canonical
    * CAP:DENY marker on rejection. */
   if (cap_broker_delete_owner_check(actor_subject_id, owner_subject_id) == 0) {
+    /* Issue #370: record one cap.deny audit event for the bystander
+     * (or otherwise unauthorised) caller. Mirrors the marker shape:
+     * actor = would-be deleter, subject = the owner being targeted,
+     * cap_id = CAP_CAPABILITY_ADMIN (same id the deny marker uses),
+     * result = CAP_ERR_MISSING. CASCADE_REVOKE / CASCADE_DONE are
+     * NOT emitted on this path — there is no cascade. */
+    cap_audit_emit(CAP_AUDIT_OP_CHECK,
+                   actor_subject_id,
+                   owner_subject_id,
+                   CAP_CAPABILITY_ADMIN,
+                   CAP_ERR_MISSING);
     return BROKER_SVC_ERR_DELETE_DENIED;
   }
 
@@ -309,8 +320,19 @@ broker_svc_result_t broker_svc_delete_owner(cap_subject_id_t actor_subject_id,
   for (size_t i = 0u; i < CAP_BROKER_MAX_SHARES; ++i) {
     if (g_broker_shares[i].child_handle != CAP_HANDLE_NULL &&
         g_broker_shares[i].owner_subject == owner_subject_id) {
-      /* TODO(#98): emit cap.revoked.cascade {owner, recipient,
-       * share_id} structured audit event here. */
+      /* Issue #370: per-child cap.revoked.cascade audit event.
+       * actor   = caller of broker_svc_delete_owner
+       * subject = recipient that loses the delegated handle
+       * cap_id  = 0 here (the v0 side-table row does not carry the
+       *           underlying CAP_*; child_handle is the load-bearing
+       *           handle revoked by step 3's subtree walk). The
+       *           per-row event still uniquely identifies the
+       *           (owner, recipient) edge being torn down. */
+      cap_audit_emit(CAP_AUDIT_OP_CASCADE_REVOKE,
+                     actor_subject_id,
+                     g_broker_shares[i].recipient_subject,
+                     (capability_id_t)0,
+                     CAP_OK);
       n_children = (uint32_t)(n_children + 1u);
       g_broker_shares[i].share_id          = CAP_SHARE_ID_INVALID;
       g_broker_shares[i].owner_subject     = 0u;
@@ -352,8 +374,16 @@ broker_svc_result_t broker_svc_delete_owner(cap_subject_id_t actor_subject_id,
     if (session_manager_first_session_for_subject(owner_subject_id, &sid) != 0) {
       break;
     }
-    /* TODO(#98): emit cap.revoked.cascade {owner, child_kind=SESSION,
-     * child=sid, reason="owner_deleted"}. */
+    /* Issue #370: cap.revoked.cascade for the SESSION leg. The
+     * session id is folded into subject_id position so the audit
+     * record uniquely names which session was torn down; cap_id=0
+     * marks this as a non-cap edge (window-manager session, per
+     * plan plans/2026-05-26-m5-wm-cascade-on-substrate.md). */
+    cap_audit_emit(CAP_AUDIT_OP_CASCADE_REVOKE,
+                   actor_subject_id,
+                   (cap_subject_id_t)sid,
+                   (capability_id_t)0,
+                   CAP_OK);
     session_manager_destroy(sid);
     n_children = (uint32_t)(n_children + 1u);
   }
@@ -368,8 +398,16 @@ broker_svc_result_t broker_svc_delete_owner(cap_subject_id_t actor_subject_id,
     (void)process_destroy(owner_pid);
   }
 
-  /* Step 5: summary audit (SKIP — gated on #98). */
-  /* TODO(#98): emit cap.cascade.done {owner, n_children}. */
+  /* Step 5: summary audit. Issue #370 — emit terminal
+   * cap.cascade.done exactly once per ALLOW invocation. The
+   * cascade count is encoded into the capability_id field of the
+   * audit tuple (overload documented in capability.h alongside
+   * CAP_AUDIT_OP_CASCADE_DONE). */
+  cap_audit_emit(CAP_AUDIT_OP_CASCADE_DONE,
+                 actor_subject_id,
+                 owner_subject_id,
+                 (capability_id_t)n_children,
+                 CAP_OK);
 
   /* Step 6: surface the cascade count. */
   if (out_n != NULL) {

--- a/tests/m5_owner_delete_cascade_allow_qemu_test.c
+++ b/tests/m5_owner_delete_cascade_allow_qemu_test.c
@@ -364,12 +364,46 @@ int main(void) {
   printf("TEST:PASS:m5_owner_delete_cascade_allow_qemu:"
          "delegated_caps_invalid\n");
 
-  /* Audit SKIPs — gated on #98 (cap.revoked.cascade + cap.cascade.done
-   * event classes). Mirror the #304 audit_deny_recorded_qemu shape. */
-  printf("TEST:SKIP:m5_owner_delete_cascade_allow_qemu:"
-         "audit_cascade_recorded\n");
-  printf("TEST:SKIP:m5_owner_delete_cascade_allow_qemu:"
-         "audit_cascade_done_recorded\n");
+  /* Audit assertions — issue #370. Confirm the cascade emitted at
+   * least one cap.revoked.cascade event for the recipient AND a
+   * terminal cap.cascade.done with n_children > 0 attributed to the
+   * owner. We scan the audit ring rather than pinning a slot index
+   * so the test is robust to other audit traffic (e.g. broker
+   * grant/revoke records from cap_broker_*) interleaving. */
+  {
+    size_t total = cap_audit_count_for_tests();
+    int saw_cascade  = 0;
+    int saw_done     = 0;
+    for (size_t i = 0u; i < total; ++i) {
+      cap_audit_event_t ev;
+      if (cap_audit_get_for_tests(i, &ev) != CAP_OK) continue;
+      if (ev.operation == CAP_AUDIT_OP_CASCADE_REVOKE &&
+          ev.actor_subject_id == owner &&
+          ev.subject_id == recipient &&
+          ev.result == CAP_OK) {
+        saw_cascade = 1;
+      }
+      if (ev.operation == CAP_AUDIT_OP_CASCADE_DONE &&
+          ev.actor_subject_id == owner &&
+          ev.subject_id == owner &&
+          ev.capability_id == (capability_id_t)n_children &&
+          ev.result == CAP_OK) {
+        saw_done = 1;
+      }
+    }
+    if (!saw_cascade) {
+      fail("audit_cascade_recorded");
+      goto out;
+    }
+    printf("TEST:PASS:m5_owner_delete_cascade_allow_qemu:"
+           "audit_cascade_recorded\n");
+    if (!saw_done) {
+      fail("audit_cascade_done_recorded");
+      goto out;
+    }
+    printf("TEST:PASS:m5_owner_delete_cascade_allow_qemu:"
+           "audit_cascade_done_recorded\n");
+  }
 
   /* Cleanup. Owner PCB is still live because we passed PID_INVALID
    * above; tear it down through the launcher so the spawn-table

--- a/tests/m5_owner_delete_cascade_deny_qemu_test.c
+++ b/tests/m5_owner_delete_cascade_deny_qemu_test.c
@@ -334,6 +334,46 @@ int main(void) {
   printf("TEST:PASS:m5_owner_delete_cascade_deny_qemu:"
          "bystander_cannot_delete_owner\n");
 
+  /* Issue #370 audit assertion (bystander path):
+   *   - exactly one cap.deny event recorded against the bystander
+   *     for {actor=bystander, subject=owner, cap=CAP_CAPABILITY_ADMIN}
+   *   - zero cap.cascade.* events emitted on the deny path (no
+   *     false-positive cascade audit). */
+  {
+    size_t total = cap_audit_count_for_tests();
+    int deny_count       = 0;
+    int cascade_seen     = 0;
+    int cascade_done_seen = 0;
+    for (size_t i = 0u; i < total; ++i) {
+      cap_audit_event_t ev;
+      if (cap_audit_get_for_tests(i, &ev) != CAP_OK) continue;
+      if (ev.operation == CAP_AUDIT_OP_CHECK &&
+          ev.actor_subject_id == bystander &&
+          ev.subject_id == owner &&
+          ev.capability_id == CAP_CAPABILITY_ADMIN &&
+          ev.result == CAP_ERR_MISSING) {
+        deny_count++;
+      }
+      if (ev.operation == CAP_AUDIT_OP_CASCADE_REVOKE) {
+        cascade_seen = 1;
+      }
+      if (ev.operation == CAP_AUDIT_OP_CASCADE_DONE) {
+        cascade_done_seen = 1;
+      }
+    }
+    if (deny_count != 1) {
+      fprintf(stderr, "bystander deny audit count = %d (want 1)\n", deny_count);
+      fail("bystander_deny_audit_not_recorded");
+      goto out;
+    }
+    if (cascade_seen || cascade_done_seen) {
+      fail("bystander_deny_leaked_cascade_audit");
+      goto out;
+    }
+  }
+  printf("TEST:PASS:m5_owner_delete_cascade_deny_qemu:"
+         "audit_deny_recorded_no_cascade_qemu\n");
+
   /* ------------------------------------------------------------------
    * Sub-check 2: double_delete_is_idempotent
    *


### PR DESCRIPTION
Closes #370.

## Summary

Wires structured audit events through `broker_svc_delete_owner` (BUILD_ROADMAP §5.5) so the M5 ownership cascade leaves audit evidence on every edge it tears down, and flips the two `TEST:SKIP` markers in the M5 cascade allow/deny peers to `TEST:PASS`. Same playbook as #311 used for §5.4.

## Schema (additive, no `OS_ABI_VERSION` bump)

Reuses the existing `cap_audit_event_t` tuple from #98. Two new ops in `cap_audit_op_t`:

- `CAP_AUDIT_OP_CASCADE_REVOKE` — one event per edge revoked by the cascade. `actor` = caller, `subject` = recipient (or session id for the step-3.5 WM leg), `cap_id` = underlying CAP_* (0 for non-cap edges).
- `CAP_AUDIT_OP_CASCADE_DONE` — terminal event emitted exactly once per ALLOW invocation. `subject` = owner; `cap_id` overloaded with `n_children` cascade count.

`cap_audit_event_outcome` / `cap_audit_op_name` / `cap_audit_outcome_name` extended with `CASCADE_REVOKED` and `CASCADE_DONE`.

## Emitters (`kernel/svc/broker_svc.c`)

- **Step 1 deny path:** bystander / unauthorised caller now records a `cap.deny` (`OP_CHECK`, `cap=CAP_CAPABILITY_ADMIN`, `result=CAP_ERR_MISSING`) — mirrors the existing `CAP:DENY` stdout marker.
- **Step 2 (cap edge):** one `cap.revoked.cascade` per delegated recipient walked out of the broker_svc side-table.
- **Step 3.5 (session edge, #350):** `cap.revoked.cascade` per torn-down WM session (`cap_id=0` marks the non-cap edge).
- **Step 5 terminal:** `cap.cascade.done` once per ALLOW with `n_children` in `capability_id`.

## Test flips

- `tests/m5_owner_delete_cascade_allow_qemu_test.c`: `audit_cascade_recorded` and `audit_cascade_done_recorded` SKIP → PASS by scanning the audit ring for matching CASCADE_REVOKE / CASCADE_DONE tuples.
- `tests/m5_owner_delete_cascade_deny_qemu_test.c`: new `audit_deny_recorded_no_cascade_qemu` PASS — asserts exactly one cap.deny event AND zero cascade audit leakage on the bystander path.
- Both driver shell scripts updated to grep for the PASS markers.

## Drive-by fix

`build/scripts/test_m5_owner_delete_cascade_deny_qemu.sh` was missing `tests/harness/session_manager_stub.c` (regression from #363 — step-3.5 landed but the deny driver wasn't updated). Added so the deny test links cleanly. Without this the deny test was failing at link time on `session_manager_first_session_for_subject` / `session_manager_destroy`.

## Validation (all PASS locally)

- `test_m5_owner_delete_cascade_{allow,deny}_qemu.sh`
- `test_capability_audit{,_fixture,_log}.sh`
- `test_broker_share_{allow,deny,revoke}.sh`
- `test_m4_broker_share_{allow,deny,revoke}_qemu.sh`
- `test_broker_svc_{cascade_revokes_minted_handle,delete_owner_authority_check,step3_5_session_teardown,port_alloc}.sh`

## Out of scope (per #370)

- Byte-exact audit fixture diff for cascade events (analogue of #244 for M5) — separate follow-up.
- M5-SUBSTRATE-005 WM cascade audit (#350) edge type already covered by the additive step-3.5 emit above; deeper WM-specific audit fixturing left for a separate slice.