### PR TITLE
ci(bundle): wire broker_svc_step3_5_session_teardown into TEST_TARGETS (M4 substrate host gate, refs #299)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -57,6 +57,13 @@ TEST_TARGETS=(
     broker_svc_port_alloc
     broker_svc_delete_owner_authority_check
     broker_svc_cascade_revokes_minted_handle
+    # `broker_svc_step3_5_session_teardown` is the host-side pin on
+    # step 3.5 of `broker_svc_delete_owner` (session-leg drain); the
+    # M5 WM/session-leg `_qemu` peer below covers the on-target arm,
+    # but the host gate that pins the no-session-owner / table-drain
+    # contract was still orphan from TEST_TARGETS. Same orphan-from-
+    # TEST_TARGETS shape catalogued by #129 / #366 / #384 / #482 / #487.
+    broker_svc_step3_5_session_teardown
     m4_broker_share_allow_qemu
     m4_broker_share_deny_qemu
     m4_broker_share_revoke_qemu


### PR DESCRIPTION
Refs #299 (M4 capability-broker substrate umbrella).

## What

Adds the M4 broker_svc host gate `broker_svc_step3_5_session_teardown`
to the `TEST_TARGETS` array in `build/scripts/validate_bundle.sh`. The
target passes on `main` and is dispatched by `build/scripts/test.sh`,
but was orphan from the bundle gate.

## Why

Step 3.5 of `broker_svc_delete_owner` (session-leg drain) is the
contract that PR #363 added on top of the cap-leg cascade. The M5
WM/session-leg `_qemu` peer (`m5_owner_delete_cascade_window_qemu`,
already in TEST_TARGETS) covers the on-target arm, but the host gate
pinning the no-session-owner / table-drain / multi-session / post-
enumerator-misses / unrelated-subject-isolated / cascade-count
contracts can't be deterministically reached from QEMU. Without this
wire-up a regression in those six host invariants lands green.

Same orphan-from-TEST_TARGETS shape catalogued by #129 / #366 / #384 /
#482 / #487. Continues the #299 M4-substrate wire-up arc PR #366
started.

## Validation

```
$ bash build/scripts/test.sh broker_svc_step3_5_session_teardown
TEST:PASS:broker_svc_step3_5_no_session_owner
TEST:PASS:broker_svc_step3_5_single_session_destroyed
TEST:PASS:broker_svc_step3_5_multiple_sessions_destroyed
TEST:PASS:broker_svc_step3_5_post_enumerator_misses
TEST:PASS:broker_svc_step3_5_unrelated_subject_isolated
TEST:PASS:broker_svc_step3_5_cascade_count_includes_sessions
TEST:PASS:broker_svc_step3_5_session_teardown
```

## Scope discipline

One-line list addition (plus a comment block naming the orphan
class). No new test code, no test reshape, no change to
`build/scripts/test.sh` (dispatch arm already exists), no schema
or `OS_ABI_VERSION` change.

## Follow-ups (intentionally not in this PR)

Remaining still-orphan M1/M2/M3/M4 host gates (`process_table`,
`process_find_aspace_by_subject`,
`process_create_table_full_deny_marker`, `session_manager_first_for_subject`,
`session_manager_subject_for_session`, `aspace_bounds`,
`aspace_carve`, `aspace_invariant`, `console_svc_port_alloc`,
`fs_svc_port_alloc`) all pass locally and deserve their own one-line
wire-ups, kept out of this PR to stay scoped — same cadence as
#469 / #482 / #487.