### PR TITLE
ci(bundle): wire process_table / process_find_aspace_by_subject / process_create_table_full_deny_marker into TEST_TARGETS (M1 substrate host gates, refs #299)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -63,6 +63,18 @@ TEST_TARGETS=(
     proc_sched
     m1_ipc_demo
     validate_abi_stamps
+    # M1 substrate process-table host gates (umbrella #299, plan
+    # plans/2026-05-25-m4-broker-on-m1-substrate.md): host-side checks
+    # that pin the `process_*` table contract every M2/M3/M4/M5 slice
+    # rides on. All three pass on `main` and are dispatched by
+    # `build/scripts/test.sh`, but were not yet gating the bundle —
+    # same orphan-from-TEST_TARGETS shape as #129 / #366 / #384 /
+    # #401 / #414 / #469 / #482 / #487 / #489 / #490. A regression in
+    # the process-table bounds, the per-subject aspace finder, or the
+    # table-full deny marker would otherwise land green.
+    process_table
+    process_find_aspace_by_subject
+    process_create_table_full_deny_marker
     # M4 capability-broker substrate (umbrella #299, plan
     # plans/2026-05-25-m4-broker-on-m1-substrate.md): host-side broker_svc
     # checks + the three `_qemu` peers (slices 003/004) are all green on


### PR DESCRIPTION
## Summary

Three M1-substrate process-table host gates pass on `main` and are dispatched by `build/scripts/test.sh`, but were not present in the `TEST_TARGETS` array of `build/scripts/validate_bundle.sh`:

- `process_table` — process table bounds + slot allocation contract
- `process_find_aspace_by_subject` — per-subject aspace finder contract
- `process_create_table_full_deny_marker` — table-full deny marker contract

Same orphan-from-TEST_TARGETS shape as #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490. The `process_*` table contract is the foundation every M2/M3/M4/M5 slice sits on, so a regression here would otherwise land green.

## Scope

Three-line list addition. No new test code, no test reshape, no schema or ABI changes.

## Validation

```
$ bash build/scripts/validate_bundle.sh
... (TEST:PASS for each of the three new targets) ...
$ python3 -c "import json; d=json.load(open('artifacts/runs/.../validator_report.json')); [print(c['name'],c['status']) for c in d['checks'] if c['name'] in ('process_table','process_find_aspace_by_subject','process_create_table_full_deny_marker')]"
process_table pass
process_find_aspace_by_subject pass
process_create_table_full_deny_marker pass
```

## Follow-ups (out of scope)

Remaining orphan M1..M5 host gates still pending one-line wire-ups (intentionally separate PRs to keep scope tight, mirroring the #469/#482/#487/#489/#490 cadence): `aspace_carve` / `aspace_bounds` / `aspace_invariant`, `console_svc_port_alloc`, `fs_svc_port_alloc`.

Refs #299.