### PR TITLE
fix #414: install python3-jsonschema in toolchain image + wire 6 manifest_* targets into validate_bundle

### DIFF
--- a/build/docker/Dockerfile.toolchain
+++ b/build/docker/Dockerfile.toolchain
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     python3 \
     python3-pip \
+    python3-jsonschema \
     qemu-system-x86 \
     xorriso \
     grub-common \

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -142,6 +142,23 @@ TEST_TARGETS=(
     # `user/libs/clib`) — pure host-side check, no env deps. The matching
     # `os_mem_brk` kernel-side wiring lands as the M7-TOOLCHAIN-001 follow-up.
     clib_malloc
+    # Manifest schema v0 validator + additive-enum gates (umbrella #285 /
+    # #312 / #368 / #396 / #150). These six targets were intentionally
+    # dropped from PR #401 (commit 667e932) because the
+    # secureos/toolchain container did not ship python3-jsonschema, so
+    # every wrapper short-circuited with TEST:FAIL:harness_missing_jsonschema
+    # (rc=78). PR for #414 added python3-jsonschema to
+    # build/docker/Dockerfile.toolchain (kept the container-internal
+    # invariant post-#332) and wires the targets here so a regression to
+    # any manifest enum / required-field / abi-major check flips the
+    # bundle to FAIL — same orphan-from-TEST_TARGETS shape #129 / #366 /
+    # #384 / #401 caught for prior host-only targets.
+    manifest_required_fields
+    manifest_persistence_enum
+    manifest_broker_role_enum
+    manifest_ownership_role_enum
+    manifest_owner_kind_enum
+    validate_manifests_abi_major
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/build/toolchain.lock
+++ b/build/toolchain.lock
@@ -17,6 +17,7 @@
     "ninja",
     "cmake",
     "python3",
+    "python3-jsonschema",
     "qemu-system-x86_64",
     "xorriso",
     "grub-mkrescue",


### PR DESCRIPTION
Closes #414. Follow-up to PR #401.

## Summary

PR #401 deliberately dropped 6 jsonschema-dependent manifest targets in commit 667e932 because they failed inside the `secureos/toolchain` container with `TEST:FAIL:harness_missing_jsonschema` (rc=78). The container shipped `python3` + `python3-pip` but not `python3-jsonschema`, and the runner-side `apt-get install` in `.github/workflows/pr-build.yml` is unreachable from inside the container shell that drives `validate_bundle.sh`.

This PR fixes the root cause and re-wires the targets, exactly as the #401 author follow-up note requested.

## Changes

- `build/docker/Dockerfile.toolchain` — add `python3-jsonschema` to the `apt-get install` list. Keeps the container-internal invariant established by #332's Docker-toolchain consolidation.
- `build/toolchain.lock` — add `python3-jsonschema` to `requiredTools` so the lock file stays an accurate inventory of the image.
- `build/scripts/validate_bundle.sh` — wire the 6 host-only manifest targets back into `TEST_TARGETS` with an explanatory comment block:
  - `manifest_required_fields`
  - `manifest_persistence_enum` (umbrella #285)
  - `manifest_broker_role_enum` (umbrella #312)
  - `manifest_ownership_role_enum` (umbrella #368 / PR #372)
  - `manifest_owner_kind_enum` (umbrella #396 slice 3a / PR #398)
  - `validate_manifests_abi_major` (umbrella #150)

Same orphan-from-`TEST_TARGETS` shape that #129 / #366 / #384 / #401 caught for prior host-only targets — wires the gate so a regression to any manifest enum / required-field / abi-major check flips the bundle to FAIL.

## Validation

Local (host has `python3-jsonschema` 4.10.3):

```
$ for t in manifest_required_fields manifest_persistence_enum manifest_broker_role_enum manifest_ownership_role_enum manifest_owner_kind_enum validate_manifests_abi_major; do build/scripts/test.sh $t 2>&1 | tail -1; done
TEST:PASS:manifest_required_fields
TEST:PASS:manifest_persistence_enum
TEST:PASS:manifest_broker_role_enum
TEST:PASS:manifest_ownership_role_enum
TEST:PASS:manifest_owner_kind_enum
TEST:PASS:validate_manifests_abi_major
```

CI will additionally rebuild the toolchain image and exercise the 6 targets inside it via `validate_bundle.sh`.

## Non-goals / ABI

- No `OS_ABI_VERSION` bump.
- No code-side changes — CI / Dockerfile / lock-file only.
- No new manifest targets; the forthcoming `capabilities.required` / `capabilities.optional` additions from #396 slice 3 main body should land alongside that slice.

## Follow-ups

None planned. Re-enabling the dropped targets was the entire remaining hygiene debt from #401.