### PR TITLE
feat(#407): freestanding strspn/strcspn/strpbrk/strtok family (M7-TOOLCHAIN-004 slice 12)

### DIFF
--- a/build/scripts/test_clib_string.sh
+++ b/build/scripts/test_clib_string.sh
@@ -12,6 +12,8 @@
 #   - strcpy / strncpy (historical zero-pad + truncation)
 #   - strcat / strncat
 #   - strchr / strrchr / strstr (incl. empty-needle + OOB-safety)
+#   - strspn / strcspn / strpbrk (slice 12)
+#   - strtok / strtok_r (slice 12, single-state + reentrant)
 #   - symbol_set_pinned drift test
 #
 # Outputs deterministic TEST:PASS markers consumed by
@@ -50,6 +52,11 @@ grep -q "TEST:PASS:clib_string:strcpy_and_strncpy_pad"    "$LOG_PATH"
 grep -q "TEST:PASS:clib_string:strcat_and_strncat"        "$LOG_PATH"
 grep -q "TEST:PASS:clib_string:strchr_and_strrchr"        "$LOG_PATH"
 grep -q "TEST:PASS:clib_string:strstr_hit_and_miss"       "$LOG_PATH"
+grep -q "TEST:PASS:clib_string:strspn_basic"              "$LOG_PATH"
+grep -q "TEST:PASS:clib_string:strcspn_basic"             "$LOG_PATH"
+grep -q "TEST:PASS:clib_string:strpbrk_hit_and_miss"      "$LOG_PATH"
+grep -q "TEST:PASS:clib_string:strtok_walks_tokens"       "$LOG_PATH"
+grep -q "TEST:PASS:clib_string:strtok_r_reentrant_independence" "$LOG_PATH"
 grep -q "TEST:PASS:clib_string:symbol_set_pinned"         "$LOG_PATH"
 grep -q "TEST:PASS:clib_string$"                          "$LOG_PATH"
 ! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/tests/clib_string_test.c
+++ b/tests/clib_string_test.c
@@ -17,6 +17,11 @@
  *   TEST:PASS:clib_string:strcat_and_strncat
  *   TEST:PASS:clib_string:strchr_and_strrchr
  *   TEST:PASS:clib_string:strstr_hit_and_miss
+ *   TEST:PASS:clib_string:strspn_basic
+ *   TEST:PASS:clib_string:strcspn_basic
+ *   TEST:PASS:clib_string:strpbrk_hit_and_miss
+ *   TEST:PASS:clib_string:strtok_walks_tokens
+ *   TEST:PASS:clib_string:strtok_r_reentrant_independence
  *   TEST:PASS:clib_string:symbol_set_pinned
  *   TEST:PASS:clib_string
  *
@@ -200,6 +205,119 @@ static void test_strstr_hit_and_miss(void) {
   PASS("strstr_hit_and_miss");
 }
 
+/* --- tokenize / span family (slice 12) -------------------------------- */
+
+static void test_strspn_basic(void) {
+  /* Leading run of accept-class bytes. */
+  CHECK(strspn("aabbcXY", "abc") == 5, "strspn_basic");
+  /* Empty accept set -> 0. */
+  CHECK(strspn("abc", "") == 0, "strspn_basic");
+  /* All-accept -> full length. */
+  CHECK(strspn("abc", "cba") == 3, "strspn_basic");
+  /* First byte not in set -> 0. */
+  CHECK(strspn("xabc", "abc") == 0, "strspn_basic");
+  /* Empty input -> 0. */
+  CHECK(strspn("", "abc") == 0, "strspn_basic");
+  /* High-bit byte treated as unsigned (matches strcmp posture). */
+  const char hi[2] = { (char)0x80, 0 };
+  const char set[2] = { (char)0x80, 0 };
+  CHECK(strspn(hi, set) == 1, "strspn_basic");
+  PASS("strspn_basic");
+}
+
+static void test_strcspn_basic(void) {
+  /* Leading run of bytes NOT in reject set. */
+  CHECK(strcspn("hello/world", "/") == 5, "strcspn_basic");
+  /* No hit -> full length. */
+  CHECK(strcspn("hello", "XYZ") == 5, "strcspn_basic");
+  /* First byte in reject -> 0. */
+  CHECK(strcspn("/abc", "/") == 0, "strcspn_basic");
+  /* Empty input -> 0. */
+  CHECK(strcspn("", "/") == 0, "strcspn_basic");
+  /* Empty reject -> full length. */
+  CHECK(strcspn("abc", "") == 3, "strcspn_basic");
+  PASS("strcspn_basic");
+}
+
+static void test_strpbrk_hit_and_miss(void) {
+  const char *s = "hello world";
+  /* First match is the space at index 5. */
+  CHECK(strpbrk(s, " \t") == s + 5, "strpbrk_hit_and_miss");
+  /* Multi-char accept set: first 'o' at index 4. */
+  CHECK(strpbrk(s, "o") == s + 4, "strpbrk_hit_and_miss");
+  /* No match -> NULL. */
+  CHECK(strpbrk("abc", "XYZ") == NULL, "strpbrk_hit_and_miss");
+  /* Empty input -> NULL. */
+  CHECK(strpbrk("", "abc") == NULL, "strpbrk_hit_and_miss");
+  /* Empty accept set -> NULL. */
+  CHECK(strpbrk("abc", "") == NULL, "strpbrk_hit_and_miss");
+  PASS("strpbrk_hit_and_miss");
+}
+
+static void test_strtok_walks_tokens(void) {
+  /* Classic strtok walk: split a path-ish string on '/'. The first
+   * call seeds with the buffer; subsequent calls pass NULL to resume
+   * from the saved state. */
+  char buf[] = "//usr//bin/cc//";
+  char *t1 = strtok(buf, "/");
+  CHECK(t1 != NULL && strcmp(t1, "usr") == 0, "strtok_walks_tokens");
+  char *t2 = strtok(NULL, "/");
+  CHECK(t2 != NULL && strcmp(t2, "bin") == 0, "strtok_walks_tokens");
+  char *t3 = strtok(NULL, "/");
+  CHECK(t3 != NULL && strcmp(t3, "cc") == 0, "strtok_walks_tokens");
+  /* Trailing delimiters -> no more tokens -> NULL. */
+  CHECK(strtok(NULL, "/") == NULL, "strtok_walks_tokens");
+  /* All-delim input -> immediately NULL. */
+  char only_delims[] = "////";
+  CHECK(strtok(only_delims, "/") == NULL, "strtok_walks_tokens");
+  /* Empty input -> NULL. */
+  char empty[] = "";
+  CHECK(strtok(empty, "/") == NULL, "strtok_walks_tokens");
+  PASS("strtok_walks_tokens");
+}
+
+static void test_strtok_r_reentrant_independence(void) {
+  /* Two interleaved walks must not share state. */
+  char a[] = "one,two,three";
+  char b[] = "alpha;beta;gamma";
+  char *sa = NULL;
+  char *sb = NULL;
+
+  char *ta1 = strtok_r(a, ",", &sa);
+  char *tb1 = strtok_r(b, ";", &sb);
+  char *ta2 = strtok_r(NULL, ",", &sa);
+  char *tb2 = strtok_r(NULL, ";", &sb);
+  char *ta3 = strtok_r(NULL, ",", &sa);
+  char *tb3 = strtok_r(NULL, ";", &sb);
+
+  CHECK(ta1 && strcmp(ta1, "one")    == 0, "strtok_r_reentrant_independence");
+  CHECK(ta2 && strcmp(ta2, "two")    == 0, "strtok_r_reentrant_independence");
+  CHECK(ta3 && strcmp(ta3, "three")  == 0, "strtok_r_reentrant_independence");
+  CHECK(tb1 && strcmp(tb1, "alpha")  == 0, "strtok_r_reentrant_independence");
+  CHECK(tb2 && strcmp(tb2, "beta")   == 0, "strtok_r_reentrant_independence");
+  CHECK(tb3 && strcmp(tb3, "gamma")  == 0, "strtok_r_reentrant_independence");
+
+  CHECK(strtok_r(NULL, ",", &sa) == NULL, "strtok_r_reentrant_independence");
+  CHECK(strtok_r(NULL, ";", &sb) == NULL, "strtok_r_reentrant_independence");
+
+  /* Multi-character delimiter set: split on whitespace OR comma. */
+  char mixed[] = " \tfoo, bar\tbaz ";
+  char *sm = NULL;
+  char *m1 = strtok_r(mixed, " \t,", &sm);
+  char *m2 = strtok_r(NULL,  " \t,", &sm);
+  char *m3 = strtok_r(NULL,  " \t,", &sm);
+  CHECK(m1 && strcmp(m1, "foo") == 0, "strtok_r_reentrant_independence");
+  CHECK(m2 && strcmp(m2, "bar") == 0, "strtok_r_reentrant_independence");
+  CHECK(m3 && strcmp(m3, "baz") == 0, "strtok_r_reentrant_independence");
+  CHECK(strtok_r(NULL, " \t,", &sm) == NULL,
+        "strtok_r_reentrant_independence");
+
+  /* Defensive: NULL saveptr -> NULL without crash. */
+  CHECK(strtok_r(NULL, ",", NULL) == NULL, "strtok_r_reentrant_independence");
+
+  PASS("strtok_r_reentrant_independence");
+}
+
 /* --- ABI pin ----------------------------------------------------------- */
 /*
  * Drift test: pin the exact slice-1 symbol set so a TinyCC drop or an
@@ -225,10 +343,15 @@ static void test_symbol_set_pinned(void) {
   char *(*p_strchr) (const char *, int)                   = strchr;
   char *(*p_strrchr)(const char *, int)                   = strrchr;
   char *(*p_strstr) (const char *, const char *)          = strstr;
+  size_t(*p_strspn) (const char *, const char *)          = strspn;
+  size_t(*p_strcspn)(const char *, const char *)          = strcspn;
+  char *(*p_strpbrk)(const char *, const char *)          = strpbrk;
+  char *(*p_strtok) (char *, const char *)                = strtok;
+  char *(*p_strtok_r)(char *, const char *, char **)      = strtok_r;
 
   /* Touch every pointer so -Wunused-variable does not strip them and
    * so the symbol-set pin is observable at runtime. */
-  void *sink[16];
+  void *sink[21];
   sink[0]  = (void *)p_memcpy;
   sink[1]  = (void *)p_memmove;
   sink[2]  = (void *)p_memset;
@@ -245,8 +368,13 @@ static void test_symbol_set_pinned(void) {
   sink[13] = (void *)p_strchr;
   sink[14] = (void *)p_strrchr;
   sink[15] = (void *)p_strstr;
+  sink[16] = (void *)p_strspn;
+  sink[17] = (void *)p_strcspn;
+  sink[18] = (void *)p_strpbrk;
+  sink[19] = (void *)p_strtok;
+  sink[20] = (void *)p_strtok_r;
 
-  for (int i = 0; i < 16; i++) {
+  for (int i = 0; i < 21; i++) {
     CHECK(sink[i] != NULL, "symbol_set_pinned");
   }
   PASS("symbol_set_pinned");
@@ -266,6 +394,11 @@ int main(void) {
   test_strcat_and_strncat();
   test_strchr_and_strrchr();
   test_strstr_hit_and_miss();
+  test_strspn_basic();
+  test_strcspn_basic();
+  test_strpbrk_hit_and_miss();
+  test_strtok_walks_tokens();
+  test_strtok_r_reentrant_independence();
   test_symbol_set_pinned();
 
   if (g_failures == 0) {

--- a/user/libs/clib/README.md
+++ b/user/libs/clib/README.md
@@ -17,6 +17,10 @@ against. Today it ships:
   `strcmp`, `strncmp`, `strcpy`, `strncpy`, `strcat`, `strncat`,
   `strchr`, `strrchr`, `strstr`) under `include/clib/string.h` — slice 1
   of M7-TOOLCHAIN-004 ([#407](https://github.com/rwrife/SecureOS/issues/407)).
+  Slice 12 of #407 extends the same header with the freestanding
+  tokenize / span family (`strspn`, `strcspn`, `strpbrk`, `strtok`,
+  `strtok_r`) TinyCC's argv + include-path parsers link against.
+  of M7-TOOLCHAIN-004 ([#407](https://github.com/rwrife/SecureOS/issues/407)).
 
 Later slices of #407 add stdio (`fopen` / `fread` / `fwrite` /
 `fclose` / `fprintf`) on top of `os_fs_*` + `os_console_write`,
@@ -201,6 +205,11 @@ TEST:PASS:clib_string:strcpy_and_strncpy_pad
 TEST:PASS:clib_string:strcat_and_strncat
 TEST:PASS:clib_string:strchr_and_strrchr
 TEST:PASS:clib_string:strstr_hit_and_miss
+TEST:PASS:clib_string:strspn_basic
+TEST:PASS:clib_string:strcspn_basic
+TEST:PASS:clib_string:strpbrk_hit_and_miss
+TEST:PASS:clib_string:strtok_walks_tokens
+TEST:PASS:clib_string:strtok_r_reentrant_independence
 TEST:PASS:clib_string:symbol_set_pinned
 TEST:PASS:clib_string
 ```

--- a/user/libs/clib/include/clib/string.h
+++ b/user/libs/clib/include/clib/string.h
@@ -27,6 +27,10 @@
  *   - strchr, strrchr
  *   - strstr
  *
+ * Symbol coverage (slice 12, additive, issue #407):
+ *   - strspn, strcspn, strpbrk
+ *   - strtok, strtok_r
+ *
  * Out of scope for this slice (folded in by later #407 slices once
  * TinyCC's link-error set pins them):
  *   - stdio (`fopen` / `fprintf` / `fread` / `fwrite` / `fclose`) — needs
@@ -92,6 +96,32 @@ char   *strncat(char *dst, const char *src, size_t n);
 char   *strchr (const char *s, int c);
 char   *strrchr(const char *s, int c);
 char   *strstr (const char *haystack, const char *needle);
+
+/* --- string tokenize / span -------------------------------------------- *
+ *
+ * M7-TOOLCHAIN-004 slice 12 (issue #407): freestanding tokenize / span
+ * family. TinyCC's option parser (`tcc.c` argv walk), include-path /
+ * library-path splitters, and `-D`/`-U` macro definition parser all
+ * link against `strspn`, `strcspn`, `strpbrk`, and the `strtok` /
+ * `strtok_r` pair.
+ *
+ * Notes:
+ *   - `strtok` keeps state in a single static `char *` (canonical C99
+ *     §7.21.5.8 contract). Not thread-safe by design — the in-OS
+ *     toolchain is single-threaded (P0 plan §"Threading model"), so
+ *     this matches the consumer.
+ *   - `strtok_r` is the re-entrant POSIX variant that threads its
+ *     state through a caller-provided `char **saveptr`. We ship it
+ *     because some TinyCC drops (and any future on-target callers)
+ *     prefer the re-entrant form and the implementation cost is one
+ *     extra public symbol over the canonical `strtok`.
+ */
+
+size_t  strspn (const char *s, const char *accept);
+size_t  strcspn(const char *s, const char *reject);
+char   *strpbrk(const char *s, const char *accept);
+char   *strtok (char *s, const char *delim);
+char   *strtok_r(char *s, const char *delim, char **saveptr);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/user/libs/clib/src/string.c
+++ b/user/libs/clib/src/string.c
@@ -218,3 +218,117 @@ char *strstr(const char *haystack, const char *needle) {
   }
   return (char *)0;
 }
+
+/* --- string tokenize / span -------------------------------------------- *
+ *
+ * Slice 12 of M7-TOOLCHAIN-004 (issue #407). Adds the freestanding
+ * tokenize / span family TinyCC's argv + include-path parsers link
+ * against. Pure byte-level, no allocator, no syscalls.
+ *
+ * Implementation notes:
+ *   - Class membership (`s_in_set`) treats bytes as `unsigned char`,
+ *     mirroring the existing `memcmp` posture so that ordering and
+ *     membership match the C standard regardless of host `char`
+ *     signedness.
+ *   - `strtok` uses a single static `char *` for state (canonical
+ *     C99 §7.21.5.8). The re-entrant `strtok_r` keeps its state in
+ *     a caller-provided `*saveptr` and is implemented by the same
+ *     core helper so the two cannot drift apart.
+ *   - `strpbrk` returns the first occurrence of any byte from
+ *     `accept` in `s`, or NULL on no match. `strspn` returns the
+ *     length of the leading run of bytes that ARE in `accept`;
+ *     `strcspn` returns the leading run that are NOT in `reject`.
+ *     All three treat NUL as a hard terminator on the searched
+ *     string (`s`) but a normal byte inside the set string when
+ *     scanning the set — i.e. the set ends at its own NUL exactly as
+ *     the standard prescribes.
+ *   - Defensive posture: NULL `s` or NULL set inputs are treated as
+ *     empty rather than dereferenced, matching the same
+ *     no-crash-on-programmer-mistake stance used by qsort / bsearch
+ *     slices.
+ */
+
+static int s_in_set(unsigned char c, const char *set) {
+  if (set == (const char *)0) {
+    return 0;
+  }
+  for (const unsigned char *p = (const unsigned char *)set; *p != 0; p++) {
+    if (*p == c) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+size_t strspn(const char *s, const char *accept) {
+  if (s == (const char *)0) {
+    return 0;
+  }
+  size_t i = 0;
+  while (s[i] != '\0' && s_in_set((unsigned char)s[i], accept)) {
+    i++;
+  }
+  return i;
+}
+
+size_t strcspn(const char *s, const char *reject) {
+  if (s == (const char *)0) {
+    return 0;
+  }
+  size_t i = 0;
+  while (s[i] != '\0' && !s_in_set((unsigned char)s[i], reject)) {
+    i++;
+  }
+  return i;
+}
+
+char *strpbrk(const char *s, const char *accept) {
+  if (s == (const char *)0) {
+    return (char *)0;
+  }
+  for (size_t i = 0; s[i] != '\0'; i++) {
+    if (s_in_set((unsigned char)s[i], accept)) {
+      return (char *)(s + i);
+    }
+  }
+  return (char *)0;
+}
+
+char *strtok_r(char *s, const char *delim, char **saveptr) {
+  if (saveptr == (char **)0) {
+    return (char *)0;
+  }
+  char *cursor = (s != (char *)0) ? s : *saveptr;
+  if (cursor == (char *)0) {
+    return (char *)0;
+  }
+  /* Skip leading delimiters. */
+  while (*cursor != '\0' && s_in_set((unsigned char)*cursor, delim)) {
+    cursor++;
+  }
+  if (*cursor == '\0') {
+    *saveptr = cursor;
+    return (char *)0;
+  }
+  /* Scan to the next delimiter (or end of string). */
+  char *tok_start = cursor;
+  while (*cursor != '\0' && !s_in_set((unsigned char)*cursor, delim)) {
+    cursor++;
+  }
+  if (*cursor == '\0') {
+    *saveptr = cursor;
+  } else {
+    *cursor  = '\0';
+    *saveptr = cursor + 1;
+  }
+  return tok_start;
+}
+
+/* Canonical C99 `strtok` keeps its state in a single static pointer.
+ * Not thread-safe by design — the in-OS toolchain is single-threaded
+ * (plan P0 §Threading model). */
+static char *s_strtok_saveptr;
+
+char *strtok(char *s, const char *delim) {
+  return strtok_r(s, delim, &s_strtok_saveptr);
+}


### PR DESCRIPTION
Refs #407 (M7-TOOLCHAIN-004), plan `plans/2026-05-28-in-os-toolchain-self-hosting.md` P3.

## What

Slice 12 of the freestanding libc nucleus: extends `user/libs/clib/string.h` + `string.c` with the tokenize / span family TinyCC's argv parser, include-path / library-path splitters, and `-D`/`-U` macro-definition parsers link against.

## Shipped surface (5 symbols, canonical libc names)

- `size_t strspn(const char *s, const char *accept)`
- `size_t strcspn(const char *s, const char *reject)`
- `char *strpbrk(const char *s, const char *accept)`
- `char *strtok(char *s, const char *delim)` — canonical C99 §7.21.5.8, single static `char *` state.
- `char *strtok_r(char *s, const char *delim, char **saveptr)` — POSIX reentrant variant; `strtok` is implemented in terms of it so the two cannot drift apart.

All routines share one helper (`s_in_set`) so class-membership semantics are bit-for-bit identical across the family. Bytes are treated as `unsigned char` to match the existing `memcmp`/`strcmp` posture.

**Defensive contract** (same posture as qsort/bsearch slices): `NULL` `s` or `NULL` `saveptr` degrade to empty/NULL rather than dereferencing, so a programmer mistake doesn't crash the in-OS toolchain.

## Threading

`strtok`'s single static state is not thread-safe by design (C99 contract). The in-OS toolchain is single-threaded (plan P0 §"Threading model"), so this matches the consumer. Callers that need re-entrancy use `strtok_r`.

## Validation

```
$ bash build/scripts/test.sh clib_string
TEST:PASS:clib_string:memcpy_basic
TEST:PASS:clib_string:memmove_overlap_forward
TEST:PASS:clib_string:memmove_overlap_backward
TEST:PASS:clib_string:memset_fill
TEST:PASS:clib_string:memcmp_order
TEST:PASS:clib_string:memchr_hit_and_miss
TEST:PASS:clib_string:strlen_and_strnlen
TEST:PASS:clib_string:strcmp_order
TEST:PASS:clib_string:strncmp_bounded
TEST:PASS:clib_string:strcpy_and_strncpy_pad
TEST:PASS:clib_string:strcat_and_strncat
TEST:PASS:clib_string:strchr_and_strrchr
TEST:PASS:clib_string:strstr_hit_and_miss
TEST:PASS:clib_string:strspn_basic
TEST:PASS:clib_string:strcspn_basic
TEST:PASS:clib_string:strpbrk_hit_and_miss
TEST:PASS:clib_string:strtok_walks_tokens
TEST:PASS:clib_string:strtok_r_reentrant_independence
TEST:PASS:clib_string:symbol_set_pinned
TEST:PASS:clib_string
```

19 sub-markers + roll-up PASS locally. Compiled with `-fno-builtin` so the assertions exercise OUR implementation rather than `__builtin_*`.

- 5 new sub-markers cover hit/miss/empty-input/empty-set paths for each new symbol, defensive `NULL` posture, two interleaved `strtok_r` walks with independent saveptrs, and a multi-character-delimiter walk.
- `symbol_set_pinned` count bumped **16 → 21** so a TinyCC drop or unrelated PR cannot silently remove a family member.
- Driver `build/scripts/test_clib_string.sh` grep-pins each new marker.

## Files changed

- `user/libs/clib/include/clib/string.h` — five new prototypes + rationale block.
- `user/libs/clib/src/string.c` — implementations + `s_in_set` helper.
- `tests/clib_string_test.c` — five new test functions + symbol pin bump.
- `build/scripts/test_clib_string.sh` — grep-pin the five new markers.
- `user/libs/clib/README.md` — slice-12 note + updated marker list.

## ABI

Additive userland-only at `OS_ABI_VERSION=0` — no `OS_ABI_VERSION` bump (same precedent as #416 str/mem, #417 ctype, #418 qsort, #428 stdlib, #430 errno, #431 stdarg, #433 bsearch slices).

## Peer-PR overlap

Zero file overlap with the in-flight #407 slice PRs (#433 bsearch, #434 limits, #435 stdbool, #436 stddef, #437 stdint, #439 iso646, #440 stdalign, #441 float, #442 stdnoreturn, #443 assert, #444 strtoll/strtoull). Each touches a different header / source / test pair; this slice is the only one editing `string.{h,c}` + `clib_string_test.c`.

## Follow-ups (out of scope)

- `strdup` / `strndup` — allocator-dependent; deferred to a slice that wires the on-target allocator.
- Wiring `clib_string` into `validate_bundle.sh` already done in an earlier slice; no bundle change needed.
- `strerror` alias on top of the existing `clib_strerror` — separate slice, errno-family scoped.