### PR TITLE
fix #463: replace docs/abi/manifest.md 'Last verified: HEAD' placeholder with real SHA

### DIFF
--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -447,4 +447,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: HEAD
+Last verified against commit: 11e1d73


### PR DESCRIPTION
Closes #463.

## Summary

`docs/abi/manifest.md` ended with `Last verified against commit: HEAD`.
The string `HEAD` doesn't match the validator regex
`^Last verified against commit:\s*([0-9a-fA-F]{7,40})\s*$` in
`tools/validate_abi_stamps.py` (#297), so the validator fell through to
the "no stamp line" arm and silently SKIPped the file instead of gating
it — the only `docs/abi/*.md` doc carrying the header convention that
wasn't actually being checked for freshness.

Replace `HEAD` with `11e1d73`, the SHA of the commit that last
content-changed the file (`feat(#424): additive runtime.arena_bytes
manifest field`).

## Validation

Before:

```
$ bash build/scripts/validate_abi_stamps.sh | grep manifest
ABI_STAMP:SKIP:docs/abi/manifest.md:no_stamp_line
```

After:

```
$ bash build/scripts/validate_abi_stamps.sh | grep manifest
ABI_STAMP:PASS:docs/abi/manifest.md:11e1d7390b
$ bash build/scripts/validate_abi_stamps.sh; echo "exit=$?"
… (all PASS / two unrelated SKIPs) …
exit=0
```

The two remaining SKIPs (`capability-deny-contract.md`,
`sosh-capability-contract.md`) are out of scope per #463 — each has a
different root cause (no stamp line at all vs. parenthesised suffix
that breaks the regex). File separate issues if those should also be
gated.

## Scope guard

Docs-only, one-line change. No code, no schema, no `OS_ABI_VERSION`
bump. No `TEST_TARGETS` change needed; `validate_abi_stamps` is already
wired into the bundle via #297.

## Follow-ups

- Optional: tighten `tools/validate_abi_stamps.py` to fail-loud (rather
  than SKIP) on a non-empty `Last verified against commit:` line whose
  value doesn't match the SHA regex, so the `HEAD` placeholder class of
  bug surfaces immediately next time. Not done here to keep this PR
  surgical.
