### PR TITLE
fix #485: bump manifest.md stamp to squashed-merge SHA of #465

### DIFF
--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -464,4 +464,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 30d41d6eaae617e56d9f36c7aa0fca51de0761e0
+Last verified against commit: 40836340d47fdf133d1dc44cadbbc8875d90aa8a


### PR DESCRIPTION
## What

Bumps the `Last verified against commit:` stamp in `docs/abi/manifest.md` from `30d41d6eaa…` to `40836340d4…` (the squashed-merge SHA of PR #465).

## Why

`validate_abi_stamps` is FAILing on `main` (HEAD `e9e1b25`):

```
ABI_STAMP:FAIL:docs/abi/manifest.md:stamp=30d41d6eaa:last_content=40836340d4
```

PR #465 stamped with the parent stamp-replacing commit (`30d41d6`), but squash-merged as `40836340`. The validator's content-detector treats the `HEAD`→SHA diff in `40836340` as non-stamp content (`HEAD` doesn't match `STAMP_RE`'s hex requirement), so `40836340` is the `last_content` commit and `30d41d6` (an ancestor) FAILs.

The failure slipped past `main` because `build-and-validate` is PR-only; it surfaced on PR #484's CI (run [26734156369](https://github.com/rwrife/SecureOS/actions/runs/26734156369)) and now blocks every rebased PR. See #485 for the full root-cause writeup.

## Fix

One-line stamp bump. Since this commit's diff is SHA→SHA, the validator classifies it as stamp-only — `40836340` stays as `last_content` and the new stamp matches.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
…
ABI_STAMP:PASS:docs/abi/manifest.md:40836340d4
…
exit=0

$ bash build/scripts/test.sh validate_abi_stamps
… exit 0
```

## Out of scope (follow-ups)

- Hardening the `HEAD`→SHA edge in `tools/validate_abi_stamps.py` so a future placeholder stamp can't recreate this race (separate; #470 strict-mode covers the SKIP arm, not this one).
- Running `build-and-validate` on `push: main` so the next squash-SHA mismatch doesn't silently land.

Fixes #485.