### PR TITLE
docs(abi): bump syscalls.md Last verified stamp to 6f842a0

### DIFF
--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -141,5 +141,5 @@ unused"). The reservation is purely an ABI-shape anchor.
 4. Add an allow-path and a deny-path test under `build/scripts/test_*.sh`.
 5. Update this table and bump the verification line below.
 
-Last verified against commit: dddd86bbec8080e8f6de6d27ef5d8e1738d91273
+Last verified against commit: 6f842a0c1fff901b5542f02894dc284eed1440aa
 


### PR DESCRIPTION
PR #427 (`feat(#422): wire os_process_spawn end-to-end`) updated the body of `docs/abi/syscalls.md` but did not bump the trailing `Last verified against commit:` line, so `validate_abi_stamps` is red on `main`:

```
ABI_STAMP:FAIL:docs/abi/syscalls.md:stamp=dddd86bbec:last_content=6f842a0c1f
VALIDATION_FAIL:validate_abi_stamps
```

This blocks `build-and-validate` on `main` and cascades onto every open PR (#428 / #432 / the rest of the M7-TOOLCHAIN-004 slice 4..10 stack).

Bump the stamp to `6f842a0c1fff901b5542f02894dc284eed1440aa` (the actual merge commit of #427 on main) — pure stamp-only change, no substantive ABI delta. Mirrors the precedent of PRs #258 and #420.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
...
ABI_STAMP:PASS:docs/abi/syscalls.md:6f842a0c1f
```

Refs #297.