### PR TITLE
docs(abi): stamp clib-symbols.md with 'Last verified against commit' (fix #468)

### DIFF
--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -316,3 +316,5 @@ When a new clib symbol is added (or an obsolete one removed) in the
 Step 4 is what the bundle gate (`validate_bundle.sh` `TEST_TARGETS`)
 runs in CI, so if you forget any of steps 1-3 the bundle flips to FAIL
 with a descriptive marker pointing at which source disagreed.
+
+Last verified against commit: a70ba19


### PR DESCRIPTION
Closes #468.

## Change

Append `Last verified against commit: a70ba19` to `docs/abi/clib-symbols.md`, matching the file's last content-changing commit. This brings it under the freshness gate landed by #297.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh | grep clib-symbols
ABI_STAMP:PASS:docs/abi/clib-symbols.md:a70ba1925b

$ bash build/scripts/test.sh validate_abi_stamps; echo EXIT=$?
... (all PASS / pre-existing SKIPs unchanged)
EXIT=0
```

Pre-existing `SKIP:no_stamp_line` entries for `capability-deny-contract.md`, `manifest.md` (tracked by #463), and `sosh-capability-contract.md` are unchanged — out of scope here. #467 (README stamp) appears to already be resolved on main (README shows PASS).

## Scope discipline

- Only `docs/abi/clib-symbols.md` modified (stamp-bump discipline per #257).
- Existing `Last reviewed: 2026-05-30` line preserved (human-review cadence vs. machine SHA freshness).
- No code, no schema, no OS_ABI_VERSION bump.

## Follow-ups

- #463 (manifest.md HEAD placeholder) and the remaining two SKIP docs still need their own one-line stamp PRs.
- Once all stamp gaps are closed, #470 can promote `no_stamp_line` SKIP → FAIL in strict mode.