### PR TITLE
docs(abi): bump syscalls.md Last verified stamp to af8ece8 (unblock CI)

### DIFF
--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -142,5 +142,5 @@ unused"). The reservation is purely an ABI-shape anchor.
 4. Add an allow-path and a deny-path test under `build/scripts/test_*.sh`.
 5. Update this table and bump the verification line below.
 
-Last verified against commit: 015ea664ce
+Last verified against commit: af8ece8
 


### PR DESCRIPTION
PR #432 (af8ece8) squash-merged with `Last verified against commit: 015ea664ce` — a SHA that only existed on the original feature branch and is unreachable from `origin/main`. `validate_abi_stamps` therefore fails on every open PR with:

```
ABI_STAMP:FAIL:docs/abi/syscalls.md:stamp_sha_unknown_to_git:015ea664ce
VALIDATION_FAIL:validate_abi_stamps
```

…which is blocking the entire current PR queue (#433–#445 all red on the same line).

This bumps the stamp to the actual squash-merge SHA on main (`af8ece8`), same pattern used by previously merged stamp-bump PRs #420 (a2177df) and #438 (6f842a0).

## Validation

```
$ bash build/scripts/test.sh validate_abi_stamps
…
ABI_STAMP:PASS:docs/abi/syscalls.md:af8ece8459
…
```

🤖 Filed by `cron:secureos-hourly-pr-review` while working PR #433 — every open PR hits this same failure.