### PR TITLE
feat(#522): additive owner.kind="local" enumerator for in-OS-built apps

### DIFF
--- a/build/scripts/test_manifest_owner_kind_enum.sh
+++ b/build/scripts/test_manifest_owner_kind_enum.sh
@@ -53,6 +53,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WRAPPER="$ROOT_DIR/build/scripts/validate_manifests.sh"
 POS_EXTERNAL="$ROOT_DIR/manifests/examples/helloapp.owner_external.json"
 POS_INTERNAL="$ROOT_DIR/manifests/examples/helloapp.owner_internal.json"
+POS_LOCAL="$ROOT_DIR/manifests/examples/helloapp.owner_kind_local.json"
 POS_OMITTED="$ROOT_DIR/manifests/examples/helloapp.json"
 NEG_FIXTURE="$ROOT_DIR/manifests/examples/invalid/helloapp.owner_kind_invalid.json"
 
@@ -60,7 +61,7 @@ if [[ ! -r "$WRAPPER" ]]; then
   echo "TEST:FAIL:harness_missing_script:$WRAPPER" >&2
   exit 78
 fi
-for f in "$POS_EXTERNAL" "$POS_INTERNAL" "$POS_OMITTED" "$NEG_FIXTURE"; do
+for f in "$POS_EXTERNAL" "$POS_INTERNAL" "$POS_LOCAL" "$POS_OMITTED" "$NEG_FIXTURE"; do
   if [[ ! -r "$f" ]]; then
     echo "TEST:FAIL:harness_missing_positive_example:$f" >&2
     exit 78
@@ -103,7 +104,13 @@ check_positive() {
 
 check_positive "external_example" "$POS_EXTERNAL"
 check_positive "internal_example" "$POS_INTERNAL"
+check_positive "local_example" "$POS_LOCAL"
 check_positive "omitted_field_backcompat" "$POS_OMITTED"
+
+# Spelled-out positive sub-marker for the M7-TOOLCHAIN-006 'local'
+# enumerator (issue #522, refs #409 / #410); parity with the
+# `:default_when_omitted` / `:negative_rejected` sub-markers.
+echo "TEST:PASS:manifest_owner_kind_enum:local_accepted"
 
 # --- Default-when-omitted sub-marker (parity with §5.3/§5.4/§5.5). ---
 # The omitted-field case above already passed; explicitly emit the
@@ -194,5 +201,64 @@ fi
 
 # Negative-path sub-marker (parity with §5.3/§5.4/§5.5).
 echo "TEST:PASS:manifest_owner_kind_enum:negative_rejected"
+
+# --- Additional negatives for the 'local' enumerator added by #522.
+# Assert that case-variant ('LOCAL') and near-miss ('local-shipped')
+# values are still rejected — the enum is case-sensitive and exact,
+# matching the precedent set by 'external' / 'internal'.
+for BAD_VAL in "LOCAL" "local-shipped"; do
+  BAD_PATH="$TMP/owner_kind_${BAD_VAL//\//_}.json"
+  cat >"$BAD_PATH" <<EOF
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": []
+  },
+  "owner": {
+    "kind": "${BAD_VAL}"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}
+EOF
+  LOCAL_NEG_OUT="$TMP/local_neg_${BAD_VAL//\//_}.log"
+  set +e
+  bash "$WRAPPER" "$BAD_PATH" >"$LOCAL_NEG_OUT" 2>&1
+  LOCAL_NEG_RC=$?
+  set -e
+  if [[ "$LOCAL_NEG_RC" -eq 0 ]]; then
+    echo "TEST:FAIL:manifest_owner_kind_enum:local_near_miss_accepted:${BAD_VAL}" >&2
+    sed 's/^/  | /' "$LOCAL_NEG_OUT" >&2
+    exit 1
+  fi
+  if ! grep -Eq "MANIFEST_VALIDATE:(ERROR|FAIL)" "$LOCAL_NEG_OUT"; then
+    echo "TEST:FAIL:manifest_owner_kind_enum:local_near_miss_missing_marker:${BAD_VAL}" >&2
+    sed 's/^/  | /' "$LOCAL_NEG_OUT" >&2
+    exit 1
+  fi
+  if ! grep -Eq "owner|kind" "$LOCAL_NEG_OUT"; then
+    echo "TEST:FAIL:manifest_owner_kind_enum:local_near_miss_field_name_not_in_error:${BAD_VAL}" >&2
+    sed 's/^/  | /' "$LOCAL_NEG_OUT" >&2
+    exit 1
+  fi
+done
+echo "TEST:PASS:manifest_owner_kind_enum:local_near_miss_rejected"
 
 echo "TEST:PASS:manifest_owner_kind_enum"

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -2,7 +2,7 @@
 
 > **Owner:** launcher / user-runtime
 > **Status:** draft `v0` — on-disk schema not yet load-bearing
-> **Last reviewed:** 2026-05-29
+> **Last reviewed:** 2026-06-02
 > **Applies to:** `OS_ABI_VERSION = 0`
 > **Tracking issues:** [#82](https://github.com/rwrife/SecureOS/issues/82), [#83](https://github.com/rwrife/SecureOS/issues/83)
 
@@ -162,28 +162,44 @@ Field semantics we are committing to at v0:
 - `provides[]` lists IPC endpoints the app exposes (see
   [`ipc-wire.md`](./ipc-wire.md)). Endpoint names use a narrow
   reverse-DNS-ish pattern.
-- `owner.kind` is an optional enum (`"internal"` | `"external"`)
+- `owner.kind` is an optional enum (`"internal"` | `"external"` |
+  `"local"`)
   that marks the origin of the module (BUILD_ROADMAP §5.6, plan
   `plans/2026-05-15-public-sdk-external-app-template.md`
-  §"Manifest Schema (additions)", issue #396). The default is
+  §"Manifest Schema (additions)", issue #396; the additive
+  `"local"` enumerator for in-OS-built apps lands in the
+  M7-TOOLCHAIN-006 schema sub-slice, issue #522, refs #409 /
+  #410). The default is
   `"internal"`, which preserves today's behavior exactly: the
   module is shipped in-tree and the launcher applies its existing
   trust/policy path unchanged. `"external"` marks a module produced
   via the public SDK toolchain (`os-cc` / `os-pack`) by a
   third-party author; downstream M6 slices may use this marker
-  to apply stricter signing or cap-grant policy. Like
+  to apply stricter signing or cap-grant policy. `"local"` marks a
+  module produced **on-target** by the in-OS toolchain
+  (#403 / M7-TOOLCHAIN-006); its trust origin is the runtime uid
+  at the SecureOS shell rather than a host-side reproducible build
+  pipeline (which is what `"internal"` records) and rather than an
+  off-target signed SDK invocation (which is what `"external"`
+  records). The Tier-1 unsigned-run flow (#410) uses this third
+  enumerator to keep local-built and external-imported binaries
+  distinguishable in the capability-audit log without forcing
+  either of them to mis-label as `"external"`. Like
   `capabilities.persistence`, `capabilities.broker_role`, and
   `capabilities.ownership_role`, this field is schema-only at v0 —
   the runtime wiring (M6-SDK-003 wrappers and the
-  `sdk_external_build_isolation` acceptance test) lands in later
-  M6-SDK slices and is gated on the A/B design decision tracked
-  in #396. Because the field is **optional**, has a non-default
-  value only when explicitly declared, and `"internal"` exactly
+  `sdk_external_build_isolation` acceptance test, plus the
+  M7-TOOLCHAIN-006/007 in-OS `cc` driver and unsigned-run flow)
+  lands in later slices and is gated on the A/B design decision
+  tracked in #396 / the unsigned-run flow tracked in #410. Because
+  the field is **optional**, has a non-default value only when
+  explicitly declared, and `"internal"` exactly
   preserves the current launcher path, adding it is additive and
   does **not** bump `OS_ABI_VERSION` (same precedent as
   `capabilities.persistence` in #285/#286,
   `capabilities.broker_role` in #312, and
-  `capabilities.ownership_role` in #368, and `owner.kind` in #396).
+  `capabilities.ownership_role` in #368, and the introduction of
+  `owner.kind` itself in #396).
 - `runtime.arena_bytes` is an optional integer field that declares a
   per-app userland arena ceiling in bytes (BUILD_ROADMAP §5.7 and
   plan `plans/2026-05-28-in-os-toolchain-self-hosting.md` §P1,
@@ -331,6 +347,14 @@ list while still being a stable target for the regression test.
   same as `helloapp.json` but with `owner.kind: "internal"`
   (explicit form of today's default; behaves identically to
   omitting the field).
+- **Owner local (in-OS toolchain)** —
+  [`helloapp.owner_kind_local.json`](../../manifests/examples/helloapp.owner_kind_local.json):
+  same as `helloapp.json` but with `owner.kind: "local"`. Added
+  by the M7-TOOLCHAIN-006 schema sub-slice (issue #522) so the
+  in-OS `cc` driver (#409) can synthesise a manifest for a binary
+  it just compiled on-target without having to mis-label it as
+  `"external"`. Runtime semantics (Tier-1 unsigned-run flow,
+  audit-log marker) land with #410.
 - **Owner omitted (back-compat)** — the bundled
   `helloapp.json`, `helloapp.deny.json`, `helloapp.persistent.json`,
   `helloapp.broker_provider.json`, `helloapp.broker_consumer.json`,
@@ -359,6 +383,8 @@ list while still being a stable target for the regression test.
 | Sub-marker | Status |
 | --- | --- |
 | `manifest_owner_kind_enum` (positive) | enforced (PR for #396 schema sub-slice) |
+| `manifest_owner_kind_enum:local_accepted` | enforced (PR for #522 schema sub-slice) |
+| `manifest_owner_kind_enum:local_near_miss_rejected` | enforced (PR for #522 schema sub-slice) |
 | `manifest_owner_kind_enum:negative_rejected` | enforced (PR for #396 schema sub-slice) |
 | `manifest_owner_kind_enum:default_when_omitted` | enforced (PR for #396 schema sub-slice) |
 
@@ -464,4 +490,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 40836340d47fdf133d1dc44cadbbc8875d90aa8a
+Last verified against commit: c40c7cbc0d60934094bc1620aab11201b53e98be

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -490,4 +490,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: c40c7cbc0d60934094bc1620aab11201b53e98be
+Last verified against commit: 3befdfe1676621d7d69c1489a880289fbb7851a9

--- a/manifests/examples/helloapp.owner_kind_local.json
+++ b/manifests/examples/helloapp.owner_kind_local.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 0,
+  "os_abi_version": 0,
+  "app": {
+    "id": "helloapp",
+    "version": "0.1.0",
+    "subject_id": 2,
+    "binary": "apps/helloapp.bin",
+    "signer_key_id": "secureos-dev-key-1"
+  },
+  "capabilities": {
+    "request": ["CAP_CONSOLE_WRITE"],
+    "optional": []
+  },
+  "owner": {
+    "kind": "local"
+  },
+  "provides": [],
+  "launcher": {
+    "auto_grant_at_launch": ["CAP_CONSOLE_WRITE"],
+    "require_user_confirm": []
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "signer_key_id": "secureos-dev-key-1",
+    "signature_path": "apps/helloapp.bin.sig"
+  }
+}

--- a/manifests/schema/v0.json
+++ b/manifests/schema/v0.json
@@ -110,14 +110,14 @@
       }
     },
     "owner": {
-      "description": "M6 SDK ownership-origin marker (BUILD_ROADMAP §5.6, plan plans/2026-05-15-public-sdk-external-app-template.md §'Manifest Schema (additions)', issue #396). 'internal' (default) preserves today's behavior — the module is shipped in-tree and the launcher applies its existing trust/policy path unchanged. 'external' marks a module produced via the public SDK toolchain (os-cc / os-pack) by a third-party author; downstream slices may use this marker to apply stricter signing or cap-grant policy. Schema-only / additive at v0 — runtime wiring (M6-SDK-003 wrappers, M6-SDK-004 launch path) lands in later M6 slices and is gated on the A/B design decision tracked in #396. This field does NOT bump OS_ABI_VERSION (same precedent as 'persistence' in #285, 'broker_role' in #312, 'ownership_role' in #368).",
+      "description": "M6 SDK ownership-origin marker (BUILD_ROADMAP §5.6, plan plans/2026-05-15-public-sdk-external-app-template.md §'Manifest Schema (additions)', issue #396; additive 'local' enumerator for in-OS-built apps added by M7-TOOLCHAIN-006 schema sub-slice, issue #522, refs #409 / #410). 'internal' (default) preserves today's behavior — the module is shipped in-tree and the launcher applies its existing trust/policy path unchanged. 'external' marks a module produced via the public SDK toolchain (os-cc / os-pack) by a third-party author; downstream slices may use this marker to apply stricter signing or cap-grant policy. 'local' marks a module produced on-target by the in-OS toolchain (#403 / M7-TOOLCHAIN); its trust origin is the runtime uid at the SecureOS shell, not a host-side reproducible build pipeline nor an off-target signed SDK invocation — the Tier-1 unsigned-run flow (#410) uses this to keep local-built and external-imported binaries distinguishable in the audit log. Schema-only / additive at v0 — runtime wiring (M6-SDK-003 wrappers, M6-SDK-004 launch path, M7-TOOLCHAIN-006/007 in-OS cc + unsigned-run flow) lands in later slices and is gated on the A/B design decision tracked in #396 / the unsigned-run flow tracked in #410. This field does NOT bump OS_ABI_VERSION (same precedent as 'persistence' in #285, 'broker_role' in #312, 'ownership_role' in #368, and the introduction of 'owner.kind' itself in #396).",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "kind": {
-          "description": "Origin of the module. 'internal' = in-tree build, today's default; 'external' = SDK-produced module per plan §'Manifest Schema (additions)'.",
+          "description": "Origin of the module. 'internal' = in-tree build, today's default; 'external' = SDK-produced module per plan §'Manifest Schema (additions)'; 'local' = produced on-target by the in-OS toolchain (#403 / M7-TOOLCHAIN-006, issue #522), trust origin is the runtime uid rather than a host build pipeline.",
           "type": "string",
-          "enum": ["internal", "external"],
+          "enum": ["internal", "external", "local"],
           "default": "internal"
         }
       }


### PR DESCRIPTION
Closes #522.

M7-TOOLCHAIN-006 schema sub-slice. Adds the third enumerator on the existing additive `owner.kind` field so the in-OS `cc` driver (#409) can synthesise a manifest for a binary it just compiled on-target without mis-labelling it as `"external"`, and so the Tier-1 unsigned-run flow (#410) can keep local-built vs. external-imported binaries distinguishable in the audit log.

## Changes

- `manifests/schema/v0.json`: extend `owner.kind` enum to `["internal", "external", "local"]`; expand description with the `local` trust-origin semantics (runtime uid at the SecureOS shell, not a host build pipeline nor an off-target signed SDK invocation) and the no-`OS_ABI_VERSION`-bump rationale.
- `manifests/examples/helloapp.owner_kind_local.json`: new positive fixture.
- `build/scripts/test_manifest_owner_kind_enum.sh`: include the new positive example in the validator sweep; add the `:local_accepted` sub-marker; add a case/near-miss negative sweep (`LOCAL`, `local-shipped`) emitting a `:local_near_miss_rejected` sub-marker (parity with existing `:negative_rejected` shape).
- `docs/abi/manifest.md`: document the third enumerator inline + a §5.6 fixture entry, expand the §5.6 sub-marker table with the two new sub-markers, bump `Last reviewed` and `Last verified against commit` to today's HEAD.

## Done-when (from #522)

- [x] Schema enum has `["internal", "external", "local"]`.
- [x] `docs/abi/manifest.md` documents the third enumerator + stamp bumped to today; `validate_abi_stamps` green.
- [x] Positive + negative + default-when-omitted sub-markers green (parity with §5.3 / §5.4 / §5.5 / §5.6 prior enum sub-slices).
- [x] No `OS_ABI_VERSION` bump (additive enumerator on an existing additive field; default behaviour preserved).
- [x] No launcher / kernel runtime change (runtime semantics for `"local"` land in #410).

## Validation

Local runs against this branch:

```
$ bash build/scripts/test.sh manifest_owner_kind_enum
TEST:PASS:manifest_owner_kind_enum:local_accepted
TEST:PASS:manifest_owner_kind_enum:default_when_omitted
TEST:PASS:manifest_owner_kind_enum:negative_rejected
TEST:PASS:manifest_owner_kind_enum:local_near_miss_rejected
TEST:PASS:manifest_owner_kind_enum

$ bash build/scripts/validate_manifests.sh
MANIFEST_VALIDATE:SUMMARY:pass 13/13

$ bash build/scripts/test.sh validate_manifests_abi_major
TEST:PASS:validate_manifests_abi_major

$ bash build/scripts/test.sh validate_abi_stamps
ABI_STAMP:PASS:docs/abi/manifest.md:c40c7cbc0d
... (all 10 PASS)
```

Peer enum tests (`manifest_persistence_enum`, `manifest_ownership_role_enum`) still PASS.

## Follow-ups

- #409 (cc driver) can now synthesise `owner.kind: "local"` without schema friction.
- #410 (unsigned-run / Tier-1 flow) owns the runtime semantics — audit-log marker distinguishing local-built vs. external-imported.
- No new bundle target; `manifest_owner_kind_enum` was already wired into `TEST_TARGETS` via #396.

---

_Filed by `cron:secureos-hourly-issue-work` (run e4c62e32, 2026-06-02 15:38 UTC)._