### PR TITLE
fix #512: wire 6 launcher_* host gates into bundle TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -104,6 +104,28 @@ TEST_TARGETS=(
     # bundle to FAIL instead of landing green on `main`.
     console_svc_port_alloc
     fs_svc_port_alloc
+    # Launcher host gates (issue #512): the launcher is the single
+    # trust-boundary every M2/M3/M4/M5/M7 slice mounts onto (console,
+    # fs, broker, spawn handoff, HAL callsite migration, arena clamp).
+    # All six host tests pass on main and are dispatched by
+    # build/scripts/test.sh, but were orphan from TEST_TARGETS so a
+    # regression in launcher revoke-restores-deny / invalid-app /
+    # reset-clears-state (launcher_console), fs bypass-unregistered-
+    # denied / invalid-inputs (launcher_fs), spawn-handoff destroy /
+    # invalid-manifest (launcher_spawn_handoff), console-video HAL
+    # callsite allow/deny-drops-silently (launcher_hal_callsite_migration),
+    # broker spawn handoff gate + revoke-on-destroy
+    # (launcher_broker_spawn_handoff), or fs spawn handoff read/write +
+    # revoke-on-destroy (launcher_fs_spawn_handoff) would otherwise land
+    # green. Same orphan-from-TEST_TARGETS shape as
+    # #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 /
+    # #490 / #491 / #492 / #503.
+    launcher_console
+    launcher_fs
+    launcher_spawn_handoff
+    launcher_hal_callsite_migration
+    launcher_broker_spawn_handoff
+    launcher_fs_spawn_handoff
     # M4 capability-broker substrate (umbrella #299, plan
     # plans/2026-05-25-m4-broker-on-m1-substrate.md): host-side broker_svc
     # checks + the three `_qemu` peers (slices 003/004) are all green on


### PR DESCRIPTION
Closes #512.

## What

Wires six launcher host gates into `build/scripts/validate_bundle.sh`
`TEST_TARGETS`:

- `launcher_console`
- `launcher_fs`
- `launcher_spawn_handoff`
- `launcher_hal_callsite_migration`
- `launcher_broker_spawn_handoff`
- `launcher_fs_spawn_handoff`

All six pass on `main` and are dispatched by `build/scripts/test.sh`, but
were orphan from `TEST_TARGETS` — so a regression in launcher
revoke-restores-deny / invalid-app / reset-clears-state, fs
bypass-unregistered-denied / invalid-inputs, spawn-handoff destroy /
invalid-manifest, console-video HAL callsite allow/deny-drops-silently,
broker spawn handoff gate + revoke-on-destroy, or fs spawn handoff
read/write + revoke-on-destroy would otherwise land green.

The launcher is the single trust-boundary every M2/M3/M4/M5/M7 slice
mounts onto (console, fs, broker, spawn handoff, HAL callsite migration,
arena clamp), so silent drift here is particularly load-bearing.

## Why

Same orphan-from-`TEST_TARGETS` regression shape catalogued by
#129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 / #490 /
#491 / #492 / #503.

## Scope

Six-line list addition under a comment block citing the orphan lineage.
No new test code, no dispatch-arm change, no test reshape, no ABI churn.

## Validation

```
$ for t in launcher_console launcher_fs launcher_spawn_handoff \
           launcher_hal_callsite_migration launcher_broker_spawn_handoff \
           launcher_fs_spawn_handoff; do
    grep -qE "^\s+${t}\s*$" build/scripts/validate_bundle.sh && echo "WIRED:$t"
  done
WIRED:launcher_console
WIRED:launcher_fs
WIRED:launcher_spawn_handoff
WIRED:launcher_hal_callsite_migration
WIRED:launcher_broker_spawn_handoff
WIRED:launcher_fs_spawn_handoff

$ bash build/scripts/validate_bundle.sh
# … exits 0; VALIDATION_FAIL baseline unchanged
# (hello_boot/hello_boot_negative/harness_negative/kernel_console/
#  kernel_filedemo/kernel_persistence — same as on main in this sandbox,
#  unrelated to this change; CI environment has the missing deps.)

$ jq '.checks[] | select(.name|test("^launcher_(console|fs|spawn_handoff|hal_callsite_migration|broker_spawn_handoff|fs_spawn_handoff)$")) | {name,status}' \
    artifacts/runs/*/validator_report.json
{"name":"launcher_console","status":"pass"}
{"name":"launcher_fs","status":"pass"}
{"name":"launcher_spawn_handoff","status":"pass"}
{"name":"launcher_hal_callsite_migration","status":"pass"}
{"name":"launcher_broker_spawn_handoff","status":"pass"}
{"name":"launcher_fs_spawn_handoff","status":"pass"}
```

## ABI

No `OS_ABI_VERSION` change. CI-config only.

## Follow-ups

Still-orphan host gates flagged across the #299 / #487 arc not covered
by this PR or the #488 / #489 / #490 / #491 / #492 / #504 chain remain
as separate one-line follow-ups to keep PRs scoped.
