### PR TITLE
docs: add missing ABI stamp to clib-symbols.md

### DIFF
--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -316,3 +316,5 @@ When a new clib symbol is added (or an obsolete one removed) in the
 Step 4 is what the bundle gate (`validate_bundle.sh` `TEST_TARGETS`)
 runs in CI, so if you forget any of steps 1-3 the bundle flips to FAIL
 with a descriptive marker pointing at which source disagreed.
+
+Last verified against commit: 64e92183a1fb9b3707341fa8c22de8c5a6f0bc8e


### PR DESCRIPTION
## What

Added missing `Last verified against commit` line to `docs/abi/clib-symbols.md`.

## Why

The file had a `Last reviewed` date but no machine-checked SHA stamp, so `validate_abi_stamps` silently SKIPped it instead of checking freshness.

## Changes

- Appended `Last verified against commit: 64e92183a1fb9b3707341fa8c22de8c5a6f0bc8e` to the end of the file

## Verification

```bash
bash build/scripts/validate_abi_stamps.sh | grep clib-symbols
# Should show: ABI_STAMP:PASS:docs/abi/clib-symbols.md:64e9218...
```

Closes #468