### PR TITLE
fix #508: workflow_rule capability_is_known() switch + bundle wire-up

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -259,6 +259,19 @@ TEST_TARGETS=(
     # reserved-flag / bad-arg early-reject contract flips the
     # bundle to FAIL.
     process_spawn_wrapper
+    # Issue #508: kernel-side capability workflow-rule layer (PR #209,
+    # closes #77). Host-side dispatcher exists and is documented in the
+    # test.sh usage banner, but was never added to TEST_TARGETS, so a
+    # `-Werror=switch` regression in `kernel/cap/workflow_rule.c`'s
+    # `capability_is_known()` allow-list slid in unnoticed when #348
+    # (CAP_GFX_FRAMEBUFFER / CAP_INPUT_{KEYBOARD,MOUSE}) and
+    # CAP_CLOCK_SET appended new `capability_id_t` slots. Same
+    # orphan-from-TEST_TARGETS shape catalogued by #129 / #366 / #384 /
+    # #401 / #414 / #469 / #482 / #487 / #489 / #490 / #491 / #492 /
+    # #503 -- wiring here ensures the next cap-id addition flips the
+    # bundle if the allow-list (or the deferred-cap fall-through arm)
+    # is not updated in the same PR.
+    workflow_rule
     # M7-TOOLCHAIN-004 slice 3 (issue #407): freestanding `qsort` in
     # `user/libs/clib`. Same parity shape as the str/mem slice (PR
     # #416) and the ctype slice (PR #417) — userland-only, no syscall

--- a/kernel/cap/workflow_rule.c
+++ b/kernel/cap/workflow_rule.c
@@ -74,6 +74,19 @@ static int reason_is_valid(workflow_reason_t reason) {
 }
 
 static int capability_is_known(capability_id_t cap) {
+  /*
+   * Allow-list of capability ids that have defined workflow-rule
+   * semantics. New `capability_id_t` slots MUST be added here (even
+   * when no workflow consumer is wired yet) so that `-Werror=switch`
+   * keeps `capability_is_known()` exhaustive — see issue #508.
+   *
+   * Caps that exist for the deny-marker / registry contract but do
+   * not (yet) have workflow-rule meaning are listed under the
+   * fall-through `return 0` arm. They round-trip cleanly through
+   * `workflow_rule_add()` input validation (rejected as
+   * WORKFLOW_RULE_ERR_INVALID_INPUT) until a workflow consumer
+   * promotes them into the allow-list above.
+   */
   switch (cap) {
     case CAP_CONSOLE_WRITE:
     case CAP_SERIAL_WRITE:
@@ -91,6 +104,16 @@ static int capability_is_known(capability_id_t cap) {
     case CAP_IPC_RECV:
     case CAP_SYSCALL:
       return 1;
+    /*
+     * Registered-but-not-yet-workflow-scoped caps. Listed explicitly
+     * to satisfy `-Werror=switch` and document the gap. Promote to
+     * the allow-list above when a workflow consumer needs them.
+     */
+    case CAP_CLOCK_SET:        /* registry slot 16 */
+    case CAP_INPUT_MOUSE:      /* registry slot 17 (refs #348) */
+    case CAP_GFX_FRAMEBUFFER:  /* registry slot 18 (refs #348) */
+    case CAP_INPUT_KEYBOARD:   /* registry slot 19 (refs #348) */
+      return 0;
   }
   return 0;
 }

--- a/tests/workflow_rule_test.c
+++ b/tests/workflow_rule_test.c
@@ -194,6 +194,40 @@ int main(void) {
                              WORKFLOW_REASON_TENANT_POLICY),
       WORKFLOW_ERR_CAPABILITY_INVALID,
       "register_rejects_unknown_capability");
+  /*
+   * Regression pin for issue #508: caps registered after the original
+   * workflow_rule_register() allow-list (CAP_CLOCK_SET / CAP_INPUT_*
+   * / CAP_GFX_FRAMEBUFFER, added by #348 et al.) are intentionally
+   * not yet workflow-rule-scoped and MUST round-trip through input
+   * validation as WORKFLOW_ERR_CAPABILITY_INVALID rather than silently
+   * succeeding. Promote per-cap into the allow-list above (in
+   * `kernel/cap/workflow_rule.c::capability_is_known`) once a
+   * workflow consumer actually wires them in.
+   */
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_CLOCK_SET,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_CAPABILITY_INVALID,
+      "register_rejects_cap_clock_set_until_workflow_scoped");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_GFX_FRAMEBUFFER,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_CAPABILITY_INVALID,
+      "register_rejects_cap_gfx_framebuffer_until_workflow_scoped");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_INPUT_KEYBOARD,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_CAPABILITY_INVALID,
+      "register_rejects_cap_input_keyboard_until_workflow_scoped");
+  expect_result(
+      workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
+                             1u, CAP_INPUT_MOUSE,
+                             WORKFLOW_REASON_TENANT_POLICY),
+      WORKFLOW_ERR_CAPABILITY_INVALID,
+      "register_rejects_cap_input_mouse_until_workflow_scoped");
   expect_result(
       workflow_rule_register(1u, 1u, WORKFLOW_SCOPE_READ,
                              1u, CAP_FS_READ, WORKFLOW_REASON_NONE),


### PR DESCRIPTION
Fixes #508.

## What

`kernel/cap/workflow_rule.c::capability_is_known()` was authored against the
M1 cap-id set (#77 / PR #209) and never updated when `CAP_CLOCK_SET`,
`CAP_INPUT_MOUSE`, `CAP_GFX_FRAMEBUFFER`, and `CAP_INPUT_KEYBOARD` were
appended to `capability_id_t` (the input/gfx trio via PR #352 closing #348).
Under `-Werror=switch`, `bash build/scripts/test.sh workflow_rule` fails to
compile on `main` @ `69c2c30`:

```
kernel/cap/workflow_rule.c:77:3: error: enumeration value 'CAP_CLOCK_SET' not handled in switch [-Werror=switch]
kernel/cap/workflow_rule.c:77:3: error: enumeration value 'CAP_INPUT_MOUSE' not handled in switch [-Werror=switch]
kernel/cap/workflow_rule.c:77:3: error: enumeration value 'CAP_GFX_FRAMEBUFFER' not handled in switch [-Werror=switch]
kernel/cap/workflow_rule.c:77:3: error: enumeration value 'CAP_INPUT_KEYBOARD' not handled in switch [-Werror=switch]
```

CI never noticed because the target was orphaned from
`build/scripts/validate_bundle.sh` `TEST_TARGETS` — same shape as #129 /
#366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490 / #491 / #492 /
#503.

## Changes

- `kernel/cap/workflow_rule.c` — `capability_is_known()` switch now lists
  every `capability_id_t` value. Currently-unscoped caps (CAP_CLOCK_SET /
  CAP_INPUT_* / CAP_GFX_FRAMEBUFFER) land in an explicit `return 0` arm so
  `workflow_rule_register()` continues to reject them as
  `WORKFLOW_ERR_CAPABILITY_INVALID` until a workflow consumer promotes them.
  Header comment documents the contract for the next cap-id append PR.
- `tests/workflow_rule_test.c` — extends `workflow_rule_input_validation`
  with explicit regression pins (`register_rejects_cap_clock_set_*`,
  `..._gfx_framebuffer_*`, `..._input_keyboard_*`, `..._input_mouse_*`) so
  silent promotion of a cap into the allow-list without an accompanying
  semantic decision flips the test.
- `build/scripts/validate_bundle.sh` — adds `workflow_rule` to
  `TEST_TARGETS` next to `process_spawn_wrapper`, with a comment naming the
  orphan-from-TEST_TARGETS pattern.

## Done-when status

- [x] `capability_is_known()` covers every `capability_id_t` value
- [x] `bash build/scripts/test.sh workflow_rule` compiles and emits every
  expected `TEST:PASS:*` + `TEST:DONE:workflow_rule`
- [x] `workflow_rule` wired into `build/scripts/validate_bundle.sh`
  `TEST_TARGETS`
- [x] No `OS_ABI_VERSION` bump

## Validation

```
$ bash build/scripts/test.sh workflow_rule
TEST:PASS:workflow_rule_allow_path
TEST:PASS:workflow_rule_cross_tenant_deny
TEST:PASS:workflow_rule_scope_mismatch_deny
TEST:PASS:workflow_rule_audit_non_interference
TEST:PASS:workflow_rule_input_validation
TEST:PASS:workflow_rule_capacity
TEST:PASS:workflow_rule_audit_format
TEST:DONE:workflow_rule

$ bash build/scripts/validate_bundle.sh
# workflow_rule recorded as 'pass' in validator_report.json (targets+checks)
```

Local-only failures (hello_boot / kernel_*) require `nasm` + QEMU not
available in this sandbox; identical on `main`.

## Follow-ups

- Per-cap workflow-rule semantics for `CAP_CLOCK_SET` / `CAP_INPUT_*` /
  `CAP_GFX_FRAMEBUFFER` are intentionally out of scope — promote each into
  the `return 1` arm and drop the matching regression pin when an actual
  workflow consumer wires them in.

Refs #508
