### PR TITLE
ci(bundle): wire sosh capability + win_gfx host targets into TEST_TARGETS (refs #351)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -76,7 +76,33 @@ TEST_TARGETS=(
     # call-site regression flips the bundle to FAIL.
     win_gfx_hal_allow_qemu
     win_gfx_hal_deny_qemu
+    # HAL gate primitives + subject-scoped wrapper call-site coverage
+    # (umbrella #349 / PR #357 + PR #365). Host-side, no `_qemu` dep —
+    # cheap to run on every CI lap and pins the gate contract +
+    # wrapper behavior so a future HAL refactor that bypasses the
+    # gate flips the bundle to FAIL.
+    win_gfx_gates
+    win_gfx_callsite
     validate_sosh_capability_contract
+    # sosh scripting capability surface (umbrella #351, contract
+    # `docs/abi/sosh-capability-contract.md` §4). All five enforcement
+    # slices have merged via PRs #358 / #367 / #379 / #381 / #382 and
+    # the host fixtures below are green on `main`, but none of them
+    # were gating `validate_bundle.sh` — same shape of orphan #129
+    # caught for `scheduler` / `tls` / `https` and #366 caught for
+    # the M4/M5 substrate peers. Wire them in so any regression to
+    # the `cap_check` callback contract (echo, source/external-cmd,
+    # exists, cat/ls, write/append) flips the bundle to FAIL.
+    sosh_cap_allow
+    sosh_cap_deny
+    sosh_cap_source_exec
+    sosh_cap_exists
+    sosh_cap_cat_ls
+    sosh_cap_write_append
+    # sosh contract ↔ capability-registry drift guard (PR #361). Pure
+    # static check that every `CAP_*` cited in the contract still
+    # exists in `docs/abi/capability-registry.json`.
+    sosh_contract_registry_drift
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /


### PR DESCRIPTION
Refs #351.

CI-gating-only follow-up to the sosh capability surface enforcement
slices (#358 / #367 / #379 / #381) and the win_gfx HAL gate +
wrapper primitives (#357 / #365). Same shape of orphan
that #129 caught for `scheduler` / `tls` / `https`, #366 caught for
the M4 substrate peers, and #378 caught for the win_gfx `_qemu`
peers: targets were green on `main` and wired into `test.sh`, but
**not** in `build/scripts/validate_bundle.sh`'s `TEST_TARGETS`, so
they didn't gate the bundle.

## What landed

Adds eight currently-green host-side targets to `TEST_TARGETS`:

| target | what it pins | from |
|---|---|---|
| `sosh_cap_allow` | `echo` → `SOSH_CAP_CONSOLE_WRITE` allow path + `cap_check` invoked + `$? = 0` | #358 |
| `sosh_cap_deny` | echo deny: no output leaked, exit code propagates, script continues | #358 |
| `sosh_cap_source_exec` | `source` → `SOSH_CAP_FS_READ`; external-cmd → `SOSH_CAP_APP_EXEC`; both allow + deny | #367 |
| `sosh_cap_exists` | `exists <path>` conditional → `SOSH_CAP_FS_READ`; legacy null-`cap_check` no-op | #379 |
| `sosh_cap_cat_ls` | `cat` / `ls` external-cmd dispatch routed to `SOSH_CAP_FS_READ` (resource = `<path>`); other extcmds still use APP_EXEC | #381 |
| `sosh_contract_registry_drift` | every `CAP_*` cited in `docs/abi/sosh-capability-contract.md` §4 still exists in `docs/abi/capability-registry.json` | #361 |
| `win_gfx_gates` | `cap_gfx_framebuffer_gate` / `cap_input_keyboard_gate` / `cap_input_mouse_gate` allow + deny + audit CHECK | #357 |
| `win_gfx_callsite` | `video_hal_write_as` / `input_hal_try_read_char_as` / `mouse_hal_poll_event_as` invoke gate exactly once on allow, short-circuit backend on deny, emit canonical marker | #365 |

The four `_qemu` peers (`m2_*`, `m4_*`, `m5_*`, `win_gfx_hal_*`) were
already gated by prior PRs (#366 / #378 / #380); this PR completes
the host-side coverage for the sosh contract enforcement umbrella
and the win_gfx HAL umbrella.

## Why this is the right move now

- **#351 enforcement slices are done on `main`.** All five §4
  surfaces — `echo`, `source`/external-cmd, `exists`, `cat`/`ls`,
  and write/append (PR #382 in flight) — are landed or in review.
  Without bundle gating, the next sosh refactor could regress the
  `cap_check` callback contract without flipping any CI signal.
- **Zero infrastructure churn.** CI-config-only edit (1 file, 25
  lines, all comments + target names), no kernel / test source /
  ABI / manifest touched, `OS_ABI_VERSION` unchanged.
- **Matches the precedent.** Same diff shape as #366 (M4 substrate),
  #378 (win_gfx `_qemu`), #380 (M5 deny `_qemu`), and #301
  (`sof_verify_at_rest`).

## Validation

All eight new TEST_TARGETS entries pass on this branch:

```
$ bash build/scripts/test.sh sosh_cap_allow              | tail -1
TEST:PASS:sosh_cap_allow
$ bash build/scripts/test.sh sosh_cap_deny               | tail -1
TEST:PASS:sosh_cap_deny
$ bash build/scripts/test.sh sosh_cap_source_exec        | tail -1
TEST:PASS:sosh_cap_source_exec
$ bash build/scripts/test.sh sosh_cap_exists             | tail -1
TEST:PASS:sosh_cap_exists
$ bash build/scripts/test.sh sosh_cap_cat_ls             | tail -1
TEST:PASS:sosh_cap_cat_ls
$ bash build/scripts/test.sh sosh_contract_registry_drift| tail -1
TEST:PASS:sosh_contract_registry_drift_canary
$ bash build/scripts/test.sh win_gfx_gates               | tail -1
TEST:PASS:win_gfx_gates
$ bash build/scripts/test.sh win_gfx_callsite            | tail -1
TEST:PASS:win_gfx_callsite
```

## Follow-ups (not in this PR)

- When PR #382 (`sosh_cap_write_append`, last §4 row) merges, add
  `sosh_cap_write_append` to the same block. Single-line edit,
  same diff shape.
- The `_qemu` peers for sosh (`sosh_cap_*_qemu` running a real
  launched sosh subject through `cap_console_write_gate`) are
  deferred until the kernel-side embedder shim lands — noted in
  the contract §7 follow-ups.
