### PR TITLE
fix #514: wire syscall_entry_stub/ipc_bounds/netlib_url_scheme/harness_defense into bundle TEST_TARGETS

### DIFF
--- a/build/scripts/validate_bundle.sh
+++ b/build/scripts/validate_bundle.sh
@@ -521,6 +521,27 @@ TEST_TARGETS=(
     # the pin OR doc trips the bundle before TinyCC (#408) starts
     # linking against the same symbols.
     clib_symbol_drift
+
+    # Issue #514: four substrate-level host gates that were dispatched by
+    # build/scripts/test.sh but orphan-from-TEST_TARGETS (same shape as
+    # #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 / #489 /
+    # #490 / #491 / #492 / #503 / #512). All four are load-bearing:
+    #   - syscall_entry_stub: M1 syscall ABI anchor + deny-marker shape
+    #     (originally #232) — every M2/M3/M4/M5/M7 syscall test rides on
+    #     this contract.
+    #   - ipc_bounds: kernel IPC payload-bounds allow + one-past-end +
+    #     straddle + no-pcb skipped (every capability check + spawn
+    #     handoff path rides this).
+    #   - netlib_url_scheme: zero-trust network ABI URL-scheme allow/deny
+    #     contract — sole host gate for the netlib surface today.
+    #   - harness_defense: meta-canary that defends the bundle harness
+    #     itself against silent no-ops (the original #91 motivation; the
+    #     reason every other orphan-from-TEST_TARGETS issue in this chain
+    #     can be caught at all).
+    syscall_entry_stub
+    ipc_bounds
+    netlib_url_scheme
+    harness_defense
 )
 # NOTE: ed25519, cert_chain, codesign, and kernel_sessions are intentionally
 # NOT in TEST_TARGETS yet — see issue #129. They are wired into test.sh /


### PR DESCRIPTION
Closes #514.

## What

Adds four substrate-level host gates to the `TEST_TARGETS` array in
`build/scripts/validate_bundle.sh`:

- `syscall_entry_stub`
- `ipc_bounds`
- `netlib_url_scheme`
- `harness_defense`

All four were already dispatched by `build/scripts/test.sh` and passing on
`main`, but orphaned from the bundle gate — the same regression shape
catalogued by #129 / #366 / #384 / #401 / #414 / #469 / #482 / #487 /
#489 / #490 / #491 / #492 / #503 / #512.

## Why each is load-bearing

- **`syscall_entry_stub`** — M1 syscall ABI anchor + invalid-msg sweep +
  deny-marker shape (originally #232). Every M2/M3/M4/M5/M7 syscall test
  rides on this contract.
- **`ipc_bounds`** — kernel IPC payload-bounds: allow + one-past-end +
  straddle + no-pcb skipped. Every capability check + spawn handoff path
  depends on this.
- **`netlib_url_scheme`** — zero-trust network ABI URL-scheme allow/deny;
  sole host gate for the netlib surface today.
- **`harness_defense`** — meta-canary defending the bundle harness itself
  against silent no-ops (the original #91 motivation; the reason every
  other orphan-from-`TEST_TARGETS` regression in this chain is catchable).

## Scope

Single-file, list-only change. No test code touched. No new ABI surface,
no `OS_ABI_VERSION` bump.

## Validation

All four targets pass locally on the branch:

```
$ for t in syscall_entry_stub ipc_bounds netlib_url_scheme harness_defense; do
    bash build/scripts/test.sh "$t" >/dev/null && echo PASS:$t
  done
PASS:syscall_entry_stub
PASS:ipc_bounds
PASS:netlib_url_scheme
PASS:harness_defense
```

## Out of scope

- `ed25519`, `cert_chain`, `codesign`, `kernel_sessions` — explicitly
  excluded by the existing `# NOTE:` block in `validate_bundle.sh`
  (policy flip tracked separately under the #129 lineage; some pass
  locally now but the comment-block policy is a separate decision).
- Any remaining orphan host gates surfaced by the #299 / #487 follow-up
  chain — kept as separate one-line follow-ups to preserve the small-PR
  shape of this lineage (#491 / #492 / #503 / #512 etc.).

## Follow-ups

None for this slice. The orphan-from-`TEST_TARGETS` audit lineage
continues under the umbrella of #299.
