### PR TITLE
fix(abi): bump clib-symbols.md stamp to squashed-merge SHA of #481 (unblocks build-and-validate on main)

### DIFF
--- a/docs/abi/clib-symbols.md
+++ b/docs/abi/clib-symbols.md
@@ -409,4 +409,4 @@ Step 4 is what the bundle gate (`validate_bundle.sh` `TEST_TARGETS`)
 runs in CI, so if you forget any of steps 1-3 the bundle flips to FAIL
 with a descriptive marker pointing at which source disagreed.
 
-Last verified against commit: 08e4b4fca9d4c4e223656ac943aa784913540458
+Last verified against commit: 18b317e67f8b81bd0b3e5f9b44c5b589d51d4d79


### PR DESCRIPTION
## Summary

`validate_abi_stamps` is currently FAILing on `main` and on every open PR's `build-and-validate` job:

```
ABI_STAMP:FAIL:docs/abi/clib-symbols.md:stamp=08e4b4fca9:last_content=18b317e67f
```

Root cause: PR #481 (`feat(#407): <inttypes.h> function family … slice 11b`, squashed as `18b317e`) modified `docs/abi/clib-symbols.md` (added the new function table row and updated the canonical pin block to satisfy `clib_symbol_drift`) without bumping the `Last verified against commit` stamp. The PR body explicitly noted this and deferred the stamp bump to the issue-#468 track.

## Fix

Single-line stamp bump:

```
-Last verified against commit: 08e4b4fca9d4c4e223656ac943aa784913540458
+Last verified against commit: 18b317e67f8b81bd0b3e5f9b44c5b589d51d4d79
```

Same shape as the previously-merged unblockers:
- #498 (bumped to #476 squash SHA)
- #486 (bumped manifest.md to #465 squash SHA)
- #466 (bumped README.md)

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
ABI_STAMP:PASS:docs/abi/clib-symbols.md:18b317e67f
…all 9 stamps PASS
```

## Discipline

- Pure docs/stamp bump. No code, no schema, no `OS_ABI_VERSION` bump.
- Stamp-only diff (one line) so the validator's walk-past-stamp rule applies — no prep-commit needed.
- Unblocks: #477, #484, #488, #491, #492, #499 and any future PR.

Filed by the secureos-hourly-pr-review cron while driving #477 toward merge.