### PR TITLE
docs(abi): bump syscalls.md Last verified stamp to ac856f7 (unblock CI)

### DIFF
--- a/docs/abi/syscalls.md
+++ b/docs/abi/syscalls.md
@@ -142,5 +142,5 @@ unused"). The reservation is purely an ABI-shape anchor.
 4. Add an allow-path and a deny-path test under `build/scripts/test_*.sh`.
 5. Update this table and bump the verification line below.
 
-Last verified against commit: 4e9c32e
+Last verified against commit: ac856f7
 


### PR DESCRIPTION
## Why

PR #507 (closes #495 — the QEMU peer of #421) edited `docs/abi/syscalls.md` at commit `ac856f7` but did not bump the "Last verified against commit" line, leaving the stamp pinned at `4e9c32e`. The #297 freshness gate is now red on every open PR:

```
ABI_STAMP:FAIL:docs/abi/syscalls.md:stamp=4e9c32efd6:last_content=ac856f74a8
VALIDATION_FAIL:validate_abi_stamps
```

Verified failing on open PRs #524 / #525 / #526 (all three `build-and-validate` jobs red on this single check, while `lint` + `build-iso-vm-smoke` pass). Bumping unblocks all in-flight work.

## What

One-line stamp bump: `4e9c32e` → `ac856f7`. No ABI surface change, no kernel/userland code change, no `OS_ABI_VERSION` bump. Same post-merge bump pattern as PRs #420 / #438 / #451 / #465 for prior `os_process_*` / `os_mem_brk` / `manifest.md` stamp bumps.

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
ABI_STAMP:PASS:docs/abi/README.md:e889994e52
ABI_STAMP:PASS:docs/abi/capabilities.md:ee4426283a
ABI_STAMP:PASS:docs/abi/capability-deny-contract.md:9349706d49
ABI_STAMP:PASS:docs/abi/capability-handle.md:609a26216b
ABI_STAMP:PASS:docs/abi/clib-symbols.md:18b317e67f
ABI_STAMP:PASS:docs/abi/ipc-wire.md:7f303d7e90
ABI_STAMP:PASS:docs/abi/manifest.md:40836340d4
ABI_STAMP:PASS:docs/abi/sosh-capability-contract.md:a43ef3d7ef
ABI_STAMP:PASS:docs/abi/syscalls.md:ac856f74a8
ABI_STAMP:PASS:docs/abi/versioning.md:d60775d281
```

All 10 ABI docs PASS. `#297` strict-stamp gate satisfied.

## Refs

- Refs #421 (M7-TOOLCHAIN-001 slice 2 — the umbrella for the QEMU peer that touched the doc).
- Refs #297 (the freshness gate that caught this).
- Follows the bump-only pattern documented in PR #420 (`a2177df`), PR #438 (`6f842a0`), PR #451 (`af8ece8`).

_Filed by `cron:secureos-hourly-issue-work` (`e4c62e32`, 2026-06-02 22:58 UTC)._