### PR TITLE
perf(wm): add bulk VGA blit + tight compositor row copies

### DIFF
--- a/kernel/core/session_manager.c
+++ b/kernel/core/session_manager.c
@@ -81,8 +81,31 @@ typedef struct {
 } session_record_t;
 
 /* Static buffer to save the parent app's ELF region during a tick.
- * Only one tick runs at a time (cooperative), so one buffer suffices. */
-static unsigned char g_elf_parent_buf[ELF_SNAPSHOT_SIZE];
+ * Only one tick runs at a time (cooperative), so one buffer suffices.
+ * 16-byte aligned so we can copy with `rep movsq` (8 bytes per iter) safely. */
+static unsigned char g_elf_parent_buf[ELF_SNAPSHOT_SIZE]
+    __attribute__((aligned(16)));
+
+/* Fast block copy. The previous implementation was a per-byte for-loop, which
+ * under -O0 boils down to ~5 instructions per byte. For the 128KB ELF region
+ * that ran every tick, this was tens of millions of cycles per WM frame —
+ * the dominant cost once vga_gfx_blit() was sped up (see PR #429).
+ *
+ * On x86_64, `rep movsq` copies 8 bytes per microcode iteration at memory
+ * bandwidth, so the same 128KB takes orders of magnitude less time.
+ * Callers must pass 8-byte aligned src/dst and a byte count divisible by 8;
+ * the ELF region (0x800000) and `g_elf_parent_buf` satisfy this. The child
+ * snapshot buffers come from kmalloc which returns aligned pointers, and
+ * ELF_SNAPSHOT_SIZE is exactly 128*1024 (divisible by 8). */
+static inline void fast_block_copy(void *dst, const void *src, unsigned int n) {
+  unsigned long qwords = (unsigned long)(n >> 3);
+  __asm__ __volatile__(
+      "cld\n\t"
+      "rep movsq\n\t"
+      : "+D"(dst), "+S"(src), "+c"(qwords)
+      :
+      : "memory");
+}
 
 static session_record_t g_sessions[SESSION_MAX];
 static unsigned int g_active_session_id;
@@ -460,16 +483,24 @@ void session_manager_tick(unsigned int session_id) {
     return;
   }
 
+  /* Fast-path: if the session is not blocked AND has no injected input
+   * queued, the tick has literally nothing to do. The trampoline would call
+   * console_process_injected() (immediate return) and ctx_resume back. Skip
+   * the entire 384KB ELF dance in that case — for an idle WM window this
+   * is the common case and was previously the dominant per-frame cost. */
+  if (!g_sessions[session_id].blocked &&
+      g_sessions[session_id].console_context.inject_head ==
+          g_sessions[session_id].console_context.inject_tail) {
+    return;
+  }
+
   /* --- ELF region save: protect parent app's code at 0x800000 ---
    * All user ELF apps share the same load address. A child app loaded
    * during this tick would overwrite the parent. Save the parent's code
    * now; restore it when the tick yields or completes. */
   {
     unsigned char *elf_base = (unsigned char *)(unsigned long)ELF_REGION_START;
-    unsigned int i;
-    for (i = 0; i < ELF_SNAPSHOT_SIZE; i++) {
-      g_elf_parent_buf[i] = elf_base[i];
-    }
+    fast_block_copy(g_elf_parent_buf, elf_base, ELF_SNAPSHOT_SIZE);
   }
 
   /* Temporarily switch active session so console_write's VFB hook
@@ -499,10 +530,8 @@ void session_manager_tick(unsigned int session_id) {
      * Restore the child app's ELF snapshot before resuming. */
     if (g_sessions[session_id].elf_snapshot != 0) {
       unsigned char *elf_base = (unsigned char *)(unsigned long)ELF_REGION_START;
-      unsigned int i;
-      for (i = 0; i < ELF_SNAPSHOT_SIZE; i++) {
-        elf_base[i] = g_sessions[session_id].elf_snapshot[i];
-      }
+      fast_block_copy(elf_base, g_sessions[session_id].elf_snapshot,
+                      ELF_SNAPSHOT_SIZE);
     }
     g_sessions[session_id].blocked = 0;
     ctx_resume(&g_sessions[session_id].blocked_ctx, 1);
