### PR TITLE
sdk(samples): add hello-from-sdk source skeleton (refs #396)

### DIFF
--- a/samples/hello-from-sdk/README.md
+++ b/samples/hello-from-sdk/README.md
@@ -1,0 +1,63 @@
+# `hello-from-sdk` — minimal external-app sample
+
+Status: **source skeleton only** (slice of M6-SDK-003 / issue
+[#396](https://github.com/rwrife/SecureOS/issues/396)). The
+`os-cc` / `os-pack` / `os-run` host wrappers and the
+`sdk_external_build_isolation` acceptance test that copies this
+directory to a scratch dir outside the repo and builds it from there
+are **not yet shipped** — they are gated on the A/B design decision
+called out in the body of #396 and will be added by the wrapper
+slice. Until then this directory is read-only documentation of the
+target shape of an external SDK app.
+
+## What's here
+
+- `main.c` — calls `os_console_write("hello from sdk\n")` and returns 0.
+  Verbatim from plan §"Sample External App: `hello-from-sdk`"
+  ([`plans/2026-05-15-public-sdk-external-app-template.md`](../../plans/2026-05-15-public-sdk-external-app-template.md)).
+- `manifest.json` — manifest_version 0 / os_abi_version 0; declares
+  `CAP_CONSOLE_WRITE` as required and nothing else. Validated against
+  `manifests/schema/v0.json` (see `tools/validate_manifests.py
+  samples/hello-from-sdk/manifest.json`).
+
+## Containment rules this sample obeys
+
+The plan requires the future `sdk_external_build_isolation` test to
+prove that the wrappers do not silently rely on in-tree paths. To make
+that test honest, this sample's source file must already be SDK-only at
+the include level — even though no CI build yet copies it to a scratch
+dir:
+
+- Headers under `kernel/` are forbidden (already CI-enforced for the
+  `sdk/` tree itself by `validate_sdk_no_kernel_includes.sh`).
+- Headers under `user/include/` are forbidden — the SDK is the external
+  ABI surface; `user/include/secureos_api.h` is in-tree-only. The
+  wrapper slice's `sdk_external_build_isolation` test will enforce this
+  by building from a scratch directory with `-I sdk/include` only.
+- Only `os/*` SDK headers (and a forward declaration of
+  `os_console_write` until `sdk/include/os/console.h` lands in the
+  wrapper slice) are referenced.
+
+## When the wrappers land
+
+Once #396 (or its split sub-issues) ships the host wrappers, the
+build-and-run dance from a fresh copy will be:
+
+```bash
+cp -r /path/to/SecureOS/samples/hello-from-sdk /tmp/x
+cd /tmp/x
+os-cc main.c -o hello-from-sdk.elf
+os-pack hello-from-sdk.elf manifest.json -o hello-from-sdk.sof
+os-run hello-from-sdk.sof
+```
+
+…with no `-I` / `-L` reaching back into the source tree.
+
+## Not built by default
+
+This directory is **not** wired into `build/scripts/build.sh`,
+`build/scripts/test.sh`, or `TEST_TARGETS` in
+`build/scripts/validate_bundle.sh`. It is consumed only by the future
+`sdk_external_build_isolation` test driver. Adding the sample to the
+default build today would defeat the "scratch-dir outside the repo"
+isolation guarantee the plan requires.

--- a/samples/hello-from-sdk/main.c
+++ b/samples/hello-from-sdk/main.c
@@ -1,0 +1,63 @@
+/**
+ * @file main.c
+ * @brief Minimal external-app sample for the SecureOS public SDK.
+ *
+ * Purpose:
+ *   Skeleton companion to the M6 SDK scaffold (plan
+ *   `plans/2026-05-15-public-sdk-external-app-template.md`, BUILD_ROADMAP
+ *   §5.6, umbrella issue #396 / slice M6-SDK-003). The plan's
+ *   §"Sample External App: `hello-from-sdk`" calls for a tiny external
+ *   app whose `main.c` "calls console_write("hello from sdk\n") and
+ *   exits 0" and whose `manifest.json` declares only `CAP_CONSOLE_WRITE`.
+ *
+ *   This file lands the source skeleton ahead of the `os-cc` / `os-pack`
+ *   / `os-run` host wrappers, which are gated on the maintainer A/B
+ *   design decision tracked in the body of #396. Until those wrappers
+ *   exist, this sample is NOT built by default CI — the
+ *   `sdk_external_build_isolation` acceptance test (also in #396,
+ *   deferred) is what will eventually copy this directory to a scratch
+ *   dir outside the repo and build it from there using the SDK
+ *   wrappers, with no `-I` / `-L` reaching back into the source tree.
+ *
+ * Containment / SDK contract:
+ *   - Includes ONLY public SDK headers under `sdk/include/os/`. No
+ *     `kernel/` includes, and no in-tree `user/include/` paths — the
+ *     `validate_sdk_no_kernel_includes` CI check is the existing
+ *     enforcement point for the kernel half of that rule; the
+ *     `sdk_external_build_isolation` test (deferred) will enforce the
+ *     in-tree-`user/`-headers half.
+ *   - `os_console_write` is forward-declared here against the public
+ *     `OS_ABI_VERSION` surface (see `os/abi.h`). The eventual
+ *     `sdk/include/os/console.h` header (additive, not yet shipped) will
+ *     replace this local prototype; that header is part of the wrapper
+ *     slice (#396) since it changes the SDK public surface.
+ *
+ * Launched by:
+ *   Out-of-tree only, via the future `os-cc` / `os-pack` / `os-run`
+ *   wrappers. Never compiled by the in-tree build today.
+ */
+
+#include "os/abi.h"
+
+/*
+ * Forward declaration against the OS_ABI_VERSION=0 syscall surface. This
+ * mirrors the in-tree spelling at `user/include/secureos_api.h`:
+ *
+ *   os_status_t os_console_write(const char *message);
+ *
+ * The SDK's public re-export of this prototype lives in a follow-up
+ * header (`sdk/include/os/console.h`) that the wrapper slice (#396)
+ * will add; until then, declaring it locally keeps this sample
+ * self-contained and SDK-only at the include level.
+ *
+ * `os_status_t` is `int`-shaped in the in-tree headers; we mirror that
+ * here so the link-time signature matches once `libos.a` provides the
+ * stub. `0` is the success status.
+ */
+typedef int os_status_t;
+os_status_t os_console_write(const char *message);
+
+int main(void) {
+  (void)os_console_write("hello from sdk\n");
+  return 0;
+}

--- a/samples/hello-from-sdk/manifest.json
+++ b/samples/hello-from-sdk/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "hello-from-sdk",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/hello-from-sdk.bin"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": []
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  }
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -44,7 +44,11 @@ Deferred to the explicit follow-up slices enumerated in the plan:
 - `os-cc` / `os-pack` / `os-run` wrappers (slice `M6-SDK-003`).
 - Manifest schema additions (`abi.version`,
   `capabilities.required/optional`) — slice `M6-SDK-003`.
-- `samples/hello-from-sdk/` external app — slice `M6-SDK-004`.
+- `samples/hello-from-sdk/` external app — skeleton landed via #396
+  partial; it is **not** built by default CI and is consumed only by the
+  future `sdk_external_build_isolation` test driver (gated on the M6-SDK-003
+  wrapper slice). The end-to-end `_qemu` runner peer lives in slice
+  `M6-SDK-004`.
 - A real kernel-side user-exit syscall to back `crt0.c`'s `_os_exit()`
   helper — currently a `hlt`-loop placeholder (slice `M6-SDK-003`).
 


### PR DESCRIPTION
Lands the design-decision-independent half of M6-SDK-003 / #396: the `samples/hello-from-sdk/` source skeleton required verbatim by plan [`plans/2026-05-15-public-sdk-external-app-template.md`](../blob/main/plans/2026-05-15-public-sdk-external-app-template.md) §"Sample External App: `hello-from-sdk`".

## What's in this PR

- `samples/hello-from-sdk/main.c` — calls `os_console_write("hello from sdk\n")` and returns 0. Verbatim from the plan.
- `samples/hello-from-sdk/manifest.json` — `manifest_version: 0` / `os_abi_version: 0`; declares `CAP_CONSOLE_WRITE` as required. Uses only fields that already exist in `manifests/schema/v0.json` (no additive SDK-specific fields — those are deferred along with the wrapper slice's schema decision).
- `samples/hello-from-sdk/README.md` — documents status (skeleton-only), containment rules, and what the wrapper slice (#396) still has to add.
- `sdk/README.md` — clarifies the skeleton is in-tree now; build/CI wiring still belongs to the wrapper slice (was previously documented as deferred wholesale to M6-SDK-004).

## What this PR explicitly does NOT do

- ❌ No `os-cc` / `os-pack` / `os-run` host wrappers — those are gated on the maintainer **A vs B** host-shim-vs-container-internal decision called out in the body of #396 (see the two prior cron triage comments there from 2026-05-28 22:05 UTC and 23:10 UTC, both recommending **A**).
- ❌ No `sdk_external_build_isolation` acceptance test — depends on the wrappers.
- ❌ No additive manifest schema fields (`capabilities.required` / `capabilities.optional` / `owner.kind`) — also deferred to the wrapper slice along with the spelling decision (the plan's "required" vs the existing `capabilities.request` ambiguity).
- ❌ Not wired into `build/scripts/build.sh`, `build/scripts/test.sh`, or `TEST_TARGETS` in `build/scripts/validate_bundle.sh`. Doing so would defeat the plan's "scratch dir outside the repo, no `-I` / `-L` reaching back" isolation guarantee that the future `sdk_external_build_isolation` test exists to enforce.

## Why land just the skeleton standalone

- Every viable split of #396 (per the 2026-05-28 23:10 UTC triage comment) requires this directory to exist before the wrapper PR can be exercised; landing it standalone shrinks the wrapper PR's surface area.
- Schema-pattern-matches the M3/M4/M5 substrate-doc precedents (#285 / #312 / #368): land the additive-only, design-independent piece first, then iterate on the riskier surface.
- Unblocks reviewer attention on the A/B question in #396 without coupling it to file-skeleton review noise.

## Containment posture of `main.c`

- No `kernel/` includes (already CI-enforced for `sdk/` itself by `validate_sdk_no_kernel_includes.sh`; the future `sdk_external_build_isolation` test enforces it for `samples/` too).
- No `user/include/secureos_api.h` — the in-tree spelling is forbidden to external apps. `os_console_write` is forward-declared locally until the wrapper slice adds `sdk/include/os/console.h`.

## Validation performed

```
$ python3 tools/validate_manifests.py samples/hello-from-sdk/manifest.json
MANIFEST_VALIDATE:PASS:samples/hello-from-sdk/manifest.json
MANIFEST_VALIDATE:SUMMARY:pass 1/1

$ python3 tools/validate_manifests.py   # default glob (manifests/examples/*)
MANIFEST_VALIDATE:SUMMARY:pass 9/9      # unchanged — sample sits outside the default glob
```

No `OS_ABI_VERSION` bump. No changes to `kernel/`, `user/`, `build/scripts/`, or `manifests/schema/`.

## Follow-ups (out of scope, tracked by #396)

1. Maintainer ACK on A vs B for the host wrappers.
2. Maintainer call on manifest field spelling (`capabilities.required` vs existing `capabilities.request`).
3. Wrapper slice PR: `sdk/tools/os-cc` + `os-pack` + `os-run` + `sdk_external_build_isolation` + bundle wiring.

Refs #396.