### PR TITLE
fix(abi): bump sosh-capability-contract.md stamp to a43ef3d (#502 squash SHA)

### DIFF
--- a/docs/abi/sosh-capability-contract.md
+++ b/docs/abi/sosh-capability-contract.md
@@ -364,4 +364,4 @@ the `cap.deny` audit-ring follow-up (#389) covered by the
 on every sosh deny test.
 
 Last verified against commit: 02514ac (sosh_cap_allow/deny wired via test.sh dispatcher); cat/ls FS_READ gate landed in sosh_cap_cat_ls; write/append FS_WRITE gate landed in sosh_cap_write_append; `export` ENV_WRITE gate landed in sosh_cap_export; `source` FS_READ + external-command APP_EXEC gates pinned by sosh_cap_source_exec (slice 3/3 of #351, refs #371) — §4 enforcement matrix is now complete at `OS_ABI_VERSION = 0`.
-Last verified against commit: 24fcc86
+Last verified against commit: a43ef3d


### PR DESCRIPTION
## Why

`main` is red on `build-and-validate`:

```
ABI_STAMP:FAIL:docs/abi/sosh-capability-contract.md:stamp_sha_unknown_to_git:24fcc86
VALIDATION_FAIL:validate_abi_stamps
```

PR #502 squash-merged as `a43ef3d` ("fix(#493): wire sosh_app_exec to os_process_spawn for external binaries") landed real sosh content changes to the contract doc, but the branch's stamp-bump referenced `24fcc86` — the **unsquashed branch HEAD**, which never reaches `main`. `validate_abi_stamps` rejects the stamp as `stamp_sha_unknown_to_git`, so every open PR's `build-and-validate` is failing through no fault of its own (confirmed on #507, #518, #525, #526, etc.).

## What this does

One-line bump of the stamp in `docs/abi/sosh-capability-contract.md` from `24fcc86` → `a43ef3d` (the squash-merge SHA actually on `main`).

Same post-merge stamp-bump pattern as #500 (clib-symbols → #481 squash), #506 (capability-deny-contract → #499 squash), #486 (manifest → #465 squash), #517 (versioning → #479 squash), #471 / #466 (README → #461 squash).

## Validation

Local `bash build/scripts/validate_abi_stamps.sh` — all 10 ABI docs PASS, including the previously-failing `sosh-capability-contract.md:a43ef3d7ef`.

## Scope guardrails

- No code change.
- No other ABI doc change.
- No `OS_ABI_VERSION` change (stamp-only, doc-only).
- No test reshape; the existing `validate_abi_stamps` gate flips FAIL → PASS.

## Follow-ups

None — this is the canonical post-squash stamp bump. The next time an ABI-doc-touching PR squash-merges, the same one-line bump pattern applies.

---

_Filed by `cron:secureos-hourly-issue-work` (`e4c62e32`, 2026-06-02 17:46 UTC) — picked while triaging the open-issue queue and finding every open ABI/manifest PR (#507, #518, #525, #526) is red on the same `stamp_sha_unknown_to_git:24fcc86` line._