### PR TITLE
feat(#407): freestanding snprintf/vsnprintf nucleus (M7-TOOLCHAIN-004 slice 8b)

### DIFF
--- a/build/scripts/test_clib_stdio.sh
+++ b/build/scripts/test_clib_stdio.sh
@@ -13,7 +13,13 @@
 #   - stderr_routes_to_console       : fprintf(stderr,...) hits console sink
 #   - fopen_invalid_mode_returns_null
 #   - defensive_no_backend           : no backend → fopen("r") returns NULL
-#   - shutdown_resets_pool           : after shutdown, full pool available
+#   - shutdown_resets_pool               : after shutdown, full pool available
+#   - snprintf_basic                     : full-fits + bytes + NUL
+#   - snprintf_truncation                : returns full len, terminates at size-1
+#   - snprintf_size_zero_sizing_probe    : (NULL,0) returns required length
+#   - snprintf_exact_fit                 : size == strlen+1
+#   - snprintf_null_fmt_returns_negative : NULL fmt → -1
+#   - vsnprintf_matches_snprintf         : va_list path mirrors variadic
 #   - symbol_set_pinned              : drift guard
 #
 # Compiled with `-fno-builtin` so the assertions exercise OUR
@@ -50,6 +56,12 @@ grep -q "TEST:PASS:clib_stdio:stderr_routes_to_console"      "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdio:fopen_invalid_mode_returns_null" "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdio:defensive_no_backend"          "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdio:shutdown_resets_pool"          "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:snprintf_basic"                "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:snprintf_truncation"           "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:snprintf_size_zero_sizing_probe" "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:snprintf_exact_fit"            "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:snprintf_null_fmt_returns_negative" "$LOG_PATH"
+grep -q "TEST:PASS:clib_stdio:vsnprintf_matches_snprintf"    "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdio:symbol_set_pinned"             "$LOG_PATH"
 grep -q "TEST:PASS:clib_stdio$"                              "$LOG_PATH"
 ! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -231,6 +231,8 @@ a recorder shim.
 | `fprintf`            | `int fprintf(FILE *fp, const char *fmt, ...)`                                   | minimal printf spec set |
 | `vfprintf`           | `int vfprintf(FILE *fp, const char *fmt, va_list ap)`                           | 1 KiB stack buffer; returns full requested length |
 | `printf`             | `int printf(const char *fmt, ...)`                                              | forwards to `vfprintf(stdout, ...)` |
+| `snprintf`           | `int snprintf(char *buf, size_t size, const char *fmt, ...)`                    | C11 §7.21.6.5; NUL-terminates at `min(size-1, written)`; returns full required length |
+| `vsnprintf`          | `int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap)`            | C11 §7.21.6.13; shares the `vfprintf` walker — identical spec set |
 | `feof`               | `int feof(FILE *fp)`                                                            |  |
 | `ferror`             | `int ferror(FILE *fp)`                                                          |  |
 
@@ -320,6 +322,7 @@ memmove
 memset
 printf
 qsort
+snprintf
 stderr
 stdin
 stdout
@@ -346,6 +349,7 @@ strtoull
 tolower
 toupper
 vfprintf
+vsnprintf
 ```
 <!-- clib-symbols:end -->
 

--- a/tests/clib_stdio_test.c
+++ b/tests/clib_stdio_test.c
@@ -74,6 +74,8 @@ int          fputs (const char *s, clib_FILE_t *fp) __asm__("fputs");
 int          fputc (int c, clib_FILE_t *fp) __asm__("fputc");
 int          fprintf(clib_FILE_t *fp, const char *fmt, ...) __asm__("fprintf");
 int          printf (const char *fmt, ...) __asm__("printf");
+int          snprintf(char *buf, size_t size, const char *fmt, ...) __asm__("snprintf");
+int          vsnprintf(char *buf, size_t size, const char *fmt, va_list ap) __asm__("vsnprintf");
 int          feof  (clib_FILE_t *fp) __asm__("feof");
 int          ferror(clib_FILE_t *fp) __asm__("ferror");
 
@@ -396,6 +398,77 @@ static void test_shutdown_resets_pool(void) {
   if (opened == 8 && reopened == 8) PASS("shutdown_resets_pool");
 }
 
+static void test_snprintf_basic_and_truncation(void) {
+  /* snprintf full-fits case: returns the full length, NUL-terminates. */
+  char buf[64];
+  for (size_t i = 0; i < sizeof buf; ++i) buf[i] = 0x7f; /* sentinel */
+  int n = snprintf(buf, sizeof buf, "hi %s %d", "world", 42);
+  int len_ok    = (n == 11);
+  int bytes_ok  = (memcmp(buf, "hi world 42", 11) == 0);
+  int nul_ok    = (buf[11] == '\0');
+  /* Untouched tail keeps sentinel — we only write 12 bytes total. */
+  int tail_ok   = (buf[12] == 0x7f);
+  int ok = len_ok && bytes_ok && nul_ok && tail_ok;
+  CHECK(ok, "snprintf_basic");
+  if (ok) PASS("snprintf_basic");
+
+  /* Truncation case: tiny buffer. Return value is the full length
+   * we WOULD have produced (so callers can re-size); buffer is
+   * NUL-terminated at size-1. */
+  char small[6];
+  for (size_t i = 0; i < sizeof small; ++i) small[i] = 0x7f;
+  int n2 = snprintf(small, sizeof small, "hi %s %d", "world", 42);
+  int len_ok2     = (n2 == 11);
+  int bytes_ok2   = (memcmp(small, "hi wo", 5) == 0);
+  int nul_ok2     = (small[5] == '\0');
+  int trunc_ok    = (n2 >= (int)sizeof small);
+  int ok2 = len_ok2 && bytes_ok2 && nul_ok2 && trunc_ok;
+  CHECK(ok2, "snprintf_truncation");
+  if (ok2) PASS("snprintf_truncation");
+
+  /* size == 0, buf == NULL: legal sizing probe. No writes, full
+   * length returned. */
+  int n3 = snprintf(NULL, 0, "need %d bytes", 12345);
+  int ok3 = (n3 == 16);
+  CHECK(ok3, "snprintf_size_zero_sizing_probe");
+  if (ok3) PASS("snprintf_size_zero_sizing_probe");
+
+  /* Exact-fit edge: size == strlen+1 → no truncation, terminator at
+   * size-1. */
+  char tight[6];
+  for (size_t i = 0; i < sizeof tight; ++i) tight[i] = 0x7f;
+  int n4 = snprintf(tight, sizeof tight, "abcde");
+  int ok4 = (n4 == 5) && (memcmp(tight, "abcde", 5) == 0) && (tight[5] == '\0');
+  CHECK(ok4, "snprintf_exact_fit");
+  if (ok4) PASS("snprintf_exact_fit");
+
+  /* NULL fmt → -1. */
+  char dummy[4] = { 'a', 'a', 'a', 'a' };
+  int n5 = snprintf(dummy, sizeof dummy, NULL);
+  int ok5 = (n5 < 0);
+  CHECK(ok5, "snprintf_null_fmt_returns_negative");
+  if (ok5) PASS("snprintf_null_fmt_returns_negative");
+}
+
+static int vsn_trampoline(char *buf, size_t size, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int r = vsnprintf(buf, size, fmt, ap);
+  va_end(ap);
+  return r;
+}
+
+static void test_vsnprintf_forwarding(void) {
+  /* vsnprintf must produce identical bytes / return value to
+   * snprintf for the same call — they share the underlying walker. */
+  char a[32], b[32];
+  int  ra = snprintf(a, sizeof a, "%08x|%-4s|%lu", 0x2au, "q", 7uL);
+  int  rb = vsn_trampoline(b, sizeof b, "%08x|%-4s|%lu", 0x2au, "q", 7uL);
+  int ok = (ra == rb) && (ra > 0) && (memcmp(a, b, (size_t)ra + 1) == 0);
+  CHECK(ok, "vsnprintf_matches_snprintf");
+  if (ok) PASS("vsnprintf_matches_snprintf");
+}
+
 static void test_symbol_set_pinned(void) {
   /* Drift guard — take the address of every public symbol through a
    * function pointer table. If any signature changes or any symbol is
@@ -413,6 +486,8 @@ static void test_symbol_set_pinned(void) {
     (void *)(uintptr_t)&fputc,
     (void *)(uintptr_t)&fprintf,
     (void *)(uintptr_t)&printf,
+    (void *)(uintptr_t)&snprintf,
+    (void *)(uintptr_t)&vsnprintf,
     (void *)(uintptr_t)&feof,
     (void *)(uintptr_t)&ferror,
     (void *)(uintptr_t)&stdin,
@@ -436,6 +511,8 @@ int main(void) {
   test_fopen_invalid_mode_returns_null();
   test_defensive_no_backend();
   test_shutdown_resets_pool();
+  test_snprintf_basic_and_truncation();
+  test_vsnprintf_forwarding();
   test_symbol_set_pinned();
 
   if (!g_fail) hprintf("TEST:PASS:clib_stdio\n");

--- a/tests/data/clib_symbols.expected
+++ b/tests/data/clib_symbols.expected
@@ -69,6 +69,7 @@ memmove
 memset
 printf
 qsort
+snprintf
 stderr
 stdin
 stdout
@@ -95,3 +96,4 @@ strtoull
 tolower
 toupper
 vfprintf
+vsnprintf

--- a/user/libs/clib/include/clib/stdio.h
+++ b/user/libs/clib/include/clib/stdio.h
@@ -15,6 +15,7 @@
  *   - `fopen` / `fclose` / `fread` / `fwrite` / `fflush`
  *   - `fputs` / `fputc`
  *   - `fprintf` / `vfprintf` / `printf`
+ *   - `snprintf` / `vsnprintf` (C11 §7.21.6.5 / §7.21.6.13)
  *   - format specifiers TinyCC and `cc` actually emit:
  *       `%s %d %u %x %p %c %%`
  *       `%ld %lu` for `long` ints
@@ -182,6 +183,31 @@ int    fputc(int c, FILE *fp);
 int    fprintf(FILE *fp, const char *fmt, ...);
 int    vfprintf(FILE *fp, const char *fmt, va_list ap);
 int    printf(const char *fmt, ...);
+
+/*
+ * `snprintf` / `vsnprintf` (C11 §7.21.6.5 / §7.21.6.13).
+ *
+ * Format-render into a caller-supplied buffer. The format spec set
+ * is identical to `vfprintf` (see the implementation TU and
+ * `docs/abi/clib-symbols.md` for the canonical list). NUL-
+ * termination semantics follow C11 exactly:
+ *
+ *   - if `size > 0`, at most `size - 1` formatted bytes are written
+ *     to `buf` and a trailing `'\0'` is always placed at
+ *     `buf[min(size-1, written)]`;
+ *   - if `size == 0`, `buf` may be NULL and no bytes are written;
+ *   - the return value is the number of bytes the full formatted
+ *     output would have produced (excluding the NUL), i.e. the
+ *     length needed by a buffer big enough to hold everything.
+ *     Callers detect truncation with `ret >= size`.
+ *
+ * On error (NULL `fmt`) the return value is negative.
+ *
+ * No floats, no `*`-from-arg width, no positional args — same
+ * scope rules as `vfprintf` (issue #447).
+ */
+int    snprintf(char *buf, size_t size, const char *fmt, ...);
+int    vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
 
 /* `feof` / `ferror`: TinyCC tests these on its source-file reads. */
 int feof(FILE *fp);

--- a/user/libs/clib/src/stdio.c
+++ b/user/libs/clib/src/stdio.c
@@ -534,6 +534,58 @@ int printf(const char *fmt, ...) {
   return r;
 }
 
+/* ---- snprintf / vsnprintf -----------------------------------------------
+ *
+ * Pure-memory format renderers — no FILE, no backend, no syscalls.
+ * Reuses the exact same `do_vfprintf_into` walker as `vfprintf` so
+ * the spec set stays in lock-step (one place to add features, one
+ * place to add bugs).
+ *
+ * C11 §7.21.6.5 (snprintf):
+ *   - if `size > 0`, writes up to `size - 1` formatted bytes to
+ *     `buf` followed by a terminating `'\0'`;
+ *   - if `size == 0`, `buf` may be NULL and no bytes are written;
+ *   - returns the number of bytes the *full* formatted output
+ *     would have required (NUL excluded), so callers can detect
+ *     truncation via `ret >= size`.
+ *
+ * On a NULL `fmt` we return -1 (mirrors `vfprintf`).
+ */
+int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap) {
+  if (fmt == 0) return -1;
+  /* If size == 0 we still need to compute the full length so the
+   * caller can size a buffer. We point the walker at a 1-byte
+   * scratch slot it will overwrite but never read; sink_put tracks
+   * `used` independently of `cap`, so the returned length is the
+   * full requested length. */
+  unsigned char scratch;
+  unsigned char *out;
+  size_t         out_cap;
+  if (size == 0 || buf == 0) {
+    out     = &scratch;
+    out_cap = 0;
+  } else {
+    out     = (unsigned char *)buf;
+    /* Reserve one slot for the trailing NUL. */
+    out_cap = size - 1;
+  }
+  fmt_sink_t sk = { out, out_cap, 0 };
+  int        full_len = do_vfprintf_into(&sk, fmt, ap);
+  if (size > 0 && buf != 0) {
+    size_t nul_at = (sk.used < out_cap) ? sk.used : out_cap;
+    buf[nul_at] = '\0';
+  }
+  return full_len;
+}
+
+int snprintf(char *buf, size_t size, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int r = vsnprintf(buf, size, fmt, ap);
+  va_end(ap);
+  return r;
+}
+
 /* ---- eof / err ----------------------------------------------------------- */
 
 int feof(FILE *fp)   { return (fp != 0 && fp->eof_flag) ? 1 : 0; }


### PR DESCRIPTION
Follow-on to slice 8 (PR #447) — TinyCC (#408) and the `cc` driver app (#409) both need pure-memory format rendering, but the slice-8 surface only shipped the `FILE`-backed `printf`/`fprintf`/`vfprintf` family.

## What ships

- `snprintf` / `vsnprintf` in `user/libs/clib/{include/clib,src}/stdio.h*`
- 5 new sub-check markers in `tests/clib_stdio_test.c`:
  - `snprintf_basic` — full-fits + bytes + NUL
  - `snprintf_truncation` — returns full required length, terminates at `size-1`
  - `snprintf_size_zero_sizing_probe` — `(NULL, 0, fmt, ...)` returns required length
  - `snprintf_exact_fit` — `size == strlen+1`
  - `snprintf_null_fmt_returns_negative` — defensive
  - `vsnprintf_matches_snprintf` — va_list path mirrors variadic
- Symbol-pin update: `tests/data/clib_symbols.expected` + `docs/abi/clib-symbols.md` canonical block + stdio table row in lockstep (the existing `clib_symbol_drift` gate enforces all three move together)
- Test runner grep additions in `build/scripts/test_clib_stdio.sh`

## Implementation note

`vsnprintf` reuses the exact same `do_vfprintf_into` walker as `vfprintf`, so the spec set (`%s %d %i %u %x %p %c %% %ld %li %lu %lx`, optional width, `%0Nd` zero-pad, `%-Ns` left-justify) stays in lock-step with the FILE-backed path. One walker, two output surfaces.

## Semantics (C11 §7.21.6.5 / §7.21.6.13)

- `size > 0` → writes ≤ `size-1` formatted bytes then NUL-terminates
- `size == 0` (`buf` may be NULL) → no writes, full required length returned
- Return value is the full length the output would have required, so callers detect truncation via `ret >= size`
- `NULL` `fmt` → `-1`

## ABI

No `OS_ABI_VERSION` bump. Purely additive userland surface, same containment rules as the rest of the slice-8 family (no `<secureos_api.h>`, no kernel headers, no syscalls).

## Validation

```
build/scripts/test.sh clib_stdio          PASS (16 sub-checks: 9 existing + 7 new)
build/scripts/test.sh clib_symbol_drift   PASS (pin_sorted, doc_matches_pin, libclib_matches_pin, no_undocumented_export)
```

## Follow-ups

- None blocking. The `sprintf` family (no `n` bound) is intentionally NOT shipped — TinyCC and the `cc` driver have no callers that need it, and bounded `snprintf` is the safer-by-default primitive.

Refs: #407, #447, #408, #409
Plan: `plans/2026-05-28-in-os-toolchain-self-hosting.md` (P3)