### PR TITLE
ci(bundle): install python3-jsonschema in toolchain image + wire 6 manifest_* targets (fix #414)

### DIFF
--- a/build/docker/Dockerfile.toolchain
+++ b/build/docker/Dockerfile.toolchain
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     python3 \
     python3-pip \
+    python3-jsonschema \
     qemu-system-x86 \
     xorriso \
     grub-common \

--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -142,6 +142,23 @@ TEST_TARGETS=(
     # `user/libs/clib`) — pure host-side check, no env deps. The matching
     # `os_mem_brk` kernel-side wiring lands as the M7-TOOLCHAIN-001 follow-up.
     clib_malloc
+    # Manifest schema + ABI gates (follow-up to PR #401, issue #414).
+    # These six targets shell out to `jsonschema` (the canonical JSON
+    # Schema validator) against `docs/manifest/manifest.schema.json` and
+    # were dropped from TEST_TARGETS in PR #401 (commit 667e932) because
+    # `validate_bundle.sh` runs inside the `secureos/toolchain` container
+    # (`build/docker/Dockerfile.toolchain`) which lacked
+    # `python3-jsonschema`. With that package now installed in the
+    # toolchain image, wire them back in so any regression to the
+    # manifest schema, persistence enum (#285), broker-role enum (#312),
+    # ownership-role enum (#368), owner-kind enum (#396 slice 3a), or
+    # `os_abi_major` pin (#150) flips the bundle to FAIL.
+    manifest_required_fields
+    manifest_persistence_enum
+    manifest_broker_role_enum
+    manifest_ownership_role_enum
+    manifest_owner_kind_enum
+    validate_manifests_abi_major
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /

--- a/build/toolchain.lock
+++ b/build/toolchain.lock
@@ -17,6 +17,7 @@
     "ninja",
     "cmake",
     "python3",
+    "python3-jsonschema",
     "qemu-system-x86_64",
     "xorriso",
     "grub-mkrescue",


### PR DESCRIPTION
Follow-up to PR #401 (`ci(bundle): wire manifest schema + SDK public-surface targets into TEST_TARGETS`). Closes #414.

## What

1. **`build/docker/Dockerfile.toolchain`** — install `python3-jsonschema` alongside `python3` / `python3-pip`. Keeps the container-internal invariant from the Docker toolchain consolidation (#332): the bundle harness should be able to find every tool it needs *inside* the `secureos/toolchain` container, not on the GitHub runner host.
2. **`build/toolchain.lock`** — add `python3-jsonschema` to `requiredTools` so the lockfile stays in parity with the Dockerfile. Base digest + `imageTag` unchanged.
3. **`build/scripts/validate_bundle.sh`** — re-wire the 6 manifest schema / ABI targets dropped from `TEST_TARGETS` in PR #401 commit `667e932`:
   - `manifest_required_fields`
   - `manifest_persistence_enum`        (umbrella #285)
   - `manifest_broker_role_enum`        (umbrella #312)
   - `manifest_ownership_role_enum`     (umbrella #368, PR #372)
   - `manifest_owner_kind_enum`         (#396 slice 3a, PR #398)
   - `validate_manifests_abi_major`     (umbrella #150)

   Each shells out to the canonical `jsonschema` validator against `docs/manifest/manifest.schema.json`. They were orphan-from-`TEST_TARGETS` only because the in-container harness couldn't `import jsonschema` (rc=78 / `TEST:FAIL:harness_missing_jsonschema`).

## Why

PR #401's commit message + review comment explicitly filed this as a follow-up:

> Follow-up: add `python3-jsonschema` to `build/docker/Dockerfile.toolchain` (preferred, keeps the container-internal invariant), then wire the 6 manifest targets in a separate PR.

Issue #414 is that follow-up. Without these targets in the bundle, a regression to the manifest schema, persistence enum, broker-role enum, ownership-role enum, owner-kind enum, or the `os_abi_major` pin would not flip `validate_bundle.sh` to FAIL — same orphan shape as #129 / #366.

## Validation performed

- `python3 -c 'import jsonschema'` → 4.10.3 on host.
- `build/scripts/test.sh <target>` green for all 6 targets individually.
- `build/scripts/validate_bundle.sh` runs all 6 to `TEST:PASS`:
  ```
  TEST:PASS:manifest_required_fields
  TEST:PASS:manifest_persistence_enum
  TEST:PASS:manifest_broker_role_enum
  TEST:PASS:manifest_ownership_role_enum
  TEST:PASS:manifest_owner_kind_enum
  TEST:PASS:validate_manifests_abi_major
  ```
  (The QEMU-dependent failures observed locally in this sandbox are pre-existing — no KVM in the agent environment — and unrelated to this change; CI runs them on a real runner host.)

## Scope guard

- **No** code-side ABI changes.
- **No** `OS_ABI_VERSION` bump.
- CI / toolchain-image only.
- Image `imageTag` deliberately **not** bumped — only an additive apt package; if reviewers prefer a date-stamped re-pin (e.g. `bookworm-2026-05-29`) and a fresh base-digest resolve, happy to follow up.

## Out of scope

- Any *new* manifest target from #396 slice 3 main body — those land with their owning slice.
- Switching the harness off `jsonschema`.

## Follow-ups

- If a future bundle run inside a freshly built toolchain image still emits `TEST:FAIL:harness_missing_jsonschema`, that means the CI image cache is stale and needs a manual `docker build -f build/docker/Dockerfile.toolchain ...` re-bake.