### PR TITLE
fix #497: bump clib-symbols.md stamp to squashed-merge SHA of #476

### DIFF
--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -397,4 +397,4 @@ Step 4 is what the bundle gate (`validate_bundle.sh` `TEST_TARGETS`)
 runs in CI, so if you forget any of steps 1-3 the bundle flips to FAIL
 with a descriptive marker pointing at which source disagreed.
 
-Last verified against commit: 60b0f95
+Last verified against commit: 08e4b4fca9d4c4e223656ac943aa784913540458


### PR DESCRIPTION
## Summary

`main` is currently red on `validate_abi_stamps` after #476 squash-merged:

```
ABI_STAMP:FAIL:docs/abi/clib-symbols.md:stamp=60b0f95d3b:last_content=08e4b4fca9
VALIDATION_FAIL:validate_abi_stamps
```

This is the exact same shape as #485 / fix #486 for `manifest.md`: the stamp commit on the PR branch (`60b0f95`) is not the squashed-merge commit (`08e4b4f`), so the validator's content-detector treats `08e4b4f` as `last_content` and the ancestor stamp FAILs.

## Fix

One-line bump of the stamp to the squashed-merge SHA `08e4b4fca9d4c4e223656ac943aa784913540458`. The new commit's diff is SHA→SHA, classified as stamp-only by the validator, so it remains the `last_content` and matches the stamp.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
ABI_STAMP:PASS:docs/abi/clib-symbols.md:08e4b4fca9
```

(The remaining `SKIP` for `capability-deny-contract.md` on main resolves when #477 lands.)

## Impact

Unblocks PR Build Validation on `main` and every open PR (including the oldest open PR #477, which is currently red solely on this preexisting failure).

fix #497