### PR TITLE
fix(abi): bump docs/abi/README.md stamp to e889994 (unblocks build-and-validate on main)

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -60,4 +60,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: 857b369434b069e63116e2cbe036584812674bd7
+Last verified against commit: e889994e520a81120633e5dfda5c0ee08e3b1e89


### PR DESCRIPTION
## Summary

`docs/abi/README.md` has been failing the #297 `validate_abi_stamps` gate on every open PR since #461 merged:

```
ABI_STAMP:FAIL:docs/abi/README.md:stamp=857b369434:last_content=e889994e52
```

The stamp line still reads `857b369…` (a stale value from a prior bump pass) but `git log -1 -- docs/abi/README.md` resolves to `e889994…` — the squash-merge commit of #461 (which itself was a docs-only index entry + a stamp bump that, of course, couldn't predict its own squash SHA).

Classic squash-merge stamp-bump trap.

## Change

One-line bump of the `Last verified against commit:` line in `docs/abi/README.md` from `857b369434b069e63116e2cbe036584812674bd7` → `e889994e520a81120633e5dfda5c0ee08e3b1e89`.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh | grep README
ABI_STAMP:PASS:docs/abi/README.md:e889994e52
```

Full bundle now passes the stamp gate; remaining SKIPs (`capability-deny-contract.md`, `manifest.md`, `sosh-capability-contract.md`, `clib-symbols.md`) are all `no_stamp_line` — pre-existing and tracked separately (#463 covers manifest.md).

## Scope

Pure docs, additive, no `OS_ABI_VERSION` bump, no code or schema change. Surgical fix to unblock CI.

## Unblocks

#452, #453, #454, #455, #456, #457, #458, #459, #460, #462, #464, #465 — every currently-open PR is red on this same stamp drift.

## Follow-up

Worth filing a separate issue to make stamp bumps survive squash-merge automatically (e.g. post-merge bot that rewrites the stamp to the squash SHA), but out of scope here.