### PR TITLE
fix #503: wire aspace_carve/bounds/invariant + proc_sched_aspace_invariant into bundle TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -31,6 +31,21 @@ TEST_TARGETS=(
   cap_handle_revoke_subject
   cap_handle_revoke_subtree
   cap_table_skeleton
+  # M1 substrate address-space host gates (issue #503): pin the
+  # flat-with-bounds address_space_t + .proc_arena carve-out (#248 /
+  # PR #249), per-aspace bounds enforcement, aspace structural
+  # invariant, and the scheduler<->aspace invariant (#250 area). All
+  # pass on main and are wired into test.sh, but were missing from
+  # TEST_TARGETS — same orphan-from-TEST_TARGETS shape #129 / #366 /
+  # #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490 / #491 /
+  # #492 catches for other host-only gates. The aspace layer is the
+  # foundation every M2/M3/M4/M5/M7 slice mounts onto (every
+  # process's arena window, every brk syscall, every launcher
+  # spawn), so a silent drift here is particularly load-bearing.
+  aspace_carve
+  aspace_bounds
+  aspace_invariant
+  proc_sched_aspace_invariant
   capability_audit
   capability_audit_fixture
   capability_audit_log


### PR DESCRIPTION
Closes #503.

## What landed

Added four M1-substrate address-space host gates to the \`TEST_TARGETS\` array in \`build/scripts/validate_bundle.sh\`:

- \`aspace_carve\` — flat-with-bounds \`address_space_t\` + \`.proc_arena\` carve-out (#248 / PR #249)
- \`aspace_bounds\` — per-aspace bounds enforcement
- \`aspace_invariant\` — aspace structural invariant
- \`proc_sched_aspace_invariant\` — scheduler↔aspace invariant pin (#250 area)

Grouped with the existing M1-substrate host gates (\`capability_table\`, \`capability_gate\`, \`cap_handle_*\`) and annotated with the same orphan-from-TEST_TARGETS comment lineage (#129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490 / #491 / #492) the other recent wire-ups use.

## Why now

These four targets pass on \`main\` and are wired into \`build/scripts/test.sh\`, but were not gating the bundle. The aspace layer is the foundation every M2/M3/M4/M5/M7 slice mounts onto (every process's arena window, every \`os_mem_brk\` syscall, every launcher spawn) — silent drift here would be particularly load-bearing.

Same one-line cadence as merged #489 and in-flight #488 / #490 / #491 / #492.

## Validation

\`\`\`
$ for t in aspace_carve aspace_bounds aspace_invariant proc_sched_aspace_invariant; do
    grep -qE "^\s+${t}\s*$" build/scripts/validate_bundle.sh && echo "WIRED:$t" || echo "MISSING:$t"
  done
WIRED:aspace_carve
WIRED:aspace_bounds
WIRED:aspace_invariant
WIRED:proc_sched_aspace_invariant

$ bash build/scripts/validate_bundle.sh 2>&1 | grep -E "TEST:PASS:(aspace_|proc_sched_aspace_)" | sort -u
TEST:PASS:aspace_bounds
TEST:PASS:aspace_bounds_allow
TEST:PASS:aspace_bounds_deny
TEST:PASS:aspace_bounds_null_aspace
TEST:PASS:aspace_bounds_overflow
TEST:PASS:aspace_bounds_straddle
TEST:PASS:aspace_carve
TEST:PASS:aspace_carve_arena_too_small
TEST:PASS:aspace_carve_invalid_arg
TEST:PASS:aspace_carve_min_window_bytes
TEST:PASS:aspace_carve_partition_layout
TEST:PASS:aspace_invariant
TEST:PASS:aspace_invariant_allow_no_scratch
TEST:PASS:aspace_invariant_allow_partitioned
TEST:PASS:aspace_invariant_deny_layout
TEST:PASS:aspace_invariant_deny_scratch_escapes
TEST:PASS:proc_sched_aspace_invariant
TEST:PASS:proc_sched_aspace_invariant_clean
TEST:PASS:proc_sched_aspace_invariant_null_aspace
TEST:PASS:proc_sched_aspace_invariant_stack_escape
\`\`\`

Bundle exit status / pre-existing \`VALIDATION_FAIL\` set is unchanged from bare \`main\` in this environment (the failing entries — \`hello_boot\`, \`hello_boot_negative\`, \`harness_negative\`, \`kernel_console\`, \`kernel_filedemo\`, \`kernel_persistence\`, \`validate_abi_stamps\` — are QEMU/environment + the known #470 stamp situation, unrelated to this four-line wire-up).

## Scope discipline (non-conflicting with in-flight PRs)

- No change to \`build/scripts/test.sh\` (dispatch arms already exist).
- No change to any test source, schema, ABI, or \`OS_ABI_VERSION\`.
- Does not touch the files modified by in-flight #488 (cap_handle bundle wire), #490 (session_manager), #491 (process_table), #492 (console_svc / fs_svc) beyond shared insertion neighborhood; will rebase cleanly if any of those land first.

## Follow-ups (not in this PR)

The remaining still-orphan M1-M5 host gates flagged in #487's "Out of scope" list (the \`session_manager_*\`, \`process_table\` group, \`console_svc_port_alloc\` / \`fs_svc_port_alloc\`) are intentionally deferred to their own one-line follow-ups — same cadence as #469 / #482 / #489.