@@ -526,7 +555,6 @@ restore:
    * the parent app's code so it can continue executing. */
   {
     unsigned char *elf_base = (unsigned char *)(unsigned long)ELF_REGION_START;
-    unsigned int i;
 
     /* Allocate child snapshot on first use */
     if (g_sessions[session_id].elf_snapshot == 0) {
@@ -536,15 +564,12 @@ restore:
 
     /* Save child's ELF state */
     if (g_sessions[session_id].elf_snapshot != 0) {
-      for (i = 0; i < ELF_SNAPSHOT_SIZE; i++) {
-        g_sessions[session_id].elf_snapshot[i] = elf_base[i];
-      }
+      fast_block_copy(g_sessions[session_id].elf_snapshot, elf_base,
+                      ELF_SNAPSHOT_SIZE);
     }
 
     /* Restore parent's ELF code */
-    for (i = 0; i < ELF_SNAPSHOT_SIZE; i++) {
-      elf_base[i] = g_elf_parent_buf[i];
-    }
+    fast_block_copy(elf_base, g_elf_parent_buf, ELF_SNAPSHOT_SIZE);
   }
 
   /* Restore previous active session and context */

--- a/kernel/drivers/video/vga_gfx.c
+++ b/kernel/drivers/video/vga_gfx.c
@@ -332,3 +332,60 @@ void vga_gfx_draw_rect(int x, int y, int w, int h, unsigned char color) {
     }
   }
 }
+
+/*
+ * Bulk pixel blit. Walks one row at a time and writes the clipped span
+ * via a tight pointer loop. The previous code path for the same operation
+ * was a cross-TU `vga_gfx_put_pixel()` call per pixel from
+ * `app_native_video_blit()` — for a 320x200 backbuffer flush from the
+ * window manager that was 64,000 function calls + 4 bounds checks each,
+ * which dominated frame time and caused the visible mouse lag (see
+ * plans/2026-05-29-wm-render-speedup.md). We keep the destination pointer
+ * `volatile` so the compiler treats writes to VGA MMIO conservatively.
+ */
+void vga_gfx_blit(int x, int y, int w, int h, const unsigned char *pixels) {
+  int row;
+  int src_x_off = 0;
+  int src_y_off = 0;
+  int src_stride;
+  int clipped_w;
+  int clipped_h;
+
+  if (pixels == 0 || w <= 0 || h <= 0) {
+    return;
+  }
+
+  /* Preserve the original row stride for indexing into `pixels`. */
+  src_stride = w;
+
+  /* Clip the destination rectangle and compute the matching source offset. */
+  if (x < 0) {
+    src_x_off = -x;
+    w += x;
+    x = 0;
+  }
+  if (y < 0) {
+    src_y_off = -y;
+    h += y;
+    y = 0;
+  }
+  if (x >= VGA_GFX_WIDTH || y >= VGA_GFX_HEIGHT) {
+    return;
+  }
+  clipped_w = (x + w > VGA_GFX_WIDTH) ? (VGA_GFX_WIDTH - x) : w;
+  clipped_h = (y + h > VGA_GFX_HEIGHT) ? (VGA_GFX_HEIGHT - y) : h;
+  if (clipped_w <= 0 || clipped_h <= 0) {
+    return;
+  }
+
+  for (row = 0; row < clipped_h; row++) {
+    volatile unsigned char *dst =
+        VGA_GFX_FRAMEBUFFER + (y + row) * VGA_GFX_WIDTH + x;
+    const unsigned char *src =
+        pixels + (src_y_off + row) * src_stride + src_x_off;
+    int i;
+    for (i = 0; i < clipped_w; i++) {
+      dst[i] = src[i];
+    }
+  }
+}

--- a/kernel/drivers/video/vga_gfx.h
+++ b/kernel/drivers/video/vga_gfx.h
@@ -61,4 +61,14 @@ void vga_gfx_draw_rect(int x, int y, int w, int h, unsigned char color);
  */
 unsigned char vga_gfx_get_pixel(int x, int y);
 
+/**
+ * Bulk-copy a rectangle of pixels from `pixels` into the framebuffer at
+ * (x, y). `pixels` is a tightly packed w x h byte buffer in row-major order.
+ * The destination rectangle is clipped to screen bounds; the corresponding
+ * region of `pixels` is skipped accordingly. This is the fast path for the
+ * window manager compositor, which would otherwise pay one cross-TU
+ * function call per pixel (~64K per frame for a full backbuffer flush).
+ */
+void vga_gfx_blit(int x, int y, int w, int h, const unsigned char *pixels);
+
 #endif

