### PR TITLE
test(m7_toolchain): retarget runs_compiled_binary SKIP to #410

### DIFF
--- a/tests/m7_toolchain/README.md
+++ b/tests/m7_toolchain/README.md
@@ -30,7 +30,7 @@ bundle to FAIL (same orphan-from-`TEST_TARGETS` shape #129 / #366 / #384 /
 | Marker                              | Gating issue | What unblocks PASS                                       |
 | ----------------------------------- | ------------ | -------------------------------------------------------- |
 | `toolchain_compiles_hello_in_os`    | [#409]       | `cc` driver app produces a SOF/ELF on-target             |
-| `toolchain_runs_compiled_binary`    | [#422]       | `os_process_spawn` syscall + `CAP_APP_EXEC` gating       |
+| `toolchain_runs_compiled_binary`    | [#410]       | unsigned-run wiring + `cc` driver output reachable through launcher (os_process_spawn merged via #422 / PR #427) |
 | `toolchain_unsigned_prompt_enforced`| [#410]       | unsigned-run wiring through the launcher auth flow       |
 | `toolchain_large_output_persisted`  | [#409]       | `cc` emits a >1 KB binary; FS path stays byte-identical  |
 | `toolchain_compile_error_reported`  | [#409]       | `cc` exits non-zero on syntax error with no output file  |

--- a/tests/m7_toolchain/markers.json
+++ b/tests/m7_toolchain/markers.json
@@ -13,9 +13,9 @@
     },
     {
       "name": "toolchain_runs_compiled_binary",
-      "gatingIssue": 422,
-      "reason": "awaiting_422",
-      "description": "os_process_spawn syscall + CAP_APP_EXEC gating let the launcher execute the cc output."
+      "gatingIssue": 410,
+      "reason": "awaiting_410",
+      "description": "End-to-end run of cc output: os_process_spawn (#422) merged via PR #427; remaining gates are the cc driver (#409) producing a binary on-target and the launcher unsigned-run wiring (#410) that actually executes it."
     },
     {
       "name": "toolchain_unsigned_prompt_enforced",

--- a/tests/m7_toolchain/toolchain_runs_compiled_binary.sh
+++ b/tests/m7_toolchain/toolchain_runs_compiled_binary.sh
@@ -3,12 +3,18 @@
 #
 # SKIP-pinned acceptance stub for the M7-TOOLCHAIN acceptance suite
 # scaffolding (issue #423, umbrella #403). Real assertions land with
-# the gating execute slice (issue #422).
+# the gating execute slice (issue #410).
 #
 # Plan: plans/2026-05-28-in-os-toolchain-self-hosting.md
 #       (section "Acceptance tests" -> `toolchain_runs_compiled_binary`)
 #
-# Intent: os_process_spawn syscall + CAP_APP_EXEC gating let the launcher execute the cc output.
+# Intent: end-to-end "run a freshly compiled binary" path. The
+# `os_process_spawn` syscall + `CAP_APP_EXEC` gating (slice #422,
+# merged via PR #427 / commit 6f842a0) provides the spawn primitive,
+# but the acceptance assertion still requires the `cc` driver (#409)
+# to emit a binary on-target and the launcher unsigned-run wiring
+# (#410) to actually execute it. The SKIP target is therefore #410,
+# the umbrella execute issue that closes the loop.
 #
 # Emits the canonical SKIP marker for the bundle gate, then rolls up a
 # TEST:PASS:<target> so validate_bundle.sh stays green while the gating
@@ -16,5 +22,5 @@
 # stubs (#389/#392) and the M5 cascade audit SKIPs (#344).
 set -euo pipefail
 
-printf 'TEST:SKIP:toolchain_runs_compiled_binary:awaiting_422\n'
+printf 'TEST:SKIP:toolchain_runs_compiled_binary:awaiting_410\n'
 printf 'TEST:PASS:toolchain_runs_compiled_binary\n'


### PR DESCRIPTION
## Summary

The `toolchain_runs_compiled_binary` acceptance marker in `tests/m7_toolchain/` was SKIP-pinned with `awaiting_422` (os_process_spawn syscall). That work merged on 2026-05-29 via PR #427 (commit `6f842a0`), so the `awaiting_422` pointer is now stale and references work already on `main`.

The marker is still legitimately SKIP because closing the loop also needs:
- the `cc` driver app (#409) to actually emit a binary on-target, and
- the launcher unsigned-run + acceptance-suite wiring (#410) to execute it.

#410 is the umbrella execute slice that flips this marker to a real `TEST:PASS`, so retarget the SKIP reason and gating issue to #410 and rewrite the description to record that the spawn primitive (#422) is in.

## Scope

Harness scaffolding only (issue #423). No production code, no kernel or userland behavior change, no `OS_ABI_VERSION` bump. Mirrors the SKIP-discipline shape established by #344 / #389 / #392.

- `tests/m7_toolchain/toolchain_runs_compiled_binary.sh`: `awaiting_422` → `awaiting_410` + expanded header comment explaining what #422 already provided vs. what #409/#410 still owe.
- `tests/m7_toolchain/markers.json`: `gatingIssue` 422 → 410, `reason` updated, `description` rewritten to reference PR #427.
- `tests/m7_toolchain/README.md`: marker table row updated.

## Validation

```
$ bash build/scripts/test.sh toolchain_runs_compiled_binary
TEST:SKIP:toolchain_runs_compiled_binary:awaiting_410
TEST:PASS:toolchain_runs_compiled_binary
```

`markers.json` round-trips through `json.loads()`. Bundle stays green (target still emits its rolled-up `TEST:PASS:`).

## Follow-ups

Not addressed here — flipping this SKIP to a real `TEST:PASS` is exactly what #410 is for.

Refs #410, #422, #423.