### PR TITLE
docs: update stale ABI stamp in docs/abi/README.md

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -60,4 +60,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: e889994e520a81120633e5dfda5c0ee08e3b1e89
+Last verified against commit: 64e92183a1fb9b3707341fa8c22de8c5a6f0bc8e


### PR DESCRIPTION
## What

Updated the stale `Last verified against commit` stamp in `docs/abi/README.md`.

## Why

The stamp pointed at `e889994` but the last commit to touch this file was `64e9218`. This causes `validate_abi_stamps` to fail on main.

## Changes

- Updated stamp from `e889994e520a81120633e5dfda5c0ee08e3b1e89` to `64e92183a1fb9b3707341fa8c22de8c5a6f0bc8e`

## Verification

```bash
bash build/scripts/validate_abi_stamps.sh  # should show ABI_STAMP:PASS
```

Closes #467