### PR TITLE
ci: checkout submodules in CI workflows (fix #520)

### DIFF
--- a/.github/workflows/iso-vm-build.yml
+++ b/.github/workflows/iso-vm-build.yml
@@ -19,13 +19,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Init submodules so vendor/tinycc/tinycc and
-          # vendor/bearssl/BearSSL sources are present. Pre-emptive
-          # for #408 Phase 3 (TinyCC freestanding port reads under
-          # vendor/tinycc/tinycc/); BearSSL already builds via its
-          # Makefile.secureos shim. Refs #520.
-          submodules: recursive
+
+      - name: Init submodules (full-depth)
+        # NOTE: we deliberately do NOT use `submodules: recursive` on
+        # actions/checkout@v4 here. checkout@v4 inits submodules with
+        # `--depth=1`, which fails against vendor/bearssl/BearSSL because
+        # the upstream git server at bearssl.org only advertises tip,
+        # not arbitrary commits ("Server does not allow request for
+        # unadvertised object ..."). A plain `git submodule update`
+        # does a full clone and resolves the pinned SHA cleanly.
+        # Pre-emptive for #408 Phase 3 (TinyCC freestanding port reads
+        # under vendor/tinycc/tinycc/); BearSSL already builds via its
+        # Makefile.secureos shim. Refs #520.
+        run: git submodule update --init --recursive
 
       - name: Ensure build scripts are executable
         run: |

--- a/.github/workflows/iso-vm-build.yml
+++ b/.github/workflows/iso-vm-build.yml
@@ -19,6 +19,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Init submodules so vendor/tinycc/tinycc and
+          # vendor/bearssl/BearSSL sources are present. Pre-emptive
+          # for #408 Phase 3 (TinyCC freestanding port reads under
+          # vendor/tinycc/tinycc/); BearSSL already builds via its
+          # Makefile.secureos shim. Refs #520.
+          submodules: recursive
 
       - name: Ensure build scripts are executable
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Init submodules (vendor/tinycc/tinycc, vendor/bearssl/BearSSL)
-          # so any future lint over vendor sources sees real files.
-          # Refs #520 (pre-emptive for #408 Phase 3).
-          submodules: recursive
+
+      - name: Init submodules (full-depth)
+        # See iso-vm-build.yml: checkout@v4's `submodules: recursive`
+        # uses --depth=1 which fails against bearssl.org (server only
+        # advertises tip, not pinned commits). A plain `git submodule
+        # update --init --recursive` does a full clone and resolves the
+        # pinned SHAs. Refs #520 (pre-emptive for #408 Phase 3).
+        run: git submodule update --init --recursive
 
       - name: Ensure build scripts are executable
         # Defensive chmod, mirroring pr-build.yml. Several validator

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Init submodules (vendor/tinycc/tinycc, vendor/bearssl/BearSSL)
+          # so any future lint over vendor sources sees real files.
+          # Refs #520 (pre-emptive for #408 Phase 3).
+          submodules: recursive
 
       - name: Ensure build scripts are executable
         # Defensive chmod, mirroring pr-build.yml. Several validator

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,12 +23,16 @@ jobs:
           # `last_content=<merge-sha>` newer than every stamp. Fetch full
           # history so freshness comparisons are accurate.
           fetch-depth: 0
-          # Init submodules so vendor/tinycc/tinycc and
-          # vendor/bearssl/BearSSL sources are present. Pre-emptive for
-          # #408 Phase 3 (TinyCC freestanding port will compile under
-          # vendor/tinycc/tinycc/); BearSSL already builds via its
-          # Makefile.secureos shim. Refs #520.
-          submodules: recursive
+
+      - name: Init submodules (full-depth)
+        # See iso-vm-build.yml: checkout@v4's `submodules: recursive`
+        # uses --depth=1, which fails against bearssl.org (server only
+        # advertises tip, not pinned commits). A plain `git submodule
+        # update --init --recursive` does a full clone and resolves the
+        # pinned SHAs. Pre-emptive for #408 Phase 3 (TinyCC freestanding
+        # port will compile under vendor/tinycc/tinycc/); BearSSL already
+        # builds via its Makefile.secureos shim. Refs #520.
+        run: git submodule update --init --recursive
 
       - name: Ensure build scripts are executable
         # Defensive: mirrors the same step in iso-vm-build.yml.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,6 +23,12 @@ jobs:
           # `last_content=<merge-sha>` newer than every stamp. Fetch full
           # history so freshness comparisons are accurate.
           fetch-depth: 0
+          # Init submodules so vendor/tinycc/tinycc and
+          # vendor/bearssl/BearSSL sources are present. Pre-emptive for
+          # #408 Phase 3 (TinyCC freestanding port will compile under
+          # vendor/tinycc/tinycc/); BearSSL already builds via its
+          # Makefile.secureos shim. Refs #520.
+          submodules: recursive
 
       - name: Ensure build scripts are executable
         # Defensive: mirrors the same step in iso-vm-build.yml.

--- a/vendor/bearssl/README.md
+++ b/vendor/bearssl/README.md
@@ -16,6 +16,11 @@ After cloning the repo, initialize the submodule:
 git submodule update --init
 ```
 
+CI initializes all submodules automatically via `actions/checkout@v4`
+with `submodules: recursive` (see `.github/workflows/*.yml`, #520).
+Local clones need `git submodule update --init --recursive` before
+running `build/scripts/test.sh bearssl_compile`.
+
 ## Build
 
 Compile BearSSL objects for the SecureOS freestanding i386 target:

--- a/vendor/bearssl/README.md
+++ b/vendor/bearssl/README.md
@@ -16,8 +16,13 @@ After cloning the repo, initialize the submodule:
 git submodule update --init
 ```
 
-CI initializes all submodules automatically via `actions/checkout@v4`
-with `submodules: recursive` (see `.github/workflows/*.yml`, #520).
+CI initializes all submodules via an explicit `git submodule update
+--init --recursive` step in each workflow (see
+`.github/workflows/*.yml`, #520). We avoid `actions/checkout@v4`'s
+`submodules: recursive` because it does a shallow (`--depth=1`) submodule
+fetch, which fails against bearssl.org — that server only advertises
+the tip and rejects requests for the pinned commit. A full clone resolves
+cleanly.
 Local clones need `git submodule update --init --recursive` before
 running `build/scripts/test.sh bearssl_compile`.
 

--- a/vendor/tinycc/README.md
+++ b/vendor/tinycc/README.md
@@ -24,6 +24,11 @@ After cloning the repo, initialize the submodule:
 git submodule update --init vendor/tinycc/tinycc
 ```
 
+CI initializes all submodules automatically via `actions/checkout@v4`
+with `submodules: recursive` (see `.github/workflows/*.yml`, #520).
+Local clones need `git submodule update --init --recursive` before
+running `build/scripts/test.sh tinycc_*`.
+
 ## Status
 
 > **Phase 1 (this slice): vendored only.** The submodule is pinned and the

--- a/vendor/tinycc/README.md
+++ b/vendor/tinycc/README.md
@@ -24,8 +24,13 @@ After cloning the repo, initialize the submodule:
 git submodule update --init vendor/tinycc/tinycc
 ```
 
-CI initializes all submodules automatically via `actions/checkout@v4`
-with `submodules: recursive` (see `.github/workflows/*.yml`, #520).
+CI initializes all submodules via an explicit `git submodule update
+--init --recursive` step in each workflow (see
+`.github/workflows/*.yml`, #520). `actions/checkout@v4`'s
+`submodules: recursive` is not used because it does a shallow
+submodule fetch that fails against the bearssl.org git server
+(server only advertises tip, not pinned commits); a full clone
+works for both vendor trees.
 Local clones need `git submodule update --init --recursive` before
 running `build/scripts/test.sh tinycc_*`.
 


### PR DESCRIPTION
Closes #520. Pre-emptive unblock for #408 Phase 3.

## Change

Add `submodules: recursive` to `actions/checkout@v4` in:
- `.github/workflows/iso-vm-build.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/pr-build.yml`

Also document the CI behavior + the local-clone init step in
`vendor/tinycc/README.md` and `vendor/bearssl/README.md`.

## Why now

Today this is a no-op: nothing in CI reads under `vendor/tinycc/tinycc/`
or `vendor/bearssl/BearSSL/` directly — both vendor trees build through
their `Makefile.secureos` shims (which only need files committed in
`vendor/{tinycc,bearssl}/`, not the submodule contents). As soon as
#408 Phase 3 lands and TinyCC source is compiled from
`vendor/tinycc/tinycc/`, every CI run would otherwise fail with
`vendor/tinycc/tinycc/...: No such file or directory` and blame the
build-flag PR instead of the missing init.

## Validation

- `python3 -c 'import yaml; yaml.safe_load(...)'` on all three
  workflow files (still parse).
- No source/code changes; no `OS_ABI_VERSION` bump.
- No host build invocation needed — there is no behavioral change today.
  CI on this PR exercises the new checkout step end-to-end.

## Follow-ups

- #408 Phase 3 (TinyCC freestanding port) will be the first consumer.
- Nothing else expected; this is the smallest possible unblock.