### PR TITLE
test(manifest): ownership_role negative-path + default-when-omitted sub-markers (fix #390)

### DIFF
--- a/build/scripts/test_manifest_ownership_role_enum.sh
+++ b/build/scripts/test_manifest_ownership_role_enum.sh
@@ -12,16 +12,22 @@
 #      manifests/examples/helloapp.ownership_delegate.json) validate
 #      against the schema and are reported as MANIFEST_VALIDATE:PASS
 #      by the standard validator wrapper.
-#   2. A synthesized manifest that sets `capabilities.ownership_role`
-#      to a value outside the enum (e.g. "everyone") is REJECTED by
-#      the validator wrapper, with a deterministic
-#      MANIFEST_VALIDATE:(ERROR|FAIL) marker on stderr, and the
-#      offending field name surfaces in the error text. This is the
-#      regression that keeps a typo'd / drifted enum from silently
-#      leaking back in.
+#   2. A checked-in negative fixture
+#      (manifests/examples/invalid/helloapp.ownership_invalid.json)
+#      and a synthesized in-test variant that set
+#      `capabilities.ownership_role` to a value outside the enum
+#      (e.g. "supervisor", "everyone") are REJECTED by the validator
+#      wrapper, with a deterministic MANIFEST_VALIDATE:(ERROR|FAIL)
+#      marker on stderr, and the offending field name surfaces in
+#      the error text. This is the regression that keeps a typo'd /
+#      drifted enum from silently leaking back in. This path also
+#      emits the `:negative_rejected` sub-marker (parity with
+#      §5.3 manifest_persistence_enum and §5.4 manifest_broker_role_enum).
 #   3. The pre-existing `helloapp.json` (which omits `ownership_role`
 #      entirely) still validates, proving the field is additive and
-#      backward-compatible (default = "none", today's behavior).
+#      backward-compatible (default = "none", today's behavior). This
+#      path also emits the `:default_when_omitted` sub-marker (parity
+#      with §5.3 / §5.4).
 #
 # Exit codes:
 #   0  - all checks passed
@@ -38,12 +44,13 @@ WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
 POS_OWNER="$ROOT_DIR/manifests/examples/helloapp.ownership_owner.json"
 POS_DELEGATE="$ROOT_DIR/manifests/examples/helloapp.ownership_delegate.json"
 POS_OMITTED="$ROOT_DIR/manifests/examples/helloapp.json"
+NEG_FIXTURE="$ROOT_DIR/manifests/examples/invalid/helloapp.ownership_invalid.json"
 
 if [[ ! -r "$WRAPPER" ]]; then
   echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
   exit 78
 fi
-for f in "$POS_OWNER" "$POS_DELEGATE" "$POS_OMITTED"; do
+for f in "$POS_OWNER" "$POS_DELEGATE" "$POS_OMITTED" "$NEG_FIXTURE"; do
   if [[ ! -r "$f" ]]; then
     echo "TEST:FAIL:harness_missing_positive_example:$f" >&2
     exit 78
@@ -88,7 +95,36 @@ check_positive "owner_example" "$POS_OWNER"
 check_positive "delegate_example" "$POS_DELEGATE"
 check_positive "omitted_field_backcompat" "$POS_OMITTED"
 
-# --- Negative: synthesize an out-of-enum value and assert rejection. ---
+# --- Default-when-omitted sub-marker (parity with §5.3/§5.4). ---
+# The omitted-field case above already passed; explicitly emit the
+# spelled-out sub-marker so consumers / dashboards can match the same
+# token as manifest_persistence_enum / manifest_broker_role_enum.
+echo "TEST:PASS:manifest_ownership_role_enum:default_when_omitted"
+
+# --- Negative (checked-in fixture): assert rejection. ---
+NEG_FIX_OUT="$TMP/neg_fixture.log"
+set +e
+bash "$WRAPPER" "$NEG_FIXTURE" >"$NEG_FIX_OUT" 2>&1
+NEG_FIX_RC=$?
+set -e
+
+if [[ "$NEG_FIX_RC" -eq 0 ]]; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:negative_fixture_accepted" >&2
+  sed 's/^/  | /' "$NEG_FIX_OUT" >&2
+  exit 1
+fi
+if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$NEG_FIX_OUT"; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:negative_fixture_missing_deterministic_marker" >&2
+  sed 's/^/  | /' "$NEG_FIX_OUT" >&2
+  exit 1
+fi
+if ! grep -q "ownership_role" "$NEG_FIX_OUT"; then
+  echo "TEST:FAIL:manifest_ownership_role_enum:negative_fixture_field_name_not_in_error" >&2
+  sed 's/^/  | /' "$NEG_FIX_OUT" >&2
+  exit 1
+fi
+
+# --- Negative (synthesized in-test): assert rejection. ---
 TAMPERED="$TMP/ownership_role_bad.json"
 cat >"$TAMPERED" <<'EOF'
 {
@@ -140,5 +176,8 @@ if ! grep -q "ownership_role" "$NEG_OUT"; then
   sed 's/^/  | /' "$NEG_OUT" >&2
   exit 1
 fi
+
+# Negative-path sub-marker (parity with §5.3/§5.4).
+echo "TEST:PASS:manifest_ownership_role_enum:negative_rejected"
 
 echo "TEST:PASS:manifest_ownership_role_enum"

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -236,6 +236,39 @@ slices. The pre-existing `helloapp.json` / `helloapp.deny.json` /
 `ownership_role: "none"`, proving that the addition is backward-
 compatible.
 
+Negative-path coverage matching the §5.3 (`manifest_persistence_enum`)
+and §5.4 (`manifest_broker_role_enum`) precedents lands a checked-in
+bad fixture and an in-test synthesized variant:
+
+- **Out-of-enum (rejected)** —
+  [`invalid/helloapp.ownership_invalid.json`](../../manifests/examples/invalid/helloapp.ownership_invalid.json):
+  same as `helloapp.json` but with `capabilities.ownership_role:
+  "supervisor"` (not in the v0 enum). The validator wrapper rejects
+  it with a deterministic `MANIFEST_VALIDATE:(ERROR|FAIL)` marker
+  surfacing the `ownership_role` field name. The bundled regression
+  test `build/scripts/test_manifest_ownership_role_enum.sh` emits the
+  `TEST:PASS:manifest_ownership_role_enum:negative_rejected` sub-marker
+  on success (parity with `manifest_persistence_enum:negative_rejected`
+  / `manifest_broker_role_enum:negative_rejected`).
+- **Default when omitted** — the same regression test emits
+  `TEST:PASS:manifest_ownership_role_enum:default_when_omitted` after
+  asserting that `helloapp.json` (which omits `ownership_role` entirely)
+  still validates, locking in the additive / back-compat contract
+  (parity with the matching §5.3 / §5.4 sub-marker spellings).
+
+The `invalid/` subdirectory is deliberately outside the
+`manifests/examples/*.json` glob walked by `validate_manifests.sh`, so
+the checked-in bad fixture does not show up in the bulk-validator pass
+list while still being a stable target for the regression test.
+
+### §5.5 ownership_role enforcement status
+
+| Sub-marker | Status |
+| --- | --- |
+| `manifest_ownership_role_enum` (positive) | enforced (PR #372) |
+| `manifest_ownership_role_enum:negative_rejected` | enforced (PR for #390) |
+| `manifest_ownership_role_enum:default_when_omitted` | enforced (PR for #390) |
+
 ## Compatibility policy
 
 `manifest_version` and `os_abi_version` are two intentionally separate

--- a/manifests/examples/invalid/helloapp.ownership_invalid.json
+++ b/manifests/examples/invalid/helloapp.ownership_invalid.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": [],
+    "ownership_role": "supervisor"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}


### PR DESCRIPTION
Closes #390.

Adds the missing negative-path + default-when-omitted parity coverage for the optional `capabilities.ownership_role` enum, matching the §5.3 (`manifest_persistence_enum`) and §5.4 (`manifest_broker_role_enum`) precedents.

## Changes

- **`manifests/examples/invalid/helloapp.ownership_invalid.json`** — new checked-in negative fixture with `capabilities.ownership_role: "supervisor"` (out of enum). Placed under a new `invalid/` subdirectory so it is outside the `manifests/examples/*.json` glob walked by `validate_manifests.sh`'s bulk pass, while still being a stable target for the regression test.
- **`build/scripts/test_manifest_ownership_role_enum.sh`** — validates the new negative fixture rejects with a `MANIFEST_VALIDATE:(ERROR|FAIL)` marker that names the `ownership_role` field, then emits two new parity sub-markers on success:
  - `TEST:PASS:manifest_ownership_role_enum:default_when_omitted`
  - `TEST:PASS:manifest_ownership_role_enum:negative_rejected`
  Spellings deliberately mirror the §5.3 / §5.4 sub-markers so dashboards / SKIP-discipline checks (cf. #389) can match identical tokens.
- **`docs/abi/manifest.md`** — §5.5 `ownership_role` enforcement status table added (positive / negative_rejected / default_when_omitted → enforced), plus prose describing the `invalid/` fixture convention.

## Validation

```
$ bash build/scripts/test.sh manifest_ownership_role_enum
TEST:PASS:manifest_ownership_role_enum:default_when_omitted
TEST:PASS:manifest_ownership_role_enum:negative_rejected
TEST:PASS:manifest_ownership_role_enum

$ bash build/scripts/test.sh manifest_broker_role_enum
TEST:PASS:manifest_broker_role_enum

$ bash build/scripts/test.sh manifest_persistence_enum
TEST:PASS:manifest_persistence_enum

$ bash build/scripts/validate_manifests.sh
... MANIFEST_VALIDATE:SUMMARY:pass 9/9
```

The bulk validator still sees 9/9 — the negative fixture is correctly excluded from the example glob.

## Out of scope

- Launcher / broker runtime wiring of `ownership_role` (deferred to a later M5-SUBSTRATE slice per #368). Still schema-only at v0; no `OS_ABI_VERSION` bump.

## Follow-ups

- The sibling §5.3/§5.4 tests do not (yet) emit explicit `:negative_rejected` / `:default_when_omitted` sub-markers either — they assert the same behaviors but without the dashboard-matchable tokens. Worth a tiny parity-back-fill PR if a maintainer wants symmetry across all three enums. Happy to open as a follow-up.