### PR TITLE
ci(bundle): wire console_svc_port_alloc + fs_svc_port_alloc into TEST_TARGETS (M2/M3 substrate host gates, refs #299)

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -75,6 +75,20 @@ TEST_TARGETS=(
     process_table
     process_find_aspace_by_subject
     process_create_table_full_deny_marker
+    # M2 console-svc / M3 fs-svc well-known-port allocator host gates
+    # (umbrella #299, plan plans/2026-05-25-m4-broker-on-m1-substrate.md).
+    # Both pin the IPC port_table seeding contract that the boot-order
+    # wiring `ipc_port_table_init -> console_svc_init -> fs_svc_init ->
+    # broker_svc_init -> proc_init` rides on (#272 / #282 / #287). All
+    # four `*_port_alloc_{uninit,init,double_init,reset}` sub-checks
+    # pass on `main` and are dispatched by `build/scripts/test.sh`, but
+    # were not yet gating the bundle -- same orphan-from-TEST_TARGETS
+    # shape as #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 /
+    # #489 / #490 / #491. Wire so a regression in the M2/M3 port
+    # allocator (double-init, reset, or uninit sentinel) flips the
+    # bundle to FAIL instead of landing green on `main`.
+    console_svc_port_alloc
+    fs_svc_port_alloc
     # M4 capability-broker substrate (umbrella #299, plan
     # plans/2026-05-25-m4-broker-on-m1-substrate.md): host-side broker_svc
     # checks + the three `_qemu` peers (slices 003/004) are all green on


### PR DESCRIPTION
Refs #299 (M4-on-M1-substrate umbrella). Follow-up in the same cadence as PRs #488 / #489 / #490 / #491: wire two more orphan host gates from `build/scripts/test.sh` into the bundle `TEST_TARGETS` so the well-known-port allocator contract that the M2/M3/M4 boot-order wiring rides on is actually gating CI.

## Motivation

`build/scripts/test.sh` dispatches `console_svc_port_alloc` and `fs_svc_port_alloc` (each with four sub-checks: `uninit` / `init` / `double_init` / `reset`), both pass on `main`, and both pin the IPC port-table seeding contract on which the documented boot order
`ipc_port_table_init -> console_svc_init -> fs_svc_init -> broker_svc_init -> proc_init` (#272 / #282 / #287) depends. But neither target was in `validate_bundle.sh`'s `TEST_TARGETS` array, so a regression in `console_svc_init` / `fs_svc_init` (double-init, reset, or uninit sentinel) would land green on `main`. Same orphan-from-`TEST_TARGETS` shape catalogued by #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490 / #491.

## Change

Two-line list addition (with grouped comment) to `build/scripts/validate_bundle.sh`. No new test code, no test reshape, no dispatcher change.

## Validation

```
$ bash build/scripts/test.sh console_svc_port_alloc
TEST:PASS:console_svc_port_alloc_uninit
TEST:PASS:console_svc_port_alloc_init
TEST:PASS:console_svc_port_alloc_double_init
TEST:PASS:console_svc_port_alloc_reset
TEST:PASS:console_svc_port_alloc

$ bash build/scripts/test.sh fs_svc_port_alloc
TEST:PASS:fs_svc_port_alloc_uninit
TEST:PASS:fs_svc_port_alloc_init
TEST:PASS:fs_svc_port_alloc_double_init
TEST:PASS:fs_svc_port_alloc_reset
TEST:PASS:fs_svc_port_alloc

$ bash build/scripts/validate_bundle.sh
... validator_report.json checks[] now lists:
    {"name": "console_svc_port_alloc", "status": "pass", ...}
    {"name": "fs_svc_port_alloc",      "status": "pass", ...}
... VALIDATION_FAIL list identical to pre-change baseline (pre-existing
    toolchain / QEMU-dep failures unrelated to this slice).
```

## Done-when

- [x] `grep -E 'console_svc_port_alloc|fs_svc_port_alloc' build/scripts/validate_bundle.sh` shows both targets in the `TEST_TARGETS` array.
- [x] Each target appears in `validator_report.json` `checks[]` with `status=pass`.
- [x] No change to baseline `VALIDATION_FAIL` set.

## Out of scope

Other still-orphan M1 substrate host gates (`aspace_*`, `proc_sched_aspace_invariant`, etc.) -- each is a separate one-line follow-up to keep PRs scoped (mirrors the #469 / #482 / #488..#491 cadence).