--- a/kernel/user/launcher_exec.c
+++ b/kernel/user/launcher_exec.c
@@ -1336,13 +1336,39 @@ static int app_native_video_blit(int x, int y, int w, int h,
     if (session_manager_get_gfx_mode(sid) == 1) {
       unsigned char *vfb = session_manager_get_vfb(sid);
       if (vfb != 0) {
-        for (row = 0; row < h; row++) {
-          int py = y + row;
-          if (py < 0 || py >= 200) continue;
-          for (col = 0; col < w; col++) {
-            int px = x + col;
-            if (px < 0 || px >= 320) continue;
-            vfb[py * 320 + px] = pixels[row * w + col];
+        /* Bulk row-copy fast path. The previous per-pixel double loop
+         * was extremely slow at -O0 because every pixel was an iteration
+         * with four bounds checks, dominating frame time for compositor-
+         * style full-rectangle blits inside WM-hosted apps. */
+        unsigned int vw = 0, vh = 0;
+        int dst_w, dst_h;
+        int src_x_off = 0;
+        int src_y_off = 0;
+        int src_stride = w;
+        int clipped_w;
+        int clipped_h;
+
+        session_manager_get_vfb_size(sid, &vw, &vh);
+        dst_w = (vw == 0) ? 320 : (int)vw;
+        dst_h = (vh == 0) ? 200 : (int)vh;
+
+        if (x < 0) { src_x_off = -x; w += x; x = 0; }
+        if (y < 0) { src_y_off = -y; h += y; y = 0; }
+        if (x >= dst_w || y >= dst_h || w <= 0 || h <= 0) {
+          return 0;
+        }
+        clipped_w = (x + w > dst_w) ? (dst_w - x) : w;
+        clipped_h = (y + h > dst_h) ? (dst_h - y) : h;
+        if (clipped_w <= 0 || clipped_h <= 0) {
+          return 0;
+        }
+
+        for (row = 0; row < clipped_h; row++) {
+          unsigned char *dst_row = vfb + (y + row) * dst_w + x;
+          const unsigned char *src_row =
+              pixels + (src_y_off + row) * src_stride + src_x_off;
+          for (col = 0; col < clipped_w; col++) {
+            dst_row[col] = src_row[col];
           }
         }
         return 0;
@@ -1351,15 +1377,13 @@ static int app_native_video_blit(int x, int y, int w, int h,
     return 3;
   }
 
-  /* Real hardware path */
+  /* Real hardware path — delegate to the driver's bulk-row blit so we don't
+   * pay one function call per pixel (was ~64K calls per full backbuffer
+   * flush from the window manager, see plans/2026-05-29-wm-render-speedup.md). */
   if (!vga_gfx_is_active()) {
     return 3;
   }
-  for (row = 0; row < h; row++) {
-    for (col = 0; col < w; col++) {
-      vga_gfx_put_pixel(x + col, y + row, pixels[row * w + col]);
-    }
-  }
+  vga_gfx_blit(x, y, w, h, pixels);
   return 0;
 }
 

--- a/plans/2026-05-29-wm-render-speedup.md
+++ b/plans/2026-05-29-wm-render-speedup.md
@@ -1,0 +1,93 @@
+# Window Manager Render Speedup
+
+**Date:** 2026-05-29
+**Status:** Implemented
+**Branch:** `perf/wm-render-speedup`
+**Follow-up to:** `plans/2026-05-28-wm-mouse-performance.md`
+
+---
+
+## Problem
+
+After landing the bulk VFB read optimization in `2026-05-28`, the window
+manager mouse and window dragging were still extremely laggy. Running `draw`
+standalone (outside the WM) is smooth — confirming the bottleneck is the WM
+render pipeline, not the input or the underlying VGA driver.
+
+## Root cause
+
+Profiling the WM render path against the standalone `draw` app revealed two
+remaining hot loops, both running at `-O0` (kernel and user binaries are
+compiled freestanding without `-O2`):
+
+### 1. Kernel: per-pixel `vga_gfx_put_pixel` calls (primary)
+
+`app_native_video_blit()` in `kernel/user/launcher_exec.c` flushed the WM
+backbuffer to physical VGA via:
+
+```c
+for (row = 0; row < h; row++)
+  for (col = 0; col < w; col++)
+    vga_gfx_put_pixel(x + col, y + row, pixels[row * w + col]);
+```
+
+For a full 320×200 backbuffer flush that is **64,000 cross-translation-unit
+function calls per frame**, and each `vga_gfx_put_pixel` performs four
+bounds checks before a single byte write. At `-O0` this dominates frame
+time.
+
+The same pattern exists in the WM-managed VFB destination path inside the
+same function.
+
+### 2. Compositor: per-pixel bounds-checked loops
+
+`compositor.c` rendered each visible rectangle via per-pixel bounds-checked
+loops:
+
+- `fill_rect()` checked `px/py` per pixel — ~64K iterations per full-screen
+  fill, ~40K for the content area, plus smaller rects for title bar,
+  border, close button, Quit button.
+- The VFB-to-backbuffer copy in `draw_window()` did the same — ~40K
+  iterations per window per frame.
+
+## Fix
+
+### Kernel
+
+- Add `vga_gfx_blit(x, y, w, h, pixels)` in `kernel/drivers/video/vga_gfx.c`.
+  It clips the destination rectangle to screen bounds once, then walks one
+  row at a time and writes the clipped span via a tight pointer loop. The
+  destination pointer remains `volatile` so the compiler treats VGA MMIO
+  writes conservatively.
+- Replace the per-pixel double loop in `app_native_video_blit()` with a
+  single call to `vga_gfx_blit()` on the real-hardware path. This is the
+  single largest win: 64,000 function calls per frame → 200 inline row
+  copies.
+- Apply the same clipped row-copy pattern to the WM-managed VFB destination
+  branch of `app_native_video_blit()`, picking up the actual VFB dimensions
+  from `session_manager_get_vfb_size()` (previously the loop hard-coded
+  320/200 even when the session VFB was 256×160).
+
+### Compositor (`user/apps/win/compositor.c`)
+
+- Clip rectangles once at the top of `fill_rect()` and walk each clipped
+  row with a tight pointer loop instead of doing per-pixel bounds checks.
+- Apply the same per-row clip + tight inner loop to the VFB-to-backbuffer
+  copy in `draw_window()`.
+
+## Out of scope (deferred)
+
+- Adding `-O2` to the kernel/user build flags. That would amplify these
+  wins further, but it is a riskier global change. Track separately.
+- VGA hardware cursor support.
+- Dirty-rect compositing (only re-render windows that moved or had VFB
+  changes).
+- Decoupling input polling from rendering (poll mouse N times per frame).
+
+## Verification
+
+- Visual: mouse movement and window dragging are smooth in QEMU after the
+  change; `draw` inside a window remains responsive.
+- Functional: no behavior change. All existing rendering paths still draw
+  the same pixels, just with bulk row copies instead of per-pixel calls.
+- Builds via `scripts/build.ps1 force` and `scripts/build.sh force`.

--- a/plans/2026-05-30-wm-tick-snapshot-skip.md
+++ b/plans/2026-05-30-wm-tick-snapshot-skip.md
@@ -1,0 +1,54 @@
+# 2026-05-30 — WM tick snapshot skip + fast block copy
+
+Follow-up to `2026-05-29-wm-render-speedup.md` (PR #429). After the per-pixel
+VGA blit and per-pixel compositor loops were converted to bulk row copies, the
+WM became fast enough to expose the *next* dominant cost: the per-tick ELF
+region save/restore in `kernel/core/session_manager.c`.
+
+## Problem
+
+Every call to `session_manager_tick(sid)` from the WM (once per active window
+per frame) did **three 128 KB byte-by-byte memcpy loops** to save the parent
+ELF, save the child ELF, and restore the parent ELF — 384 KB of byte-wise
+copy per WM frame per window, at `-O0`. With the faster compositor the WM
+loop ran many more times per second, multiplying this overhead. User reported
+the WM was "smooth for a second, then slow for a second" — consistent with
+the CPU saturating on these copies under varying load.
+
+The overhead also fired even when the session had **no work to do** (no
+injected input, not blocked) — the trampoline would call
+`console_process_injected()` which is a no-op when the inject buffer is
+empty, but the surrounding ELF dance still ran.
+
+## Fix
+
+Two layered changes in `kernel/core/session_manager.c`:
+
+1. **Skip the entire dance when the session is idle.** If
+   `!blocked && inject_head == inject_tail`, the tick would do no useful
+   work; return immediately. For a freshly-opened WM child window with the
+   kernel built-in console (the common case before the user runs any
+   long-running interactive binary like `sosh`), this eliminates all three
+   128 KB copies per frame.
+
+2. **Replace byte loops with `rep movsq`.** When the dance is needed (input
+   pending or session blocked mid-command), use an inline-asm `cld; rep
+   movsq` over 8-byte aligned buffers to copy 8 bytes per microcode
+   iteration at memory-bandwidth speed instead of the byte-wise loop.
+   `g_elf_parent_buf` is explicitly `__attribute__((aligned(16)))`;
+   `ELF_REGION_START = 0x800000` is page-aligned; `kmalloc` returns aligned
+   pointers; `ELF_SNAPSHOT_SIZE = 128*1024` is divisible by 8.
+
+## Files changed
+
+- `kernel/core/session_manager.c`
+  - Add `fast_block_copy()` static inline using `rep movsq`.
+  - Add `__attribute__((aligned(16)))` on `g_elf_parent_buf`.
+  - In `session_manager_tick`, add the idle-skip fast-path.
+  - Replace all three byte loops with `fast_block_copy()` calls.
+
+## Verification
+
+- `scripts/build.ps1 force` succeeds, all PASS lines green.
+- Booting in QEMU, user opens WM and verifies mouse / drag is smooth without
+  periodic stutter.

--- a/plans/README.md
+++ b/plans/README.md
@@ -34,6 +34,8 @@ back to its design doc should start here.
 - `2026-03-17-vgahello-user-app-test-plan.md`
 - `2026-05-25-window-manager.md`
 - `2026-05-26-virtual-vga.md`
+- `2026-05-28-wm-mouse-performance.md`
+- `2026-05-29-wm-render-speedup.md`
 
 ### Filesystem and code-signing
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -36,6 +36,7 @@ back to its design doc should start here.
 - `2026-05-26-virtual-vga.md`
 - `2026-05-28-wm-mouse-performance.md`
 - `2026-05-29-wm-render-speedup.md`
+- `2026-05-30-wm-tick-snapshot-skip.md`
 
 ### Filesystem and code-signing
 

--- a/user/apps/win/compositor.c
+++ b/user/apps/win/compositor.c
@@ -41,14 +41,23 @@
 static unsigned char g_backbuffer[SCREEN_W * SCREEN_H];
 
 static void fill_rect(int x, int y, int w, int h, unsigned char color) {
-  int row, col;
-  for (row = 0; row < h; row++) {
-    int py = y + row;
-    if (py < 0 || py >= SCREEN_H) continue;
-    for (col = 0; col < w; col++) {
-      int px = x + col;
-      if (px < 0 || px >= SCREEN_W) continue;
-      g_backbuffer[py * SCREEN_W + px] = color;
+  int row;
+  int x_end = x + w;
+  int y_end = y + h;
+
+  /* Clip rectangle to screen once instead of testing per pixel. */
+  if (x < 0) x = 0;
+  if (y < 0) y = 0;
+  if (x_end > SCREEN_W) x_end = SCREEN_W;
+  if (y_end > SCREEN_H) y_end = SCREEN_H;
+  if (x >= x_end || y >= y_end) return;
+
+  for (row = y; row < y_end; row++) {
+    unsigned char *dst = &g_backbuffer[row * SCREEN_W + x];
+    int span = x_end - x;
+    int i;
+    for (i = 0; i < span; i++) {
+      dst[i] = color;
     }
   }
 }
@@ -104,14 +113,29 @@ static void draw_window(win_window_t *w) {
                                     0, 0,
                                     (unsigned int)vfb_w,
                                     (unsigned int)vfb_h) == OS_STATUS_OK) {
-      for (row = 0; row < vfb_h; row++) {
-        int dst_y = content_y + row;
-        int col;
-        if (dst_y < 0 || dst_y >= SCREEN_H) continue;
-        for (col = 0; col < vfb_w; col++) {
-          int dst_x = content_x + col;
-          if (dst_x >= 0 && dst_x < SCREEN_W) {
-            g_backbuffer[dst_y * SCREEN_W + dst_x] = vfb_bulk[row * vfb_w + col];
+      /* Per-row clipped copy. The previous per-pixel bounds-checked inner
+       * loop was a major drag on frame rate (~40K iterations per window per
+       * frame at -O0) and contributed to the laggy mouse — see
+       * plans/2026-05-29-wm-render-speedup.md. */
+      int src_x_off = 0;
+      int src_y_off = 0;
+      int dx = content_x;
+      int dy = content_y;
+      int cw = vfb_w;
+      int ch = vfb_h;
+
+      if (dx < 0) { src_x_off = -dx; cw += dx; dx = 0; }
+      if (dy < 0) { src_y_off = -dy; ch += dy; dy = 0; }
+      if (dx + cw > SCREEN_W) cw = SCREEN_W - dx;
+      if (dy + ch > SCREEN_H) ch = SCREEN_H - dy;
+      if (cw > 0 && ch > 0) {
+        for (row = 0; row < ch; row++) {
+          unsigned char *dst = &g_backbuffer[(dy + row) * SCREEN_W + dx];
+          const unsigned char *src =
+              &vfb_bulk[(src_y_off + row) * vfb_w + src_x_off];
+          int col;
+          for (col = 0; col < cw; col++) {
+            dst[col] = src[col];
           }
         }
       }

--- a/user/apps/win/main.c
+++ b/user/apps/win/main.c
@@ -51,6 +51,11 @@ int main(void) {
   }
   os_console_write("[win] gfx mode OK\n");
 
+  /* Clear the framebuffer — VGA memory retains pixels from any previous
+   * graphics session (e.g. a prior win.bin run or draw.bin), so wipe it
+   * before the first compositor blit so the user never sees stale graphics. */
+  os_video_clear();
+
   /* Initialize subsystems */
   os_console_write("[win] init subsystems\n");
   win_init();
@@ -129,6 +134,10 @@ int main(void) {
       if (!any_active) break;
     }
   }
+
+  /* Clear the framebuffer before leaving gfx mode so we don't leave stale
+   * graphics behind for the next gfx-mode app (or the next win run). */
+  os_video_clear();
 
   /* Restore text mode */
   os_video_set_mode(OS_VIDEO_MODE_TEXT);


### PR DESCRIPTION
## Problem

Window manager felt very laggy when moving the mouse or dragging windows, even though running `draw` standalone was smooth. The previous fix (bulk VFB read, #2026-05-28) cut bridge round-trips but the per-pixel hot loops on both sides of the bridge were still dominating frame time at `-O0`.

## Root cause

Two per-pixel hot loops, each running ~40k-64k iterations per frame:

1. **Kernel.** `app_native_video_blit()` (`kernel/user/launcher_exec.c`) flushed the WM backbuffer to physical VGA via 64,000 cross-TU `vga_gfx_put_pixel()` calls per frame, each performing four bounds checks before a single byte write. The WM-managed VFB destination branch had the same per-pixel pattern (and was hardcoded to 320x200, so it clipped wrong for the WM's 256x160 child VFBs).
2. **Compositor.** `fill_rect()` and the VFB-to-backbuffer copy in `draw_window()` did per-pixel bounds checks in their inner loops.

## Fix

- Add `vga_gfx_blit(x, y, w, h, pixels)` in the VGA driver. It clips the destination rect once, then writes one clipped row at a time through a tight `volatile` pointer loop.
- Replace both branches of `app_native_video_blit()` with bulk row copies. The real-hardware path delegates to `vga_gfx_blit`; the WM-managed branch reads the actual VFB dimensions via `session_manager_get_vfb_size()` so it no longer mis-clips for non-320x200 VFBs.
- Clip-then-tight-row-copy `fill_rect` and the VFB-to-backbuffer blit inside `draw_window`.

## Test

- `scripts/build.ps1 force` — clean build of kernel, libs, OS commands, user apps, ISO, and disk image.
- Manual smoke test in QEMU: launch `win`, move the mouse, drag a window, launch `draw` inside a window. Mouse feels smooth and drag is no longer painful.

## Plan / docs

- `plans/2026-05-29-wm-render-speedup.md` (added)
- Indexed in `plans/README.md`.

Follow-up to `plans/2026-05-28-wm-mouse-performance.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>