### PR TITLE
fix(abi): bump capability-deny-contract.md stamp to 9349706 (#499 squash SHA)

### DIFF
--- a/docs/abi/capability-deny-contract.md
+++ b/docs/abi/capability-deny-contract.md
@@ -260,4 +260,4 @@ above are unstable: additive changes (new fields appended after
 bumping `OS_ABI_VERSION`. A grammar change MUST update §4 and §7 in the
 same PR.
 
-Last verified against commit: d34f05f4a159d88c13dbd81de5667f34bf84c57b
+Last verified against commit: 9349706d49eb81a08f2b480d9b803d18fc9ebca8


### PR DESCRIPTION
PR #499 (squashed as `9349706`) stamped `docs/abi/capability-deny-contract.md` to its own pre-squash branch SHA (`d34f05f4...`), so `validate_abi_stamps` now FAILs on main with:

```
ABI_STAMP:FAIL:docs/abi/capability-deny-contract.md:stamp=d34f05f4a1:last_content=ec2b24f37d
```

Same self-referential post-squash chicken-and-egg that #498, #500, and #486 fixed for `clib-symbols.md` / `manifest.md`. Bump the stamp to the actual squash-merge SHA on main (`9349706`).

This unblocks `build-and-validate` for #479 (strict-mode flag) and every other currently-open PR that runs the ABI stamps gate.

## Validation

```
bash build/scripts/validate_abi_stamps.sh
-> ABI_STAMP:PASS:docs/abi/capability-deny-contract.md:9349706d49
```

Stamp-only diff, no code, no `OS_ABI_VERSION` bump.