### PR TITLE
ci(bundle): wire session_manager_first_for_subject + session_manager_subject_for_session into TEST_TARGETS (M4 substrate host gates, refs #299)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -78,6 +78,22 @@ TEST_TARGETS=(
     # contract was still orphan from TEST_TARGETS. Same orphan-from-
     # TEST_TARGETS shape catalogued by #129 / #366 / #384 / #482 / #487.
     broker_svc_step3_5_session_teardown
+    # M4 broker substrate session-manager host gates (umbrella #299,
+    # plan plans/2026-05-25-m4-broker-on-m1-substrate.md). These pin
+    # the broker_svc <-> session_manager bookkeeping that step 3.5 of
+    # `broker_svc_delete_owner` (PR #363, gate `broker_svc_step3_5_session_teardown`
+    # above) drains against: `session_manager_first_for_subject` covers
+    # the no-sessions / single / drain / owner-isolation / null-out
+    # invariants and `session_manager_subject_for_session` covers the
+    # bounds / unused-slot / in-use / null-out / roundtrip invariants.
+    # Both targets pass on `main` and are dispatched by
+    # `build/scripts/test.sh`, but were orphan from the bundle gate --
+    # same orphan-from-TEST_TARGETS shape catalogued by #129 / #366 /
+    # #384 / #482 / #487 / #489. Without these wire-ups a regression
+    # in the session-manager bookkeeping that step 3.5's cascade walks
+    # over would land green on `main`.
+    session_manager_first_for_subject
+    session_manager_subject_for_session
     m4_broker_share_allow_qemu
     m4_broker_share_deny_qemu
     m4_broker_share_revoke_qemu


### PR DESCRIPTION
Refs #299 (M4 capability-broker substrate umbrella).

## What

Adds two M4-substrate `session_manager` host gates to the `TEST_TARGETS`
array in `build/scripts/validate_bundle.sh`:

- `session_manager_first_for_subject` (no_sessions / single / drain /
  owner_isolation / null_out_param)
- `session_manager_subject_for_session` (out_of_range / unused_slot /
  in_use_slot / null_out_param / roundtrip)

Both pass on `main` and are dispatched by `build/scripts/test.sh`, but
were orphan from the bundle gate.

## Why

These pin the `broker_svc` <-> `session_manager` bookkeeping that step
3.5 of `broker_svc_delete_owner` (PR #363, gate
`broker_svc_step3_5_session_teardown` wired by PR #489) drains against:
`session_manager_first_for_subject` is the per-owner enumerator that
the cascade walks, and `session_manager_subject_for_session` is the
reverse mapping that proves slot recycling/owner-isolation invariants.
Without this wire-up a regression to either bookkeeping primitive
would land on `main` green because the bundle never runs them, even
though the dependent step-3.5 cascade does.

Same orphan-from-`TEST_TARGETS` shape catalogued by #129 / #366 / #384 /
#482 / #487 / #489. Continues the #299 M4-substrate wire-up arc.

## Validation

```
$ bash build/scripts/test.sh session_manager_first_for_subject
TEST:PASS:session_manager_first_for_subject:no_sessions
TEST:PASS:session_manager_first_for_subject:single
TEST:PASS:session_manager_first_for_subject:drain
TEST:PASS:session_manager_first_for_subject:owner_isolation
TEST:PASS:session_manager_first_for_subject:null_out_param
TEST:PASS:session_manager_first_for_subject

$ bash build/scripts/test.sh session_manager_subject_for_session
TEST:PASS:session_manager_subject_for_session:out_of_range
TEST:PASS:session_manager_subject_for_session:unused_slot
TEST:PASS:session_manager_subject_for_session:in_use_slot
TEST:PASS:session_manager_subject_for_session:null_out_param
TEST:PASS:session_manager_subject_for_session:roundtrip
TEST:PASS:session_manager_subject_for_session
```

Local `bash build/scripts/validate_bundle.sh` shows both new targets in
`validator_report.json` with `status=pass`. (Local sandbox is missing
`nasm` so `hello_boot*` / `kernel_*` env-gated checks fail unrelated to
this PR — CI has the toolchain container and will run them clean.)

## Scope discipline

Two-line list addition (plus a comment block naming the orphan class
and the #489 step-3.5 link). No new test code, no test reshape, no
change to `build/scripts/test.sh` (dispatch arms already exist), no
schema or `OS_ABI_VERSION` change.

## Follow-ups (intentionally not in this PR)

Remaining still-orphan M1/M2/M3 host gates (`process_table`,
`process_find_aspace_by_subject`,
`process_create_table_full_deny_marker`, `aspace_bounds`,
`aspace_carve`, `aspace_invariant`, `console_svc_port_alloc`,
`fs_svc_port_alloc`) all pass locally and deserve their own one-line
wire-ups, kept out of this PR to stay scoped — same cadence as
#469 / #482 / #487 / #489.