### PR TITLE
fix #487: wire cap_handle_repr/revoke_subject/revoke_subtree + cap_table_skeleton into bundle TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -17,6 +17,20 @@ TEST_TARGETS=(
   cap_api_contract
   capability_table
   capability_gate
+  # M1 substrate cap_handle / cap_table host gates (issue #487): pin
+  # the cap_handle_t representation (#237/#240), the
+  # cap_handle_revoke_subject + process_destroy hook contract (#247),
+  # the cap_handle_revoke_subtree BFS walker + grant_child contract
+  # (#327 / #323), and the cap_table bounds + table-full reject
+  # (#240 area). All pass on main and are wired into test.sh, but were
+  # missing from TEST_TARGETS — same orphan-from-TEST_TARGETS shape
+  # #129 / #366 / #384 / #401 / #414 / #469 / #482 catches for other
+  # host-only gates. cap_handle is the foundation every M2/M3/M4/M5
+  # slice sits on, so a silent drift here is particularly load-bearing.
+  cap_handle_repr
+  cap_handle_revoke_subject
+  cap_handle_revoke_subtree
+  cap_table_skeleton
   capability_audit
   capability_audit_fixture
   capability_audit_log


### PR DESCRIPTION
Closes #487.

## What

Adds four M1-substrate `cap_handle` / `cap_table` host gates to the
`TEST_TARGETS` array in `build/scripts/validate_bundle.sh`:

- `cap_handle_repr`
- `cap_handle_revoke_subject`
- `cap_handle_revoke_subtree`
- `cap_table_skeleton`

All four pass on `main` today, are wired into `build/scripts/test.sh`,
but were missing from the bundle gate — same orphan-from-TEST_TARGETS
shape catalogued by #129 / #366 / #384 / #401 / #414 / #469 / #482.

## Why

`cap_handle` is the foundation every M2/M3/M4/M5 slice sits on. A
silent drift on its representation, on the `process_destroy` revoke
hook, on the BFS subtree walker, or on the `cap_table` table-full
reject path would land green today because the bundle never runs the
targets pinning those contracts.

## Validation

```
$ for t in cap_handle_repr cap_handle_revoke_subject \
           cap_handle_revoke_subtree cap_table_skeleton; do
    grep -E "^\s+${t}\s*$" build/scripts/validate_bundle.sh \
      || echo MISSING:$t
  done
  cap_handle_repr
  cap_handle_revoke_subject
  cap_handle_revoke_subtree
  cap_table_skeleton

$ bash build/scripts/validate_bundle.sh
... (each new target emits TEST:PASS:<name>) ...
VALIDATION_REPORT:artifacts/runs/<run>/validator_report.json
```

All four targets appear in `validator_report.json` `checks[]` with
`status=pass`, `pass=true`. Pre-existing unrelated failures on this
checkout (`hello_boot*`, `kernel_console`, `kernel_filedemo`,
`kernel_persistence`, `validate_abi_stamps`) are independent of this
PR and tracked elsewhere (the stamp one by #485 / PR #486).

## Scope discipline

Four-line list addition. No new test code, no test reshape, no change
to `build/scripts/test.sh` (dispatch arms already exist), no schema or
`OS_ABI_VERSION` change.

## Follow-ups (intentionally not in this PR)

The remaining still-orphan M1/M2/M3/M4/M5 host gates
(`process_table`, `process_find_aspace_by_subject`,
`process_create_table_full_deny_marker`, `session_manager_*`,
`aspace_bounds`, `aspace_carve`, `aspace_invariant`,
`console_svc_port_alloc`, `fs_svc_port_alloc`,
`broker_svc_step3_5_session_teardown`) deserve their own one-line
wire-ups — kept out of this PR to stay scoped, same cadence as
#469 / #482.
