### PR TITLE
fix(win): improve auth dialog button contrast

### DIFF
--- a/user/apps/win/auth_dialog.c
+++ b/user/apps/win/auth_dialog.c
@@ -34,14 +34,22 @@
 #define BTN_ALWAYS_X (DIALOG_X + 70)
 #define BTN_DENY_X   (DIALOG_X + DIALOG_W - BTN_W - 10)
 
-/* Colors */
-#define COLOR_DLG_BG     8   /* dark grey */
-#define COLOR_DLG_BORDER 7   /* light grey */
-#define COLOR_DLG_TEXT   15  /* white */
-#define COLOR_BTN_ALLOW  2   /* green */
-#define COLOR_BTN_ALWAYS 3   /* cyan */
-#define COLOR_BTN_DENY   4   /* red */
-#define COLOR_BTN_TEXT   15  /* white */
+/* Colors.
+ *
+ * Button text/background pairs are chosen for high contrast against the VGA
+ * 16-color palette (see kernel/drivers/video/vga_gfx.c). The Allow/Always
+ * backgrounds are bright (light green/light cyan), so they pair with black
+ * text; the Deny background is a dark, saturated red that pairs with white
+ * text. This avoids the washed-out look of light text on a light fill. */
+#define COLOR_DLG_BG          8   /* dark grey */
+#define COLOR_DLG_BORDER      7   /* light grey */
+#define COLOR_DLG_TEXT        15  /* white */
+#define COLOR_BTN_ALLOW       10  /* light green */
+#define COLOR_BTN_ALLOW_TEXT  0   /* black */
+#define COLOR_BTN_ALWAYS      11  /* light cyan */
+#define COLOR_BTN_ALWAYS_TEXT 0   /* black */
+#define COLOR_BTN_DENY        4   /* red */
+#define COLOR_BTN_DENY_TEXT   15  /* white */
 
 static int g_dialog_active;
 static os_auth_prompt_t g_prompt;
@@ -175,17 +183,17 @@ void auth_dialog_render(unsigned char *backbuffer, int screen_w, int screen_h) {
   dialog_fill_rect(backbuffer, screen_w,
                    BTN_ALLOW_X, BTN_Y, BTN_W, BTN_H, COLOR_BTN_ALLOW);
   font_draw_string(backbuffer, screen_w,
-                   BTN_ALLOW_X + 4, BTN_Y + 3, "Allow", COLOR_BTN_TEXT);
+                   BTN_ALLOW_X + 4, BTN_Y + 3, "Allow", COLOR_BTN_ALLOW_TEXT);
 
   /* Always button */
   dialog_fill_rect(backbuffer, screen_w,
                    BTN_ALWAYS_X, BTN_Y, BTN_W, BTN_H, COLOR_BTN_ALWAYS);
   font_draw_string(backbuffer, screen_w,
-                   BTN_ALWAYS_X + 4, BTN_Y + 3, "Always", COLOR_BTN_TEXT);
+                   BTN_ALWAYS_X + 4, BTN_Y + 3, "Always", COLOR_BTN_ALWAYS_TEXT);
 
   /* Deny button */
   dialog_fill_rect(backbuffer, screen_w,
                    BTN_DENY_X, BTN_Y, BTN_W, BTN_H, COLOR_BTN_DENY);
   font_draw_string(backbuffer, screen_w,
-                   BTN_DENY_X + 8, BTN_Y + 3, "Deny", COLOR_BTN_TEXT);
+                   BTN_DENY_X + 8, BTN_Y + 3, "Deny", COLOR_BTN_DENY_TEXT);
 }


### PR DESCRIPTION
## Summary

The window manager's security/auth prompt (`user/apps/win/auth_dialog.c`) rendered all three buttons with white text (palette index 15) on medium-luminance fills — green (2), cyan (3), red (4). On the brighter Allow/Always fills this produced light text on a light background, which washes out and is hard to read.

## Change

Picked text/background pairs for strong contrast against the VGA 16-color palette (`kernel/drivers/video/vga_gfx.c`):

| Button | Background | Text |
| --- | --- | --- |
| Allow | light green (10) | black (0) |
| Always | light cyan (11) | black (0) |
| Deny | red (4) | white (15) |

Bright Allow/Always fills now pair with black text; the dark, saturated red Deny fill keeps white text. Semantic colors (green = allow, cyan = always, red = deny) are preserved. Introduced per-button `COLOR_BTN_*_TEXT` macros to replace the single `COLOR_BTN_TEXT`.

## Testing

Change is macro-only; no host C cross-compiler is available locally (build is Docker/clang-based), so this was verified by inspection — all `COLOR_BTN_TEXT` references were migrated and the render call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)