### PR TITLE
ci(bundle): wire process_exit_wrapper into validate_bundle.sh TEST_TARGETS (fix #469)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -199,6 +199,18 @@ TEST_TARGETS=(
     # no env deps, no syscalls. Drift on any shipped macro flips the
     # bundle to FAIL before TinyCC (P4) starts consuming the header.
     clib_float
+    # M7-TOOLCHAIN-003 slice 1 (issue #406 / PR #413): host-side smoke
+    # for the `os_process_exit` user-runtime wrapper. Sibling of
+    # `process_spawn_wrapper` (slice 2) and `mem_brk_wrapper`
+    # (M7-TOOLCHAIN-001 slice 2) -- the only one of the three
+    # M7-TOOLCHAIN-003 / -001 user-runtime wrapper smokes that was
+    # missing from TEST_TARGETS. Pins the exported symbol, signature,
+    # and no-bridge fall-through contract that `sdk/lib/crt0.c`
+    # forwards into, so a silent drift on `os_process_exit` would
+    # otherwise break every SDK-built app's process-exit path. Same
+    # orphan-from-TEST_TARGETS gate shape as #129 / #366 / #384 /
+    # #401 / #414 (see issue #469).
+    process_exit_wrapper
     # M7-TOOLCHAIN-003 slice 2 (issue #422): host-side smoke for the
     # `os_process_spawn` user-runtime wrapper. Pairs with
     # `process_exit_wrapper` (slice 1, #406 / PR #413) so any drift


### PR DESCRIPTION
Closes #469.

## Change

One-line addition (plus comment block) to `build/scripts/validate_bundle.sh`'s
`TEST_TARGETS` array: `process_exit_wrapper`, placed immediately above its
sibling `process_spawn_wrapper`. No change to `build/scripts/test.sh`
(dispatch arm already exists) or to `tests/process_exit_wrapper_test.c` /
its `.sh` wrapper.

`process_exit_wrapper` was the only one of the three M7-TOOLCHAIN-003 / -001
user-runtime wrapper smoke tests (`process_exit_wrapper`,
`process_spawn_wrapper`, `mem_brk_wrapper`) not gating the bundle. Without
it, a drift on `os_process_exit`'s exported symbol, signature, or
no-bridge fall-through contract — the things `sdk/lib/crt0.c` forwards
into — would land on `main` green.

Same orphan-from-`TEST_TARGETS` gate shape as #129 / #366 / #384 / #401 / #414.

## Validation

- ` grep -E '_wrapper$' build/scripts/validate_bundle.sh ` →
  `mem_brk_wrapper`, `process_exit_wrapper`, `process_spawn_wrapper` (all three).
- `bash build/scripts/test.sh process_exit_wrapper` → `TEST:PASS:process_exit_wrapper`.
- `bash build/scripts/validate_bundle.sh` → ran to completion; the
  `process_exit_wrapper` target reports `TEST:PASS:process_exit_wrapper`.
  Other `VALIDATION_FAIL` markers in the bundle output
  (`hello_boot`, etc.) reproduce on `main` in this environment and are
  unrelated to this change (qemu / target-build deps).

## Out of scope

- Grouping the three `*_wrapper` smokes under a single comment block —
  kept the diff minimal as the issue suggested.
- No contract / coverage change to the wrapper itself.