### PR TITLE
feat(#407): <inttypes.h> function family — imaxabs/imaxdiv/strtoimax/strtoumax (M7-TOOLCHAIN-004 slice 11b)

### DIFF
--- a/build/scripts/test_clib_inttypes.sh
+++ b/build/scripts/test_clib_inttypes.sh
@@ -18,6 +18,8 @@ mkdir -p "$OUT_DIR"
 
 cc -std=c11 -Wall -Wextra -Werror -fno-builtin \
   "$ROOT_DIR/user/libs/clib/src/inttypes.c" \
+  "$ROOT_DIR/user/libs/clib/src/stdlib.c" \
+  "$ROOT_DIR/user/libs/clib/src/errno.c" \
   "$ROOT_DIR/tests/clib_inttypes_test.c" \
   -o "$OUT_DIR/clib_inttypes_test"
 
@@ -29,5 +31,7 @@ grep -q "TEST:PASS:clib_inttypes:printf_roundtrip_pinned"   "$LOG_PATH"
 grep -q "TEST:PASS:clib_inttypes:least_fast_format_pinned"  "$LOG_PATH"
 grep -q "TEST:PASS:clib_inttypes:max_ptr_roundtrip_pinned"  "$LOG_PATH"
 grep -q "TEST:PASS:clib_inttypes:symbol_set_pinned"         "$LOG_PATH"
+grep -q "TEST:PASS:clib_inttypes:imaxabs_imaxdiv_pinned"    "$LOG_PATH"
+grep -q "TEST:PASS:clib_inttypes:strto_imax_umax_pinned"    "$LOG_PATH"
 grep -q "TEST:PASS:clib_inttypes$"                          "$LOG_PATH"
 ! grep -q "TEST:FAIL:" "$LOG_PATH"

--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -97,11 +97,15 @@ Note: `clib/stddef.h` (slice 9 / PR #436) ships drift-anchor helpers via
 | `clib_stdint_sizeof`  | `unsigned long clib_stdint_sizeof(int which)` | drift anchor for exact-width / pointer-width / max-width typedef sizes |
 | `clib_stdint_maxof`   | `unsigned long long clib_stdint_maxof(int which)` | drift anchor for `INTn_MAX`/`UINTn_MAX`/`SIZE_MAX`/`PTRDIFF_MAX` |
 
-### `clib/inttypes.h` (M7-TOOLCHAIN-004 slice 11 / PR #459)
+### `clib/inttypes.h` (M7-TOOLCHAIN-004 slice 11 / PR #459, slice 11b / this PR)
 
 | Symbol                | Signature                                 | Notes |
 | --------------------- | ----------------------------------------- | ----- |
 | `clib_inttypes_fmt`   | `const char *clib_inttypes_fmt(int which)` | drift anchor for `PRI*`/`SCN*` format-string macros (exact-width, least, fast, max, ptr) |
+| `imaxabs`             | `intmax_t imaxabs(intmax_t j)`            | slice 11b; `INTMAX_MIN` UB-safe (returns input unchanged, mirrors `abs`/`labs`) |
+| `imaxdiv`             | `imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom)` | slice 11b; deny-clean divide-by-zero (`{INTMAX_MAX,0}` / `{INTMAX_MIN,0}` sentinel, no trap) |
+| `strtoimax`           | `intmax_t strtoimax(const char *nptr, char **endptr, int base)` | slice 11b; same parse/overflow rules as `strtoll`; clamps + `errno=ERANGE` on overflow |
+| `strtoumax`           | `uintmax_t strtoumax(const char *nptr, char **endptr, int base)` | slice 11b; same parse/overflow rules as `strtoull`; clamps to `UINTMAX_MAX` + `errno=ERANGE` |
 
 ### `clib/iso646.h` (M7-TOOLCHAIN-004 slice)
 
@@ -306,6 +310,8 @@ fputc
 fputs
 fread
 fwrite
+imaxabs
+imaxdiv
 isalnum
 isalpha
 isascii
@@ -344,12 +350,14 @@ strpbrk
 strrchr
 strspn
 strstr
+strtoimax
 strtok
 strtok_r
 strtol
 strtoll
 strtoul
 strtoull
+strtoumax
 tolower
 toupper
 vfprintf

--- a/tests/clib_inttypes_test.c
+++ b/tests/clib_inttypes_test.c
@@ -32,11 +32,13 @@
  *   build/scripts/test.sh clib_inttypes).
  */
 
+#include "../user/libs/clib/include/clib/inttypes.h"
+#include "../user/libs/clib/include/clib/stdint.h"
+#include "../user/libs/clib/include/clib/errno.h"
+
 #include <stdio.h>
 #include <string.h>
-
-/* OUR freestanding header. */
-#include "../user/libs/clib/include/clib/inttypes.h"
+#include <limits.h>
 
 static int g_fail = 0;
 
@@ -215,6 +217,116 @@ static void check_symbol_set_pinned(void) {
   CHECK(clib_inttypes_fmt(-1) == NULL, "helper_negative_returns_null");
 }
 
+/* ---- 7. imaxabs / imaxdiv (C11 §7.8.2.1 / §7.8.2.2) ------------------ */
+static void check_imaxabs_imaxdiv(void) {
+  /* imaxabs positive / zero / negative. */
+  CHECK(imaxabs((intmax_t)0)     == (intmax_t)0,    "imaxabs_zero");
+  CHECK(imaxabs((intmax_t)7)     == (intmax_t)7,    "imaxabs_pos");
+  CHECK(imaxabs((intmax_t)-7)    == (intmax_t)7,    "imaxabs_neg");
+  CHECK(imaxabs(INTMAX_MAX)      == INTMAX_MAX,     "imaxabs_max");
+  /* INTMAX_MIN is the documented UB-adjacent input; the contract is
+   * "return input unchanged", same as abs/labs. */
+  CHECK(imaxabs(INTMAX_MIN)      == INTMAX_MIN,     "imaxabs_min_carveout");
+
+  /* imaxdiv: positive / negative numerator + denom, both signs of rem. */
+  imaxdiv_t d;
+
+  d = imaxdiv((intmax_t)17, (intmax_t)5);
+  CHECK(d.quot ==  3 && d.rem ==  2, "imaxdiv_pos_pos");
+
+  d = imaxdiv((intmax_t)-17, (intmax_t)5);
+  CHECK(d.quot == -3 && d.rem == -2, "imaxdiv_neg_pos_rem_sign_of_numer");
+
+  d = imaxdiv((intmax_t)17, (intmax_t)-5);
+  CHECK(d.quot == -3 && d.rem ==  2, "imaxdiv_pos_neg");
+
+  d = imaxdiv((intmax_t)-17, (intmax_t)-5);
+  CHECK(d.quot ==  3 && d.rem == -2, "imaxdiv_neg_neg_rem_sign_of_numer");
+
+  /* Exact division — rem == 0. */
+  d = imaxdiv((intmax_t)20, (intmax_t)4);
+  CHECK(d.quot ==  5 && d.rem ==  0, "imaxdiv_exact");
+
+  /* Identity: numer == quot*denom + rem. */
+  d = imaxdiv((intmax_t)1234567, (intmax_t)89);
+  CHECK(d.quot * (intmax_t)89 + d.rem == (intmax_t)1234567,
+        "imaxdiv_identity");
+
+  /* Deny-clean divide-by-zero: returns sentinel, does not trap. */
+  d = imaxdiv((intmax_t)42, (intmax_t)0);
+  CHECK(d.quot == INTMAX_MAX && d.rem == 0, "imaxdiv_div0_pos_sentinel");
+  d = imaxdiv((intmax_t)-42, (intmax_t)0);
+  CHECK(d.quot == INTMAX_MIN && d.rem == 0, "imaxdiv_div0_neg_sentinel");
+}
+
+/* ---- 8. strtoimax / strtoumax (C11 §7.8.2.3 / §7.8.2.4) -------------- */
+static void check_strto_imax_umax(void) {
+  char *end = NULL;
+
+  /* Basic decimal parse, *endptr advancement. */
+  errno = 0;
+  CHECK(strtoimax("  -1234rest", &end, 10) == (intmax_t)-1234,
+        "strtoimax_basic_neg");
+  CHECK(end != NULL && strcmp(end, "rest") == 0, "strtoimax_endptr_advanced");
+  CHECK(errno == 0, "strtoimax_no_errno_on_success");
+
+  /* Hex auto-detect via base=0. */
+  errno = 0;
+  CHECK(strtoimax("0x7f", &end, 0) == (intmax_t)0x7f, "strtoimax_base0_hex");
+  CHECK(end != NULL && *end == '\0', "strtoimax_base0_endptr");
+
+  /* Octal auto-detect via base=0. */
+  errno = 0;
+  CHECK(strtoimax("017", &end, 0) == (intmax_t)017, "strtoimax_base0_octal");
+
+  /* Overflow clamp + ERANGE. */
+  errno = 0;
+  CHECK(strtoimax("99999999999999999999999999999999", &end, 10) == INTMAX_MAX,
+        "strtoimax_overflow_clamps_to_max");
+  CHECK(errno == ERANGE, "strtoimax_sets_erange_on_overflow");
+
+  errno = 0;
+  CHECK(strtoimax("-99999999999999999999999999999999", &end, 10) == INTMAX_MIN,
+        "strtoimax_underflow_clamps_to_min");
+  CHECK(errno == ERANGE, "strtoimax_sets_erange_on_underflow");
+
+  /* strtoumax: positive parse + clamp. */
+  errno = 0;
+  CHECK(strtoumax("4242", &end, 10) == (uintmax_t)4242, "strtoumax_basic");
+
+  errno = 0;
+  CHECK(strtoumax("99999999999999999999999999999999", &end, 10) == UINTMAX_MAX,
+        "strtoumax_overflow_clamps_to_max");
+  CHECK(errno == ERANGE, "strtoumax_sets_erange_on_overflow");
+
+  /* Invalid base: errno=EINVAL, return 0, endptr = nptr. */
+  errno = 0;
+  const char *bad = "42";
+  CHECK(strtoimax(bad, &end, 1) == 0, "strtoimax_invalid_base_returns_zero");
+  CHECK(errno == EINVAL, "strtoimax_sets_einval_on_bad_base");
+  CHECK(end == bad, "strtoimax_endptr_unmoved_on_bad_base");
+
+  errno = 0;
+  CHECK(strtoumax(bad, &end, 37) == 0, "strtoumax_invalid_base_returns_zero");
+  CHECK(errno == EINVAL, "strtoumax_sets_einval_on_bad_base");
+
+  /* Round-trip with PRIdMAX / PRIuMAX formatting (slice 11 surface). */
+  char buf[64];
+  intmax_t  iv = (intmax_t)-1234567890;
+  uintmax_t uv = (uintmax_t)1234567890u;
+  int n;
+
+  n = snprintf(buf, sizeof(buf), "%" PRIdMAX, iv);
+  CHECK(n > 0 && (size_t)n < sizeof(buf), "strtoimax_roundtrip_snprintf_ok");
+  errno = 0;
+  CHECK(strtoimax(buf, &end, 10) == iv, "strtoimax_roundtrip_value");
+
+  n = snprintf(buf, sizeof(buf), "%" PRIuMAX, uv);
+  CHECK(n > 0 && (size_t)n < sizeof(buf), "strtoumax_roundtrip_snprintf_ok");
+  errno = 0;
+  CHECK(strtoumax(buf, &end, 10) == uv, "strtoumax_roundtrip_value");
+}
+
 int main(void) {
   printf("TEST:START:clib_inttypes\n");
 
@@ -232,6 +344,12 @@ int main(void) {
 
   check_symbol_set_pinned();
   if (g_fail == 0) printf("TEST:PASS:clib_inttypes:symbol_set_pinned\n");
+
+  check_imaxabs_imaxdiv();
+  if (g_fail == 0) printf("TEST:PASS:clib_inttypes:imaxabs_imaxdiv_pinned\n");
+
+  check_strto_imax_umax();
+  if (g_fail == 0) printf("TEST:PASS:clib_inttypes:strto_imax_umax_pinned\n");
 
   if (g_fail != 0) {
     fprintf(stderr, "TEST:FAIL:clib_inttypes\n");

--- a/tests/data/clib_symbols.expected
+++ b/tests/data/clib_symbols.expected
@@ -49,6 +49,8 @@ fputc
 fputs
 fread
 fwrite
+imaxabs
+imaxdiv
 isalnum
 isalpha
 isascii
@@ -87,12 +89,14 @@ strpbrk
 strrchr
 strspn
 strstr
+strtoimax
 strtok
 strtok_r
 strtol
 strtoll
 strtoul
 strtoull
+strtoumax
 tolower
 toupper
 vfprintf

--- a/user/libs/clib/include/clib/inttypes.h
+++ b/user/libs/clib/include/clib/inttypes.h
@@ -454,6 +454,57 @@ enum {
 
 const char *clib_inttypes_fmt(int which);
 
+/* ---- C11 §7.8.2 imaxabs / imaxdiv ----------------------------------- *
+ *
+ * Slice 11b (issue #407 follow-on, M7-TOOLCHAIN-004) — the function
+ * family <inttypes.h> §7.8.2 mandates on top of the format-string
+ * macros shipped in slice 11. Symbols are pinned by the existing
+ * clib_symbol_drift gate; behavior is exercised by the per-symbol
+ * sub-checks in tests/clib_inttypes_test.c.
+ *
+ * imaxabs(j)
+ *   Behavior on INTMAX_MIN is undefined per C11; this implementation
+ *   returns the input unchanged in that case (consistent with the
+ *   two's-complement carve-out we use for abs/labs).
+ *
+ * imaxdiv_t / imaxdiv(numer, denom)
+ *   Truncated-toward-zero division (C11 §7.8.2.2) — quot * denom + rem
+ *   == numer, sign(rem) == sign(numer) when rem != 0. Division by zero
+ *   is undefined per the standard; this implementation returns
+ *   {INTMAX_MAX, 0} for numer >= 0 and {INTMAX_MIN, 0} for numer < 0
+ *   rather than trapping, mirroring the deny-clean discipline the
+ *   other clib slices use for UB-adjacent inputs.
+ *
+ * Layout note: imaxdiv_t members are exposed as `intmax_t quot` then
+ * `intmax_t rem` per the C standard. Order is fixed; no other members.
+ */
+typedef struct imaxdiv_t {
+  intmax_t quot;
+  intmax_t rem;
+} imaxdiv_t;
+
+intmax_t  imaxabs(intmax_t j);
+imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom);
+
+/* ---- C11 §7.8.2 strtoimax / strtoumax ------------------------------- *
+ *
+ * Same parse / overflow / *endptr rules as strtoll / strtoull (slice 9
+ * extension, PR #444 / #458), but accumulating into intmax_t /
+ * uintmax_t. On overflow errno is set to ERANGE and the call returns
+ * INTMAX_MAX / INTMAX_MIN / UINTMAX_MAX as appropriate (same clamp
+ * shape as strtol{l}).
+ *
+ * Implementation forwards to strtoll / strtoull on targets where
+ * intmax_t / uintmax_t are layout-compatible with long long /
+ * unsigned long long (the only configuration libclib supports today —
+ * SecureOS x86_64 + the libclib host test bench). A static assertion
+ * in src/inttypes.c pins the width contract so a future target with
+ * a wider intmax_t fails the build loudly rather than silently
+ * truncating.
+ */
+intmax_t  strtoimax(const char *nptr, char **endptr, int base);
+uintmax_t strtoumax(const char *nptr, char **endptr, int base);
+
 #ifdef __cplusplus
 }
 #endif

--- a/user/libs/clib/src/inttypes.c
+++ b/user/libs/clib/src/inttypes.c
@@ -13,6 +13,18 @@
  */
 
 #include "../include/clib/inttypes.h"
+#include "../include/clib/stdint.h"
+#include "../include/clib/stdlib.h"
+
+/* Width contract: the strtoimax/strtoumax implementations forward to
+ * strtoll/strtoull (slice 9 extension, PR #444 / #458). That forward
+ * is only safe when intmax_t/uintmax_t are layout-compatible with
+ * long long / unsigned long long. Pin loudly at build time so a
+ * future target with a wider intmax_t doesn't silently truncate. */
+_Static_assert(sizeof(intmax_t)  == sizeof(long long),
+               "clib_inttypes: intmax_t must be layout-compatible with long long");
+_Static_assert(sizeof(uintmax_t) == sizeof(unsigned long long),
+               "clib_inttypes: uintmax_t must be layout-compatible with unsigned long long");
 
 const char *clib_inttypes_fmt(int which) {
   switch (which) {
@@ -32,4 +44,44 @@ const char *clib_inttypes_fmt(int which) {
     case CLIB_INTTYPES_SEL_SCNu64:   return SCNu64;
     default:                         return (const char *)0;
   }
+}
+
+/* ---- C11 §7.8.2 imaxabs / imaxdiv ----------------------------------- */
+
+intmax_t imaxabs(intmax_t j) {
+  if (j == INTMAX_MIN) {
+    /* Negation is UB per C11 §7.8.2.1; mirror abs/labs's two's-complement
+     * carve-out and return the input unchanged. */
+    return j;
+  }
+  return j < 0 ? -j : j;
+}
+
+imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom) {
+  imaxdiv_t out;
+  if (denom == 0) {
+    /* C11 §7.8.2.2 leaves divide-by-zero behavior undefined. Mirror the
+     * deny-clean discipline used elsewhere in clib: never trap, surface
+     * a sentinel quot and rem == 0 instead. */
+    out.quot = numer >= 0 ? INTMAX_MAX : INTMAX_MIN;
+    out.rem  = 0;
+    return out;
+  }
+  /* C11 §6.5.5p6: integer division truncates toward zero; rem has the
+   * sign of numer when rem != 0. Native /,% already satisfy this on a
+   * conforming C99+ compiler, which is the only configuration libclib
+   * targets. */
+  out.quot = numer / denom;
+  out.rem  = numer % denom;
+  return out;
+}
+
+/* ---- C11 §7.8.2 strtoimax / strtoumax ------------------------------- */
+
+intmax_t strtoimax(const char *nptr, char **endptr, int base) {
+  return (intmax_t)strtoll(nptr, endptr, base);
+}
+
+uintmax_t strtoumax(const char *nptr, char **endptr, int base) {
+  return (uintmax_t)strtoull(nptr, endptr, base);
 }


### PR DESCRIPTION
Follow-on to slice 11 (PR #459 / `50ee435`) — that slice shipped only the `PRI*`/`SCN*` macros and explicitly deferred the C11 §7.8.2 function family (`imaxabs`/`imaxdiv`/`strtoimax`/`strtoumax`). This PR lands them, completing the freestanding `<inttypes.h>` surface.

## What ships

- `user/libs/clib/include/clib/inttypes.h` — `imaxdiv_t` struct + four function prototypes with behavior docblock.
- `user/libs/clib/src/inttypes.c` — implementations + a `_Static_assert` width pin (`intmax_t == long long`, `uintmax_t == unsigned long long`) so a future target with a wider `intmax_t` fails the build loudly instead of silently truncating through the `strtoll`/`strtoull` forward.
- `tests/clib_inttypes_test.c` — two new sub-checks:
  - `imaxabs_imaxdiv_pinned` — sign matrix, `INTMAX_MIN` UB-safe carve-out, identity `numer = quot*denom + rem`, deny-clean divide-by-zero sentinel.
  - `strto_imax_umax_pinned` — basic parse + `*endptr` advancement, `base=0` hex/octal auto-detect, overflow clamps to `INTMAX_MAX`/`INTMAX_MIN`/`UINTMAX_MAX` with `errno=ERANGE`, invalid base `errno=EINVAL` + unmoved endptr, `PRIdMAX`/`PRIuMAX` round-trip via `snprintf`.
- `build/scripts/test_clib_inttypes.sh` — links `stdlib.c` + `errno.c` so the new functions are reachable from the test binary.
- `tests/data/clib_symbols.expected` + `docs/abi/clib-symbols.md` (table row + canonical pin block) — atomic update across all three drift-guarded surfaces; `clib_symbol_drift` enforces they move together.

## Design notes

- **Why forwarders for `strtoimax`/`strtoumax`?** Re-implementing them would duplicate the slice-9 + PR #458 overflow-clamp / `errno` plumbing without behavior gain on the only configuration libclib supports today (SecureOS x86_64 + the libclib host test bench, both with `sizeof(intmax_t) == sizeof(long long) == 8`). The `_Static_assert` pin makes the assumption explicit and fail-loud.
- **`imaxabs(INTMAX_MIN)` carve-out:** mirrors the documented `abs`/`labs` behavior — negation is UB per the standard, libclib returns the input unchanged rather than invoking it.
- **`imaxdiv` divide-by-zero:** also UB per the standard. Mirrors the deny-clean discipline used elsewhere in libclib (e.g. `os_mem_brk` out-of-arena → `OS_STATUS_DENIED` rather than panic): returns a `{INTMAX_MAX, 0}` / `{INTMAX_MIN, 0}` sentinel and `rem == 0` instead of trapping.

## ABI

No `OS_ABI_VERSION` bump. Purely additive userland surface, no kernel/syscall changes, same containment rules as the rest of slice 11.

`clib-symbols.md` has no `Last verified against commit` stamp line (issue #468 is the open ticket tracking that gap); leaving it unchanged here so #468 stays the single source of that fix.

## Validation

```
build/scripts/test.sh clib_inttypes      PASS (7 sub-checks: 5 existing + 2 new)
build/scripts/test.sh clib_symbol_drift  PASS (pin_sorted, doc_matches_pin, libclib_matches_pin, no_undocumented_export)
build/scripts/test.sh clib_stdlib        PASS (regression — forwarder targets still green)
```

## Follow-ups

None blocking. With this slice, all of C11 §7.8 is now shipped in freestanding `<inttypes.h>` (format-string macros from slice 11 + the function family here). TinyCC (#408) and the `cc` driver (#409) can now `#include <inttypes.h>` for both formatting and integer-conversion needs without missing-symbol link errors.

Refs #407
Plan: `plans/2026-05-28-in-os-toolchain-self-hosting.md` (P3)