### PR TITLE
docs(roadmap): refresh §5.5 to merged deny-peer + cascade audit PASS (refs #313)

### DIFF
--- a/BUILD_ROADMAP.md
+++ b/BUILD_ROADMAP.md
@@ -402,23 +402,29 @@ Validate:
   (`tests/broker_svc_cascade_revokes_minted_handle_test.c`, run via
   `build/scripts/test.sh broker_svc_cascade_revokes_minted_handle`).
   The audit-side `audit_cascade_recorded` /
-  `audit_cascade_done_recorded` sub-checks emit explicit
-  `TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded`
+  `audit_cascade_done_recorded` sub-checks now emit
+  `TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded`
   and
-  `TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded`
-  markers gated on the cascade-audit wiring follow-up #98
-  (`cap.revoked.cascade` + `cap.cascade.done` event classes), so the
-  validator distinguishes "not asserted" from "asserted and passed"
-  — same SKIP discipline §5.4 uses for `audit_*_recorded_qemu`.
+  `TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded`
+  on `main` — the cascade-audit wiring follow-up #370 landed the
+  `cap.revoked.cascade` + `cap.cascade.done` event classes and
+  flipped both SKIPs to PASS (see PR #374). The SKIP-discipline
+  parity §5.4 still describes is retained for any future audit-class
+  introductions that have not yet wired through.
 - delegated caps derived from deleted owner become invalid — covered
   by the `:delegated_caps_invalid` sub-check above, which asserts
   that an `ipc_send_h` on the recipient's delegated handle returns
   `IPC_ERR_CAP_DENIED` after the cascade. The deny-side substrate
   peer `m5_owner_delete_cascade_deny_qemu` (BUILD_ROADMAP §5.5
   fourth-marker peer per the M2/M3/M4 substrate-plan precedent) is
-  tracked by #326 and is in flight; this section will grow a
-  matching `TEST:PASS:m5_owner_delete_cascade_deny_qemu` reference
-  when that PR merges.
+  now green on `main` and pinned by
+  `TEST:PASS:m5_owner_delete_cascade_deny_qemu` plus its sub-checks
+  `:bystander_cannot_delete_owner`, `:double_delete_is_idempotent`,
+  and `:process_destroy_recycle_revokes_qemu` (see
+  `tests/m5_owner_delete_cascade_deny_qemu_test.c`, run via
+  `build/scripts/test.sh m5_owner_delete_cascade_deny_qemu` —
+  landed by #326 → PR #362 and gated by `validate_bundle.sh` via
+  PR #380).
 
 These markers are anchored by the M5 substrate plan #313
 (M5 ownership graph + cascading deletion re-platformed onto merged

--- a/tests/m5_owner_delete_cascade_allow_qemu_test.c
+++ b/tests/m5_owner_delete_cascade_allow_qemu_test.c
@@ -48,13 +48,14 @@
  *
  *   TEST:PASS:m5_owner_delete_cascade_allow_qemu:subtree_revoked_before_destroy_qemu
  *   TEST:PASS:m5_owner_delete_cascade_allow_qemu:delegated_caps_invalid
- *   TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded
- *   TEST:SKIP:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded
+ *   TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_recorded
+ *   TEST:PASS:m5_owner_delete_cascade_allow_qemu:audit_cascade_done_recorded
  *   TEST:PASS:m5_owner_delete_cascade_allow_qemu
  *
- * The two SKIP markers are intentional — gated on #98 (the cascade
- * audit-event class). They follow the same shape #304 used for the
- * `audit_deny_recorded_qemu` SKIP.
+ * The two audit sub-checks were originally emitted as SKIP gated on
+ * the cascade audit-event class follow-up; #370 (PR #374) landed the
+ * `cap.revoked.cascade` + `cap.cascade.done` event classes and the
+ * assertions below now PASS on `main`.
  *
  * Issue: #325. Plan: plans/2026-05-25-m5-ownership-on-m1-substrate.md
  * slice 3.


### PR DESCRIPTION
## Summary

The BUILD_ROADMAP \§5.5 M5 acceptance text and the allow-tier substrate-peer test header still described state that was true ~24h ago but has since shifted on `main`:

1. The deny-side substrate peer (`m5_owner_delete_cascade_deny_qemu`, #326) was called out as 'in flight'. It actually landed via PR #362 and was wired into `validate_bundle.sh` `TEST_TARGETS` via PR #380.
2. The two cascade audit sub-checks (`audit_cascade_recorded` / `audit_cascade_done_recorded`) were documented as `TEST:SKIP` gated on #98. The cascade-audit upgrade #370 (PR #374) landed the `cap.revoked.cascade` + `cap.cascade.done` event classes and the allow-tier peer now emits both as `TEST:PASS` on `main`.

This PR brings the §5.5 acceptance text and the allow-tier peer's documented marker block into line with what the binaries actually emit today, mirroring the §5.4 (#315) / §5.3 (#284) acceptance-discipline pattern.

## Changes

- `BUILD_ROADMAP.md` §5.5 — `audit_cascade_*` block flipped SKIP→PASS with the #370/#374 reference; deny-peer paragraph updated to point at the merged `m5_owner_delete_cascade_deny_qemu` marker + its three sub-checks, citing the #362 / #380 chain.
- `tests/m5_owner_delete_cascade_allow_qemu_test.c` — header comment block updated so the documented `TEST:PASS/SKIP` table matches what the binary actually prints (the test body itself was unchanged; #374 flipped behavior but never updated the comment).

## Validation

```
bash build/scripts/test.sh m5_owner_delete_cascade_allow_qemu  # PASS (incl. both audit_cascade_* PASS lines)
bash build/scripts/test.sh m5_owner_delete_cascade_deny_qemu   # PASS
```

## Scope discipline

- No `OS_ABI_VERSION` bump.
- No test behavior change — both peers were already emitting these markers; only the comment block + roadmap acceptance text were stale.
- No manifest / capability-registry / kernel-source change.

## Follow-ups (out of scope)

- The §5.5 paragraph still references #313 as the substrate-plan umbrella. Once all execute slices close (M5-SUBSTRATE-005c is the remaining open WM-cascade leg), a maintainer may want to close #313 as discharged — that is a triage call, not a doc fix.

refs #313