### PR TITLE
fix #482: wire validate_capability_registry + capability_registry_drift into TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -130,6 +130,19 @@ TEST_TARGETS=(
     # in `docs/abi/*.md` does not predate the file's last content
     # commit. Cheap to run, no env deps.
     abi_stamps_drift
+    # Capability-registry contract guards (umbrella #234, issue #482).
+    # `validate_capability_registry` pins the `capability_id_t` enum ↔
+    # `docs/abi/capability-registry.json` bijection, deny-marker shape,
+    # and test-target / owning-plan resolution. `capability_registry_drift`
+    # is the matching negative canary (#213 / #177 shape) that proves the
+    # validator actually fails on a fresh enum entry. Both targets are
+    # green on `main` and dispatched by `build/scripts/test.sh`, but
+    # neither was gating the bundle — same orphan-from-TEST_TARGETS
+    # regression shape #129 / #366 / #384 / #401 / #414 / #469 caught
+    # for other host-side targets. Wire so a regression to the
+    # capability-registry contract flips the bundle to FAIL.
+    validate_capability_registry
+    capability_registry_drift
     # In-OS toolchain Phase 1 (plan
     # plans/2026-05-28-in-os-toolchain-self-hosting.md): host-only check that
     # the /apps/dev developer directory + hello.c sample stage onto the disk


### PR DESCRIPTION
Fixes #482.

## Change

Adds `validate_capability_registry` and `capability_registry_drift` to the
`TEST_TARGETS` array in `build/scripts/validate_bundle.sh`, alongside
the closest semantic neighbours (`abi_stamps_drift`,
`sosh_contract_registry_drift`).

Both targets are already dispatched by `build/scripts/test.sh` and green
on `main`, but neither was gating the bundle — a regression to the
capability-registry contract (#234) would have landed on `main` green.
Same orphan-from-TEST_TARGETS regression shape as #129 / #366 / #384 /
#401 / #414 / #469.

## Validation

```
$ bash build/scripts/test.sh validate_capability_registry
REGISTRY_VALIDATE:START
REGISTRY_VALIDATE:PASS:enum_registry_bijection
REGISTRY_VALIDATE:PASS:test_targets_resolved
REGISTRY_VALIDATE:PASS:deny_marker_shape
REGISTRY_VALIDATE:PASS:owning_plan_resolves
REGISTRY_VALIDATE:DONE

$ bash build/scripts/test.sh capability_registry_drift
TEST:START:capability_registry_drift_canary
TEST:PASS:capability_registry_drift_canary

$ bash build/scripts/validate_bundle.sh   # excerpted
... validator_report.json: both targets listed with status="pass"
```

(The pre-existing QEMU-dependent FAILs in this sandbox — `hello_boot`,
`kernel_console`, etc. — are unrelated environment issues, not regressions
caused by this change.)

## Out of scope

- Touching the validator or canary themselves.
- Wiring other still-orphan host-side targets (e.g. `cap_table_skeleton`,
  `process_table`); file separately if needed.

## Follow-ups

- None.
