### PR TITLE
ci(bundle): wire manifest schema + SDK public-surface targets into TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -112,23 +112,6 @@ TEST_TARGETS=(
     # static check that every `CAP_*` cited in the contract still
     # exists in `docs/abi/capability-registry.json`.
     sosh_contract_registry_drift
-    # Manifest schema v0 validator + additive-enum gates (umbrella
-    # #285 / #312 / #368 / #396, schema at `manifests/schema/v0.json`).
-    # All targets are host-only, green on `main`, and were previously
-    # orphaned from TEST_TARGETS in the same shape #129 / #366 / #384
-    # caught — `manifest_ownership_role_enum` (PR #372, refs #368),
-    # `manifest_owner_kind_enum` (PR #398, refs #396 slice 3a), the
-    # pre-existing `manifest_required_fields` / `manifest_persistence_enum`
-    # / `manifest_broker_role_enum` shape checks, and the
-    # `validate_manifests_abi_major` ABI-major pin (#150) that every
-    # additive-field PR has been re-running by hand. Wire them in so
-    # any regression to the manifest schema flips the bundle to FAIL.
-    manifest_required_fields
-    manifest_persistence_enum
-    manifest_broker_role_enum
-    manifest_ownership_role_enum
-    manifest_owner_kind_enum
-    validate_manifests_abi_major
     # ABI / SDK public-surface gates (umbrella #136 / plan
     # `plans/2026-05-15-public-sdk-external-app-template.md`):
     # `abi_version` pins `OS_ABI_VERSION = 0` (#150 / #228),

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -112,6 +112,41 @@ TEST_TARGETS=(
     # static check that every `CAP_*` cited in the contract still
     # exists in `docs/abi/capability-registry.json`.
     sosh_contract_registry_drift
+    # Manifest schema v0 validator + additive-enum gates (umbrella
+    # #285 / #312 / #368 / #396, schema at `manifests/schema/v0.json`).
+    # All targets are host-only, green on `main`, and were previously
+    # orphaned from TEST_TARGETS in the same shape #129 / #366 / #384
+    # caught — `manifest_ownership_role_enum` (PR #372, refs #368),
+    # `manifest_owner_kind_enum` (PR #398, refs #396 slice 3a), the
+    # pre-existing `manifest_required_fields` / `manifest_persistence_enum`
+    # / `manifest_broker_role_enum` shape checks, and the
+    # `validate_manifests_abi_major` ABI-major pin (#150) that every
+    # additive-field PR has been re-running by hand. Wire them in so
+    # any regression to the manifest schema flips the bundle to FAIL.
+    manifest_required_fields
+    manifest_persistence_enum
+    manifest_broker_role_enum
+    manifest_ownership_role_enum
+    manifest_owner_kind_enum
+    validate_manifests_abi_major
+    # ABI / SDK public-surface gates (umbrella #136 / plan
+    # `plans/2026-05-15-public-sdk-external-app-template.md`):
+    # `abi_version` pins `OS_ABI_VERSION = 0` (#150 / #228),
+    # `sdk_abi_pin` keeps `sdk/VERSION` ↔ `sdk/include/os/abi.h`
+    # consistent, `sdk_libos_link` proves a freestanding link against
+    # `sdk/lib/libos.a`, and `validate_sdk_no_kernel_includes` keeps
+    # the SDK surface free of `kernel/` includes (the containment
+    # guarantee #396 slice 3 wrappers depend on). Same orphan-from-
+    # TEST_TARGETS shape — wire so a regression flips the bundle.
+    abi_version
+    sdk_abi_pin
+    sdk_libos_link
+    validate_sdk_no_kernel_includes
+    # `docs/abi/` Last-verified-stamp freshness guard (PR #298 / #297).
+    # Pure static check that every `Last verified against commit:` line
+    # in `docs/abi/*.md` does not predate the file's last content
+    # commit. Cheap to run, no env deps.
+    abi_stamps_drift
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /


### PR DESCRIPTION
## Motivation

Same orphan-from-`TEST_TARGETS` shape that issues #129 / #366 / #384 caught for prior host-only test targets: these are all green on `main`, gated by `build/scripts/test.sh`, but not gating `build/scripts/validate_bundle.sh` — so a regression would land silently.

Picked up from the hourly issue-work cron queue. Every open execute-shaped ticket on the board (#181, #233, #368, #371, #299, #351) is in done-pending-close state per prior cron triage, and #396 wrapper work is hard-blocked on the A/B host-shim-vs-container-internal maintainer call (per the 2026-05-28 22:05 UTC and 23:10 UTC triage comments). This PR is the cheapest landable hygiene slice that pulls forward CI coverage of work already merged.

## Scope

`build/scripts/validate_bundle.sh` — additive only. Adds the following host-only targets to `TEST_TARGETS` (all already wired into `test.sh` and green on `main` @ a8401a2):

**Manifest schema v0 validator + additive-enum gates** (umbrella #285 / #312 / #368 / #396):
- `manifest_required_fields`
- `manifest_persistence_enum`
- `manifest_broker_role_enum`
- `manifest_ownership_role_enum` — PR #372, refs #368
- `manifest_owner_kind_enum` — PR #398, refs #396 slice 3a
- `validate_manifests_abi_major` — #150

**ABI / SDK public-surface gates** (umbrella #136, plan `plans/2026-05-15-public-sdk-external-app-template.md`):
- `abi_version` — pins `OS_ABI_VERSION = 0` (#150 / #228)
- `sdk_abi_pin` — keeps `sdk/VERSION` ↔ `sdk/include/os/abi.h` consistent
- `sdk_libos_link` — freestanding link vs. `sdk/lib/libos.a`
- `validate_sdk_no_kernel_includes` — the containment guarantee that #396 slice 3 wrappers will depend on

**`docs/abi/` Last-verified stamp freshness guard** (PR #298 / #297):
- `abi_stamps_drift`

## Validation

Each new target verified individually before wiring:

```
manifest_required_fields         -> exit=0  TEST:PASS:manifest_required_fields
manifest_persistence_enum        -> exit=0  TEST:PASS:manifest_persistence_enum
manifest_broker_role_enum        -> exit=0  TEST:PASS:manifest_broker_role_enum
manifest_ownership_role_enum     -> exit=0  TEST:PASS:manifest_ownership_role_enum
manifest_owner_kind_enum         -> exit=0  TEST:PASS:manifest_owner_kind_enum
validate_manifests_abi_major     -> exit=0  TEST:PASS:validate_manifests_abi_major
abi_version                      -> exit=0  TEST:PASS:abi_version:os_abi_version=0x00000000
sdk_abi_pin                      -> exit=0  TEST:PASS:sdk_abi_pin:major=0:minor=0:patch=0
sdk_libos_link                   -> exit=0  TEST:PASS:sdk_libos_link
validate_sdk_no_kernel_includes  -> exit=0  SDK_VALIDATE:PASS:no_kernel_includes
abi_stamps_drift                 -> exit=0  TEST:PASS:abi_stamps_drift_canary
```

## Non-goals / follow-ups

- No code changes outside the bundle target list. No `OS_ABI_VERSION` bump.
- No new test scripts; everything here already existed in `test.sh` and was simply not in the bundle gate.
- Does not touch the #396 A/B design question or unblock the wrapper sub-slice 3b. Strictly orthogonal CI hygiene.
- `scripts/test.ps1` parity (#156) not needed: that script delegates `--all` to `test.sh` inside the toolchain container; it does not duplicate a `TEST_TARGETS` list.

— filed by `cron:secureos-hourly-issue-work` (`e4c62e32`, 2026-05-29 03:24 UTC)