### PR TITLE
docs(abi): stamp sosh-capability-contract.md with 'Last verified against commit' (refs #470)

### DIFF
--- a/docs/abi/sosh-capability-contract.md
+++ b/docs/abi/sosh-capability-contract.md
@@ -364,3 +364,4 @@ the `cap.deny` audit-ring follow-up (#389) covered by the
 on every sosh deny test.
 
 Last verified against commit: 02514ac (sosh_cap_allow/deny wired via test.sh dispatcher); cat/ls FS_READ gate landed in sosh_cap_cat_ls; write/append FS_WRITE gate landed in sosh_cap_write_append; `export` ENV_WRITE gate landed in sosh_cap_export; `source` FS_READ + external-command APP_EXEC gates pinned by sosh_cap_source_exec (slice 3/3 of #351, refs #371) — §4 enforcement matrix is now complete at `OS_ABI_VERSION = 0`.
+Last verified against commit: 761a9b2


### PR DESCRIPTION
## Summary

Adds the missing machine-readable `Last verified against commit: <sha>`
trailing line to `docs/abi/sosh-capability-contract.md`, eliminating the
last `no_stamp_line` SKIP arm the freshness gate (#297) emits today.

Before:

```
$ bash build/scripts/validate_abi_stamps.sh | grep sosh
ABI_STAMP:SKIP:docs/abi/sosh-capability-contract.md:no_stamp_line
```

After:

```
$ bash build/scripts/validate_abi_stamps.sh | grep sosh
ABI_STAMP:PASS:docs/abi/sosh-capability-contract.md:761a9b257f
```

## Why this PR (refs #470)

Issue **#470** ("validate_abi_stamps strict mode — promote
'no_stamp_line' SKIP to FAIL") lists four hard prerequisites before the
strict-mode flip can land without breaking CI:

| File | Status |
| --- | --- |
| `docs/abi/manifest.md` | tracked by #463 (PRs #464 / #465 open) |
| `docs/abi/clib-symbols.md` | tracked by #468 (PR #476 open) |
| `docs/abi/capability-deny-contract.md` | PR #477 open |
| `docs/abi/sosh-capability-contract.md` | **this PR** |

Same shape as merged #471 (README) and the in-flight #465 / #476 / #477
stamp-add PRs. Once these four land, #470 can flip
`build/scripts/validate_abi_stamps.sh` to strict mode without churning
pre-existing gaps.

## Change

Single line appended at end of file:

```
Last verified against commit: 761a9b2
```

SHA is the file's most recent content-changing commit:

```
$ git log -1 --format=%h docs/abi/sosh-capability-contract.md
761a9b2  # docs(sosh): mark §4 source + external-command rows enforced (#395)
```

Trailing-line position matches `docs/abi/syscalls.md` and
`docs/abi/versioning.md`.

The existing prose paragraph that begins `Last verified against commit:
02514ac (...)` is intentionally left in place above. That line is a
single human-readable narrative — `STAMP_RE` in
`tools/validate_abi_stamps.py` requires the SHA to be the only token on
the line, so it does not match. Reshuffling it would itself be a
content change and would require a fresh SHA before the line could be
honored; appending the canonical machine-readable line at the end keeps
this PR a pure stamp-only diff.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
ABI_STAMP:PASS:docs/abi/README.md:e889994e52
ABI_STAMP:PASS:docs/abi/capabilities.md:ee4426283a
ABI_STAMP:SKIP:docs/abi/capability-deny-contract.md:no_stamp_line   # #470 / PR #477
ABI_STAMP:PASS:docs/abi/capability-handle.md:609a26216b
ABI_STAMP:SKIP:docs/abi/clib-symbols.md:no_stamp_line               # #468 / PR #476
ABI_STAMP:PASS:docs/abi/ipc-wire.md:7f303d7e90
ABI_STAMP:SKIP:docs/abi/manifest.md:no_stamp_line                   # #463 / PR #465
ABI_STAMP:PASS:docs/abi/sosh-capability-contract.md:761a9b257f      # <- this PR
ABI_STAMP:PASS:docs/abi/syscalls.md:af8ece8459
ABI_STAMP:PASS:docs/abi/versioning.md:9b2089bbcf
$ echo $?
0
```

## Discipline

- Pure docs / stamp addition. No code, no schema, no `OS_ABI_VERSION` bump.
- No other `docs/abi/*.md` modified in the same commit (#257 stamp-bump rule).
- Independent of #463 / #468 / #470 sibling PRs — landings can be in any order.

## Follow-ups

- Once #465 (or #464), #476, and #477 also merge, **all four** SKIP arms
  listed in #470 will be cleared and the strict-mode flip in
  `build/scripts/validate_abi_stamps.sh` can land.