### PR TITLE
test(m7_toolchain): retarget heap_isolation SKIP to #410 (refs #410)

### DIFF
--- a/tests/m7_toolchain/README.md
+++ b/tests/m7_toolchain/README.md
@@ -34,7 +34,7 @@ bundle to FAIL (same orphan-from-`TEST_TARGETS` shape #129 / #366 / #384 /
 | `toolchain_unsigned_prompt_enforced`| [#410]       | unsigned-run wiring through the launcher auth flow       |
 | `toolchain_large_output_persisted`  | [#409]       | `cc` emits a >1 KB binary; FS path stays byte-identical  |
 | `toolchain_compile_error_reported`  | [#409]       | `cc` exits non-zero on syntax error with no output file  |
-| `toolchain_heap_isolation`          | [#421]       | kernel `os_mem_brk` + per-process arena reset on teardown|
+| `toolchain_heap_isolation`          | [#410]       | two sequential `cc` runs in one boot don't see each other's arena state (kernel `os_mem_brk` + per-process arena reset shipped in #421 via PR #432/#455 and per-spawn arena clamp via PR #454; remaining gate is `cc` driver #409 + acceptance-suite wiring #410) |
 
 [#409]: https://github.com/rwrife/SecureOS/issues/409
 [#410]: https://github.com/rwrife/SecureOS/issues/410

--- a/tests/m7_toolchain/markers.json
+++ b/tests/m7_toolchain/markers.json
@@ -37,9 +37,9 @@
     },
     {
       "name": "toolchain_heap_isolation",
-      "gatingIssue": 421,
-      "reason": "awaiting_421",
-      "description": "Kernel os_mem_brk syscall + per-process arena reset on teardown."
+      "gatingIssue": 410,
+      "reason": "awaiting_410",
+      "description": "Two sequential `cc` runs in one boot must not see each other's arena state. Kernel half (os_mem_brk + per-process arena reset) landed: syscall + native-bridge slot in #421 via PR #432 (af8ece8), clib_os_brk forwarder via PR #455 (30d6443), launcher per-spawn runtime.arena_bytes enforcement via PR #454 (d6ae05a, closes #448). Remaining gates are the `cc` driver app (#409) that lets us actually invoke `cc` twice in one boot and the unsigned-run/acceptance-suite wiring tracked by #410."
     }
   ]
 }

--- a/tests/m7_toolchain/toolchain_heap_isolation.sh
+++ b/tests/m7_toolchain/toolchain_heap_isolation.sh
@@ -3,12 +3,28 @@
 #
 # SKIP-pinned acceptance stub for the M7-TOOLCHAIN acceptance suite
 # scaffolding (issue #423, umbrella #403). Real assertions land with
-# the gating execute slice (issue #421).
+# the gating execute slice (issue #410 — M7-TOOLCHAIN-007).
 #
 # Plan: plans/2026-05-28-in-os-toolchain-self-hosting.md
-#       (section "Acceptance tests" -> `toolchain_heap_isolation`)
+#       (section "Acceptance tests" -> `toolchain_heap_isolation`).
+#       Intent: "Two sequential `cc` runs in one boot. Assert: the second
+#       run's allocations do not see the first's state (arena reset on
+#       process teardown); no leak panics."
 #
-# Intent: Kernel os_mem_brk syscall + per-process arena reset on teardown.
+# The kernel half this stub originally pointed at (`os_mem_brk` syscall +
+# per-process arena reset on teardown, #421) is now on `main`:
+#   - syscall + native-bridge slot: PR #432 (commit `af8ece8`)
+#   - clib forwarder (`clib_os_brk`): PR #455 (commit `30d6443`)
+#   - launcher per-spawn arena clamp from `runtime.arena_bytes`: PR #454
+#     (commit `d6ae05a`, closes #448)
+#
+# What still blocks a real TEST:PASS here is the same thing that blocks
+# the rest of the m7_toolchain acceptance markers — the `cc` driver app
+# (#409) that lets us actually run "two sequential cc invocations in one
+# boot", plus the unsigned-run wiring (#410) that this stub's umbrella
+# gating execute issue tracks. Retarget the SKIP reason and gating issue
+# to #410 in the same shape PR #456 used for `toolchain_runs_compiled_binary`
+# once its kernel-half (#422) merged.
 #
 # Emits the canonical SKIP marker for the bundle gate, then rolls up a
 # TEST:PASS:<target> so validate_bundle.sh stays green while the gating
@@ -16,5 +32,5 @@
 # stubs (#389/#392) and the M5 cascade audit SKIPs (#344).
 set -euo pipefail
 
-printf 'TEST:SKIP:toolchain_heap_isolation:awaiting_421\n'
+printf 'TEST:SKIP:toolchain_heap_isolation:awaiting_410\n'
 printf 'TEST:PASS:toolchain_heap_isolation\n'


### PR DESCRIPTION
## Summary

The `toolchain_heap_isolation` acceptance marker in `tests/m7_toolchain/` was SKIP-pinned with `awaiting_421` (kernel `os_mem_brk` + per-process arena reset on teardown). All three kernel-side slices of #421 are now on `main`:

- `os_mem_brk` syscall + native-bridge slot — PR #432 (commit `af8ece8`)
- `clib_os_brk` forwarder — PR #455 (commit `30d6443`)
- launcher per-spawn `runtime.arena_bytes` enforcement — PR #454 (commit `d6ae05a`, closes #448)

So the `awaiting_421` pointer references work already on `main`.

The marker is still legitimately SKIP because the *acceptance* ("two sequential `cc` runs in one boot must not see each other's arena state") also needs:
- the `cc` driver app (#409) so we can actually invoke `cc` twice in one boot, and
- the unsigned-run + `m7_toolchain` acceptance-suite wiring (#410) that flips this stub to a real `TEST:PASS`.

#410 is the umbrella execute slice that converts this marker, so retarget the SKIP reason and gating issue to #410 — same shape PR #456 used for `toolchain_runs_compiled_binary` once its kernel half (#422) merged.

## Scope

Harness scaffolding only (issue #423). No production code, no kernel or userland behavior change, no `OS_ABI_VERSION` bump. Mirrors the SKIP-discipline shape established by #344 / #389 / #392 / #456.

- `tests/m7_toolchain/toolchain_heap_isolation.sh`: `awaiting_421` → `awaiting_410` + expanded header comment explaining which kernel-side slices already landed (#421 / PR #432 / #455 / #454) and what #409/#410 still owe.
- `tests/m7_toolchain/markers.json`: `gatingIssue` 421 → 410, `reason` updated, `description` rewritten to record the three merged kernel slices and what's still outstanding.
- `tests/m7_toolchain/README.md`: marker table row updated.

## Validation

```
$ bash build/scripts/test.sh toolchain_heap_isolation
TEST:SKIP:toolchain_heap_isolation:awaiting_410
TEST:PASS:toolchain_heap_isolation
```

`markers.json` round-trips through `json.loads()`. Bundle stays green (target still emits its rolled-up `TEST:PASS:`).

## Follow-ups

Not addressed here — flipping this SKIP to a real `TEST:PASS` is exactly what #410 is for.

Refs #410, #421, #423.