### PR TITLE
docs(sosh): §6.1 audit integration + audit_deny_recorded SKIP on all sosh deny tests (fix #389)

### DIFF
--- a/docs/abi/sosh-capability-contract.md
+++ b/docs/abi/sosh-capability-contract.md
@@ -245,6 +245,53 @@ When a sosh builtin's gate check fails:
    §5 — same shape as the M2/M3/M4 deny paths, no sosh-specific schema
    extension.
 
+### 6.1 Audit integration (embedder follow-up)
+
+The `cap_check` deny path in soshlib is currently a *script-side* gate
+only: it short-circuits the builtin and propagates the deny rc into
+`$?`, but it does NOT itself append to the kernel capability-audit
+ring. That wiring is intentionally left to the **embedder** (the
+in-tree sosh host, future per-script launcher, or test fixture), to
+keep `user/libs/soshlib/` kernel-cap-agnostic per §5.1. This mirrors
+the M4 broker→audit split that was closed by issue [#311](https://github.com/rwrife/SecureOS/issues/311)
+(which flipped `audit_*_recorded` SKIPs to PASS once a broker embedder
+started feeding `cap_audit_record_deny`).
+
+**Embedder contract (normative):**
+
+- An embedder that owns a sosh subject id MAY wire its
+  `sosh_cap_check_fn` deny path into
+  `cap_audit_record_deny(subject_id, cap_id, "-")` (or the
+  resource-bearing equivalent, when the gated builtin carries one).
+- The canonical audit-ring line shape is
+  `CAP:DENY:<sid>:<sosh-cap>:-\n` per
+  [`docs/abi/capability-deny-contract.md`](capability-deny-contract.md)
+  §4.3. The `<sosh-cap>` token is the contract §4 spelling (e.g.
+  `console_write`, `fs_read`, `fs_write`, `app_exec`, `env_write`).
+  No sosh-specific marker grammar is introduced.
+- No new `SOSH_CAP_*` ids and no `OS_ABI_VERSION` bump are required to
+  wire this — `cap_audit_record_deny(...)` is already in tree (used by
+  the M4 broker after #311) and the soshlib API surface is unchanged.
+
+**SKIP discipline until an in-tree embedder lands:** every sosh
+host-side deny test (see §7 "Implementation tracking" for the list)
+emits the marker
+
+```
+TEST:SKIP:<test>:audit_deny_recorded:sosh_audit_unwired_pending_issue_389
+```
+
+exactly once on the deny path. The `<test>` token matches the test's
+existing `TEST:START:` / `TEST:PASS:` family root (e.g.
+`sosh_cap_deny`, `sosh_cap_cat_ls`, `sosh_cap_write_append`,
+`sosh_cap_export`, `sosh_cap_exists`, `sosh_cap_source_exec`). The
+marker is purely informational — `build/scripts/test_sosh_cap_*.sh`
+still `grep -q` the existing required PASS lines, and no validator
+asserts the SKIP shape today. Once an in-tree sosh embedder begins
+feeding deny events to the audit ring, the marker flips to a
+`TEST:PASS:<test>:audit_deny_recorded` assertion driven against the
+ring contents, mirroring the M4 #311 transition.
+
 ## 7. Implementation tracking
 
 This document is the first done-when bullet of #351. The remaining

--- a/tests/sosh_cap_cat_ls_test.c
+++ b/tests/sosh_cap_cat_ls_test.c
@@ -269,6 +269,10 @@ int main(void) {
   if (strcmp(ctx.last_exec_cmd, "cat") != 0) die("legacy_wrong_exec_cmd");
   printf("TEST:PASS:sosh_cap_cat_ls:legacy_null_cap_check_noop\n");
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389). */
+  printf("TEST:SKIP:sosh_cap_cat_ls:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_cat_ls\n");
   return 0;
 }

--- a/tests/sosh_cap_deny_test.c
+++ b/tests/sosh_cap_deny_test.c
@@ -110,6 +110,13 @@ int main(void) {
   if (strstr(ctx.out, "recovered") == NULL) die("recovery_did_not_emit");
   printf("TEST:PASS:sosh_cap_deny:script_continues\n");
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389): soshlib's
+   * cap_check deny is script-side only; the kernel audit ring is fed
+   * by the embedder, which is not yet in-tree. Flip to PASS once a
+   * sosh embedder wires cap_audit_record_deny (mirrors M4 #311). */
+  printf("TEST:SKIP:sosh_cap_deny:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_deny\n");
   return 0;
 }

--- a/tests/sosh_cap_exists_test.c
+++ b/tests/sosh_cap_exists_test.c
@@ -215,6 +215,10 @@ int main(void) {
   }
   printf("TEST:PASS:sosh_cap_exists:legacy_null_cap_check_no_op\n");
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389). */
+  printf("TEST:SKIP:sosh_cap_exists:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_exists\n");
   return 0;
 }

