### PR TITLE
docs(abi): stamp manifest.md with real SHA (fix #463)

### DIFF
--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -447,4 +447,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: HEAD
+Last verified against commit: 11e1d7390b0644413966335157e69bce6018d4a6

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -447,4 +447,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 11e1d7390b0644413966335157e69bce6018d4a6
+Last verified against commit: 30d41d6eaae617e56d9f36c7aa0fca51de0761e0


### PR DESCRIPTION
Closes #463.

## Change

`docs/abi/manifest.md` ended with the literal placeholder `Last verified against commit: HEAD`. The #297 freshness validator (`tools/validate_abi_stamps.py`) requires `^Last verified against commit:\s*([0-9a-fA-F]{7,40})\s*$`, so `HEAD` silently fell through as `no_stamp_line` SKIP — manifest.md was the only doc in `docs/abi/` carrying the header convention not actually gated by the freshness CI.

Replaced with the SHA of the file's last content-changing commit: `11e1d7390b0644413966335157e69bce6018d4a6` (`feat(#424): additive runtime.arena_bytes manifest field`).

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh | grep manifest
ABI_STAMP:PASS:docs/abi/manifest.md:11e1d7390b
```

Previously: `ABI_STAMP:SKIP:docs/abi/manifest.md:no_stamp_line`.

## Scope

Pure docs / stamp bump. No code, no schema, no OS_ABI_VERSION bump. Out-of-scope SKIPs (`capability-deny-contract.md`, `sosh-capability-contract.md`) left for separate issues as noted in #463.