### PR TITLE
docs(abi): stamp capability-deny-contract.md (closes #496, unblocks strict-mode in #470)

### DIFF
--- a/docs/abi/capability-deny-contract.md
+++ b/docs/abi/capability-deny-contract.md
@@ -259,3 +259,5 @@ above are unstable: additive changes (new fields appended after
 `<resource>` with a leading `:`) MAY land; renames or removals require
 bumping `OS_ABI_VERSION`. A grammar change MUST update §4 and §7 in the
 same PR.
+
+Last verified against commit: 7cd9eca241eb1352ad069ac2763ea2ed04279a4d

--- a/docs/abi/capability-deny-contract.md
+++ b/docs/abi/capability-deny-contract.md
@@ -260,4 +260,4 @@ above are unstable: additive changes (new fields appended after
 bumping `OS_ABI_VERSION`. A grammar change MUST update §4 and §7 in the
 same PR.
 
-Last verified against commit: 7cd9eca241eb1352ad069ac2763ea2ed04279a4d
+Last verified against commit: d34f05f4a159d88c13dbd81de5667f34bf84c57b


### PR DESCRIPTION
Closes #496.

## Summary

Adds the canonical `Last verified against commit: <sha>` line to
`docs/abi/capability-deny-contract.md`, the last file under `docs/abi/`
still on the SKIP path in `tools/validate_abi_stamps.py`.

Pattern follows #463 / #467 / #468 / #476 / #478 / #485.

## Why

Per #496, before #470 can flip `no_stamp_line` from SKIP to FAIL in
strict mode, every remaining un-stamped `docs/abi/*.md` needs to carry
the stamp line. This file (the canonical `CAP:DENY:<sid>:<gate>:<resource>`
audit-marker contract) was the only one left, so strict-mode would have
landed red.

## Validation

```
$ python3 tools/validate_abi_stamps.py --root .
ABI_STAMP:FAIL:docs/abi/clib-symbols.md:stamp=08e4b4fca9:last_content=18b317e67f
ABI_STAMP:PASS:docs/abi/README.md:e889994e52
ABI_STAMP:PASS:docs/abi/capabilities.md:ee4426283a
ABI_STAMP:PASS:docs/abi/capability-deny-contract.md:7cd9eca241
ABI_STAMP:PASS:docs/abi/capability-handle.md:609a26216b
ABI_STAMP:PASS:docs/abi/ipc-wire.md:7f303d7e90
ABI_STAMP:PASS:docs/abi/manifest.md:40836340d4
ABI_STAMP:PASS:docs/abi/sosh-capability-contract.md:761a9b257f
ABI_STAMP:PASS:docs/abi/syscalls.md:af8ece8459
ABI_STAMP:PASS:docs/abi/versioning.md:9b2089bbcf
```

- `docs/abi/capability-deny-contract.md` now carries the stamp line (✅ done-when #1).
- Zero `ABI_STAMP:SKIP:<file>:no_stamp_line` markers remain under `docs/abi/` (✅ done-when #2).
- Stamp validator (`build/scripts/validate_abi_stamps.sh`) still runs (✅ done-when #3).
- The pre-existing `clib-symbols.md` FAIL is unrelated to this PR — it's a stale-stamp issue (stamp is older than the most recent content commit) and is out of scope here; it should be addressed by a separate stamp-bump PR mirroring #497.

## Unblocks

- #470 — strict-mode promotion of `no_stamp_line` SKIP → FAIL in `tools/validate_abi_stamps.py`.

## Out of scope

- Flipping strict-mode itself (that's #470).
- Stamps for non-`docs/abi/` documentation.
- Fixing the unrelated stale-stamp FAIL on `docs/abi/clib-symbols.md`.

## Follow-ups

- Once this lands, a follow-up under the #463 / #485 idiom can replace
  the recorded SHA (`7cd9eca`) with the squash-merge SHA if desired,
  though the validator already PASSes today because stamp-only diffs are
  excluded from `last_content_commit` detection.