--- a/tests/sosh_cap_export_test.c
+++ b/tests/sosh_cap_export_test.c
@@ -238,6 +238,10 @@ int main(void) {
   if (strcmp(ctx.last_exec_args, "X=y") != 0) die("legacy_wrong_exec_args");
   printf("TEST:PASS:sosh_cap_export:legacy_null_cap_check_noop\n");
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389). */
+  printf("TEST:SKIP:sosh_cap_export:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_export\n");
   return 0;
 }

--- a/tests/sosh_cap_source_exec_test.c
+++ b/tests/sosh_cap_source_exec_test.c
@@ -235,6 +235,10 @@ int main(void) {
     die("extcmd_deny_script_aborted");
   }
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389). */
+  printf("TEST:SKIP:sosh_cap_source_exec:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_source_exec\n");
   return 0;
 }

--- a/tests/sosh_cap_write_append_test.c
+++ b/tests/sosh_cap_write_append_test.c
@@ -275,6 +275,10 @@ int main(void) {
   }
   printf("TEST:PASS:sosh_cap_write_append:legacy_null_cap_check_noop\n");
 
+  /* Audit-integration SKIP per contract §6.1 (issue #389). */
+  printf("TEST:SKIP:sosh_cap_write_append:audit_deny_recorded:"
+         "sosh_audit_unwired_pending_issue_389\n");
+
   printf("TEST:PASS:sosh_cap_write_append\n");
   return 0;
 }


### PR DESCRIPTION
Closes #389.

## Summary

Mirrors the broker→audit SKIP-discipline pattern closed by #311 onto the sosh deny tests. soshlib's `cap_check` deny path is intentionally script-side only — the kernel capability-audit ring is fed by the *embedder*, and no in-tree sosh embedder exists yet. Until one lands, the sosh host tests emit a uniform SKIP marker on the deny path so the gap is visible in the serial log.

## Changes

- **`docs/abi/sosh-capability-contract.md`**: new **§6.1 "Audit integration (embedder follow-up)"** stating:
  - embedder MAY wire `sosh_cap_check_fn` deny → `cap_audit_record_deny(subject_id, cap_id, "-")` (already in tree since #311),
  - canonical audit-ring line shape is `CAP:DENY:<sid>:<sosh-cap>:-\n` per `docs/abi/capability-deny-contract.md` §4.3 (reuses existing grammar — no sosh-specific marker),
  - until an embedder lands, host tests emit `TEST:SKIP:<test>:audit_deny_recorded:sosh_audit_unwired_pending_issue_389` exactly once on the deny path.
- **`tests/sosh_cap_{deny,cat_ls,write_append,export,exists,source_exec}_test.c`**: each emits the new SKIP marker exactly once on the deny path. No behavior change beyond the printed marker — all existing `TEST:PASS:*` lines unchanged.

## Validation

All six `build/scripts/test_sosh_cap_*.sh` runs pass locally and show the new SKIP line interleaved before the family-root PASS:

- `test_sosh_cap_deny.sh` ✅
- `test_sosh_cap_cat_ls.sh` ✅
- `test_sosh_cap_write_append.sh` ✅
- `test_sosh_cap_export.sh` ✅
- `test_sosh_cap_exists.sh` ✅
- `test_sosh_cap_source_exec.sh` ✅

`build/scripts/validate_sosh_capability_contract.sh` still emits `SOSH_CONTRACT:PASS:overall` — the §4 row enumeration is untouched.

No validator/harness regex change required: the existing `grep -q` lines in each `test_sosh_cap_*.sh` assert the PASS markers and tolerate additional output (the SKIP line is purely informational).

## Non-goals / follow-ups

- Wiring an in-tree sosh embedder's `cap_check` deny into the audit ring (the follow-up that flips these SKIPs to `TEST:PASS:<test>:audit_deny_recorded`, mirroring #311's relationship to #84/#98). Will be filed once an in-tree embedder lands.
- No kernel changes, no new `SOSH_CAP_*` ids, no `OS_ABI_VERSION` bump, soshlib API surface unchanged.