### PR TITLE
feat(#407): wire errno=ERANGE/EINVAL into freestanding strtol family

### DIFF
--- a/build/scripts/test_clib_stdlib.sh
+++ b/build/scripts/test_clib_stdlib.sh
@@ -19,6 +19,7 @@ mkdir -p "$OUT_DIR"
 
 cc -std=c11 -Wall -Wextra -Werror -fno-builtin \
   "$ROOT_DIR/user/libs/clib/src/stdlib.c" \
+  "$ROOT_DIR/user/libs/clib/src/errno.c" \
   "$ROOT_DIR/tests/clib_stdlib_test.c" \
   -o "$OUT_DIR/clib_stdlib_test"
 
@@ -39,6 +40,9 @@ grep -q "TEST:PASS:clib_stdlib:strtoll_endptr_no_digits"  "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib:strtoll_invalid_base"      "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib:strtoull_basic"            "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib:strtoull_overflow_clamp"   "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdlib:errno_overflow_set_erange"  "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdlib:errno_invalid_base_set_einval" "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdlib:errno_success_preserved"   "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib:abs_labs"                  "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib:symbol_set_pinned"         "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdlib$"                          "$LOG_PATH"

--- a/tests/clib_stdlib_test.c
+++ b/tests/clib_stdlib_test.c
@@ -13,6 +13,17 @@
 
 #include "../user/libs/clib/include/clib/stdlib.h"
 
+/*
+ * Pull in the freestanding <errno.h> nucleus so the errno-on-overflow
+ * follow-up to PR #430 can be asserted directly against OUR `errno`
+ * global and macro family rather than glibc's. The header guards on
+ * SECUREOS_USER_LIBS_CLIB_ERRNO_H and the macro values match musl /
+ * Linux numbering, so transitive inclusion of glibc's <errno.h>
+ * (which does NOT happen via <stdio.h> on Debian bookworm — same
+ * property the slice-5 test relies on) would still agree on numbering.
+ */
+#include "../user/libs/clib/include/clib/errno.h"
+
 #include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -152,6 +163,111 @@ static void test_strtol_overflow_clamp(void) {
   snprintf(buf, sizeof buf, "%ld", LONG_MAX);
   EXPECT_EQ_L(strtol(buf, &end, 10), LONG_MAX, "strtol_overflow_clamp");
   PASS("strtol_overflow_clamp");
+}
+
+/* ---------- errno-on-overflow follow-up to slice 5 (PR #430) ----------- *
+ *
+ * The slice-5 errno nucleus shipped the `int errno` global + the
+ * ERANGE / EINVAL macros precisely so the stdlib clamp paths could
+ * flip from "silent" to canonical ISO C / POSIX `errno = ERANGE`.
+ * These sub-assertions pin that contract:
+ *
+ *   - Overflow on any of strtol/strtoul/strtoll/strtoull sets
+ *     errno to ERANGE (in addition to clamping the return value).
+ *   - A bad `base` argument sets errno to EINVAL (POSIX extension;
+ *     musl matches).
+ *   - A successful parse does NOT clobber a caller-preset errno.
+ */
+static void test_errno_overflow_set_erange(void) {
+  char *end;
+  errno = 0;
+  (void)strtol("99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+
+  errno = 0;
+  (void)strtol("-99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+
+  errno = 0;
+  (void)strtoul("99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+
+  errno = 0;
+  (void)strtoll("99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+
+  errno = 0;
+  (void)strtoll("-99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+
+  errno = 0;
+  (void)strtoull("99999999999999999999999999999999", &end, 10);
+  EXPECT_EQ_L(errno, ERANGE, "errno_overflow_set_erange");
+  PASS("errno_overflow_set_erange");
+}
+
+static void test_errno_invalid_base_set_einval(void) {
+  char *end;
+  errno = 0;
+  (void)strtol("10", &end, 1);
+  EXPECT_EQ_L(errno, EINVAL, "errno_invalid_base_set_einval");
+
+  errno = 0;
+  (void)strtol("10", &end, 37);
+  EXPECT_EQ_L(errno, EINVAL, "errno_invalid_base_set_einval");
+
+  errno = 0;
+  (void)strtoul("10", &end, 1);
+  EXPECT_EQ_L(errno, EINVAL, "errno_invalid_base_set_einval");
+
+  errno = 0;
+  (void)strtoll("10", &end, 1);
+  EXPECT_EQ_L(errno, EINVAL, "errno_invalid_base_set_einval");
+
+  errno = 0;
+  (void)strtoull("10", &end, 37);
+  EXPECT_EQ_L(errno, EINVAL, "errno_invalid_base_set_einval");
+  PASS("errno_invalid_base_set_einval");
+}
+
+static void test_errno_success_preserved(void) {
+  /*
+   * Canonical contract: errno is set on error, left alone on success.
+   * Preset errno to a sentinel (EBADF) and confirm a clean parse does
+   * not clobber it. Also confirms a "no digits" call (which returns 0
+   * but is not an overflow) does not clobber errno — same musl posture.
+   */
+  char *end;
+  errno = EBADF;
+  long v = strtol("  +42x", &end, 10);
+  EXPECT_EQ_L(v, 42L,             "errno_success_preserved");
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+
+  errno = EBADF;
+  (void)strtoul("0xff", &end, 0);
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+
+  errno = EBADF;
+  (void)strtoll("8589934592", &end, 10);
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+
+  errno = EBADF;
+  (void)strtoull("42", &end, 10);
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+
+  /* No-digits path: returns 0, leaves errno untouched. */
+  errno = EBADF;
+  long w = strtol("  abc", &end, 10);
+  EXPECT_EQ_L(w, 0L,              "errno_success_preserved");
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+
+  /* LONG_MAX exactly: not an overflow, must not set errno. */
+  char buf[64];
+  snprintf(buf, sizeof buf, "%ld", LONG_MAX);
+  errno = EBADF;
+  (void)strtol(buf, &end, 10);
+  EXPECT_EQ_L(errno, EBADF,       "errno_success_preserved");
+  PASS("errno_success_preserved");
 }
 
 static void test_strtol_invalid_base(void) {
@@ -350,6 +466,9 @@ int main(void) {
   test_strtoll_invalid_base();
   test_strtoull_basic();
   test_strtoull_overflow_clamp();
+  test_errno_overflow_set_erange();
+  test_errno_invalid_base_set_einval();
+  test_errno_success_preserved();
   test_abs_labs();
   test_symbol_set_pinned();
 

--- a/user/libs/clib/README.md
+++ b/user/libs/clib/README.md
@@ -203,10 +203,12 @@ TEST:PASS:clib_errno:symbol_set_pinned
 TEST:PASS:clib_errno
 ```
 
-No `OS_ABI_VERSION` bump (userland-only, additive). A follow-up
-slice can flip the existing `strtol`/`strtoul` clamp paths from
-"silent" to `errno = ERANGE` without touching this slice's symbol
-surface.
+No `OS_ABI_VERSION` bump (userland-only, additive). The slice-4
+`strtol` / `strtoul` / `strtoll` / `strtoull` clamp paths now set
+`errno = ERANGE` on overflow and `errno = EINVAL` on a bad `base`
+argument (the canonical ISO C / POSIX contract TinyCC's driver
+relies on to distinguish a clean clamp from a real overflow). The
+clamp return values and `*endptr` semantics are unchanged.
 
 ## Slice 7 — bsearch (issue #407)
 

--- a/user/libs/clib/include/clib/errno.h
+++ b/user/libs/clib/include/clib/errno.h
@@ -13,9 +13,12 @@
  *   calling `strtol` to distinguish a clean clamp from an actual
  *   overflow. Filing this slice now lands the symbol + macro family
  *   so the M7-TOOLCHAIN-005 TinyCC port (issue #408) does not hit a
- *   link-error on `errno` / `ERANGE` / `EINVAL` / `ENOMEM`, and so a
- *   follow-up slice can flip the stdlib clamp paths from "silent" to
- *   "errno = ERANGE" without touching the symbol surface.
+ *   link-error on `errno` / `ERANGE` / `EINVAL` / `ENOMEM`, and so
+ *   the slice-4 stdlib clamp paths can be flipped from "silent" to
+ *   "errno = ERANGE" without touching the symbol surface (landed in
+ *   the errno-on-overflow follow-up that wires `errno = ERANGE` into
+ *   `strtol` / `strtoul` / `strtoll` / `strtoull` and `errno = EINVAL`
+ *   on a bad `base`).
  *
  * Why it lives in this slice
  *   Same shape as the str/mem, ctype, qsort, and stdlib slices: pure

--- a/user/libs/clib/src/stdlib.c
+++ b/user/libs/clib/src/stdlib.c
@@ -3,11 +3,12 @@
  * Freestanding stdlib subset (M7-TOOLCHAIN-004 slice 4, issue #407).
  *
  * Implementation notes:
- *   - Freestanding: no libc, no syscalls, no globals.
+ *   - Freestanding: no libc, no syscalls.
  *   - We reproduce just enough of <ctype.h> inline (the isspace test
  *     used by atoi/strtol/strtoul) so this translation unit has zero
- *     intra-clib dependencies — keeps the link of `libclib.a` flat and
- *     keeps the host unit test free of slice-1/slice-2 ordering.
+ *     intra-clib dependencies on the ctype slice — keeps the link of
+ *     `libclib.a` flat and keeps the host unit test free of
+ *     slice-1/slice-2 ordering.
  *   - Overflow uses unsigned accumulation so the cumulative check is
  *     well-defined in C; signed overflow is then translated by
  *     comparing against LONG_MAX / (LONG_MIN as unsigned).
@@ -15,9 +16,26 @@
  *     avoid invoking signed-overflow UB; the C standard leaves this
  *     case undefined, so matching two's-complement HW is acceptable
  *     and avoids surprises in TinyCC's own driver.
+ *
+ * errno wiring (errno-on-overflow follow-up to the slice-5 <errno.h>
+ * landing in PR #430):
+ *   - strtol / strtoul / strtoll / strtoull all set `errno = ERANGE`
+ *     on overflow (in addition to clamping the return value to
+ *     `{L,LL}{ONG_MIN,ONG_MAX}` / `U{L,LL}ONG_MAX`), matching the
+ *     ISO C / POSIX contract TinyCC's `tcc.c` numeric paths rely on
+ *     to distinguish a clean clamp from a real overflow.
+ *   - An out-of-range `base` argument (anything other than 0 or
+ *     2..36) sets `errno = EINVAL` before returning 0 / leaving
+ *     `*endptr == nptr`. POSIX extension — musl does the same, and
+ *     TinyCC's driver never feeds a bad base so the spelling is
+ *     forward-compatible.
+ *   - No path clears `errno`; the canonical contract is "set on
+ *     error, leave alone on success", which lets callers preset
+ *     `errno = 0` and then check after a successful parse.
  */
 
 #include "../include/clib/stdlib.h"
+#include "../include/clib/errno.h"
 
 #include <limits.h>
 #include <stddef.h>
@@ -140,6 +158,7 @@ long strtol(const char *nptr, char **endptr, int base) {
   int         overflow_flag  = 0;
 
   if (base != 0 && (base < 2 || base > 36)) {
+    errno = EINVAL;
     if (endptr) {
       *endptr = (char *)nptr;
     }
@@ -171,11 +190,13 @@ long strtol(const char *nptr, char **endptr, int base) {
 
   if (sign > 0) {
     if (overflow_flag || mag > (unsigned long)LONG_MAX) {
+      errno = ERANGE;
       return LONG_MAX;
     }
     return (long)mag;
   } else {
     if (overflow_flag || mag > long_min_mag) {
+      errno = ERANGE;
       return LONG_MIN;
     }
     if (mag == long_min_mag) {
@@ -191,6 +212,7 @@ unsigned long strtoul(const char *nptr, char **endptr, int base) {
   int         overflow_flag  = 0;
 
   if (base != 0 && (base < 2 || base > 36)) {
+    errno = EINVAL;
     if (endptr) {
       *endptr = (char *)nptr;
     }
@@ -214,6 +236,7 @@ unsigned long strtoul(const char *nptr, char **endptr, int base) {
   }
 
   if (overflow_flag) {
+    errno = ERANGE;
     return ULONG_MAX;
   }
 
@@ -300,6 +323,7 @@ long long strtoll(const char *nptr, char **endptr, int base) {
   int         overflow_flag = 0;
 
   if (base != 0 && (base < 2 || base > 36)) {
+    errno = EINVAL;
     if (endptr) {
       *endptr = (char *)nptr;
     }
@@ -327,11 +351,13 @@ long long strtoll(const char *nptr, char **endptr, int base) {
 
   if (sign > 0) {
     if (overflow_flag || mag > (unsigned long long)LLONG_MAX) {
+      errno = ERANGE;
       return LLONG_MAX;
     }
     return (long long)mag;
   } else {
     if (overflow_flag || mag > llong_min_mag) {
+      errno = ERANGE;
       return LLONG_MIN;
     }
     if (mag == llong_min_mag) {
@@ -347,6 +373,7 @@ unsigned long long strtoull(const char *nptr, char **endptr, int base) {
   int         overflow_flag = 0;
 
   if (base != 0 && (base < 2 || base > 36)) {
+    errno = EINVAL;
     if (endptr) {
       *endptr = (char *)nptr;
     }
@@ -370,6 +397,7 @@ unsigned long long strtoull(const char *nptr, char **endptr, int base) {
   }
 
   if (overflow_flag) {
+    errno = ERANGE;
     return ULLONG_MAX;
   }
 


### PR DESCRIPTION
Follow-up slice for **#407 / M7-TOOLCHAIN-004**: flips the freestanding `stdlib` clamp paths from "silent" to canonical ISO C / POSIX `errno`. The slice-5 `<errno.h>` nucleus (PR #430) explicitly called this out as the next step \u2014 the symbol surface (`errno`, `ERANGE`, `EINVAL`) is already on disk, just nothing was writing to it.

## What lands

- **`user/libs/clib/src/stdlib.c`**: `strtol` / `strtoul` / `strtoll` / `strtoull` now set `errno = ERANGE` on overflow (in addition to clamping to `{L,LL}{ONG_MIN,ONG_MAX}` / `U{L,LL}ONG_MAX`), and `errno = EINVAL` when `base` is out of range (anything other than 0 or 2..36). POSIX extension on the latter; musl does the same and TinyCC never feeds a bad base, so the spelling is forward-compatible.
- **Return values + `*endptr` semantics are unchanged.** This is purely additive on top of the existing clamp \u2014 a caller that ignored `errno` before still sees the same answer today.
- **Test wiring**: `tests/clib_stdlib_test.c` now links `errno.c` and gains three sub-assertions:
  - `errno_overflow_set_erange` \u2014 every member of the strtol family flips `errno = ERANGE` on overflow (positive and negative magnitudes).
  - `errno_invalid_base_set_einval` \u2014 `base = 1` / `base = 37` on every family member sets `errno = EINVAL`.
  - `errno_success_preserved` \u2014 canonical "set on error, leave alone on success" contract: a caller-preset `errno` survives a successful parse, the no-digits path, and `LONG_MAX` exactly (not an overflow).
- **`build/scripts/test_clib_stdlib.sh`**: links `src/errno.c` alongside `src/stdlib.c` and asserts the three new `TEST:PASS` lines.
- **Docs**: `user/libs/clib/README.md` slice-5 paragraph updated (was: "a follow-up can flip the clamp paths" \u2014 now: "the follow-up has landed"). `include/clib/errno.h` header comment likewise updated.

## Why a no-bridge, no-syscall slice

Same shape as the bsearch / qsort / errno / stdarg / stdint / iso646 nuclei: pure freestanding userland, no kernel includes, no allocator dependency, no `OS_ABI_VERSION` bump. The slice-5 `<errno.h>` nucleus is the only new dependency at link time \u2014 and it shipped in PR #430.

## Validation (all green, local)

```
$ bash build/scripts/test_clib_stdlib.sh
TEST:PASS:clib_stdlib:atoi_basic
TEST:PASS:clib_stdlib:strtol_decimal
TEST:PASS:clib_stdlib:strtol_hex_octal_auto
TEST:PASS:clib_stdlib:strtol_endptr_no_digits
TEST:PASS:clib_stdlib:strtol_overflow_clamp
TEST:PASS:clib_stdlib:strtol_invalid_base
TEST:PASS:clib_stdlib:strtoul_basic
TEST:PASS:clib_stdlib:strtoul_overflow_clamp
TEST:PASS:clib_stdlib:strtoll_decimal
TEST:PASS:clib_stdlib:strtoll_overflow_clamp
TEST:PASS:clib_stdlib:strtoll_endptr_no_digits
TEST:PASS:clib_stdlib:strtoll_invalid_base
TEST:PASS:clib_stdlib:strtoull_basic
TEST:PASS:clib_stdlib:strtoull_overflow_clamp
TEST:PASS:clib_stdlib:errno_overflow_set_erange
TEST:PASS:clib_stdlib:errno_invalid_base_set_einval
TEST:PASS:clib_stdlib:errno_success_preserved
TEST:PASS:clib_stdlib:abs_labs
TEST:PASS:clib_stdlib:symbol_set_pinned
TEST:PASS:clib_stdlib
```

`clib_errno` re-run after the link change: still green (no symbol surface delta).

`bash build/scripts/validate_bundle.sh` is otherwise green; only the pre-existing QEMU-dependent FAILs (`hello_boot`, `hello_boot_negative`, `harness_negative`, `kernel_console`, `kernel_filedemo`, `kernel_persistence`) are reported, all unrelated to this slice.

## ABI

Userland-only. **No `OS_ABI_VERSION` change** \u2014 parity with the `<limits.h>`, `<stddef.h>`, `<stdarg.h>`, `<stdbool.h>`, `<errno.h>`, and `<stdlib.h>` slices.

## Follow-ups (not in this PR)

- Same flip on a future `strtod` / `strtof` slice once those land.
- Replacing or aliasing canonical `strerror` onto `clib_strerror` once TinyCC requires the unqualified spelling (already noted in the slice-5 header).

refs #407