### PR TITLE
docs(abi): bump README 'Last verified' stamp to e889994 (fixes #467)

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -60,4 +60,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: 857b369434b069e63116e2cbe036584812674bd7
+Last verified against commit: e889994e520a81120633e5dfda5c0ee08e3b1e89


### PR DESCRIPTION
Fixes #467.

## Change

Single-line stamp bump in `docs/abi/README.md`:

```
-Last verified against commit: 857b369434b069e63116e2cbe036584812674bd7
+Last verified against commit: e889994e520a81120633e5dfda5c0ee08e3b1e89
```

The file's last content-changing commit is `e889994` (PR #461, capability-deny-contract.md index entry). The stale stamp made `validate_abi_stamps.sh` (wired into `validate_bundle.sh` TEST_TARGETS by #297) RED on main.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh ; echo exit=$?
ABI_STAMP:PASS:docs/abi/README.md:e889994e52
...
exit=0

$ bash build/scripts/test.sh validate_abi_stamps ; echo exit=$?
exit=0
```

## Scope

- Pure docs, no code, no schema, no `OS_ABI_VERSION` bump.
- Single file, single line — matches stamp-bump discipline (#257, like PRs #451 / #438 / #420).
- Independent of #463 (`manifest.md` HEAD placeholder) — intentionally kept separate per the issue's guidance.

## Follow-ups

- #463, #468 (other stamp/freshness gaps) remain open and should land as separate stamp-bump PRs.
- Post-merge / push:main freshness hook is out of scope (issue's 'Out of scope' note).