### PR TITLE
docs(abi): post-merge stamp bump versioning.md -> d60775d (follow-up to #479)

### DIFF
--- a/docs/abi/versioning.md
+++ b/docs/abi/versioning.md
@@ -124,4 +124,4 @@ implicit default) once the four pre-existing `no_stamp_line` SKIP files
 `docs/abi/capability-deny-contract.md` PR #477,
 `docs/abi/sosh-capability-contract.md` PR #478) all carry stamps.
 
-Last verified against commit: 28a4633
+Last verified against commit: d60775d


### PR DESCRIPTION
Resolves the self-referential ABI_STAMP:FAIL on `docs/abi/versioning.md` left behind by the #479 squash-merge (commit `d60775d`). Same pattern as #498/#500/#506.

Local validation:
```
bash build/scripts/validate_abi_stamps.sh   -> all 10 docs PASS
bash build/scripts/test.sh abi_stamps_strict_no_skip -> TEST:PASS
```

Refs #470.