### PR TITLE
build(sofpack): wire build_user_lib.sh sofpack archive-only target (refs #521)

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -41,7 +41,18 @@ build_libs() {
         # Skip libs that aren't structured as a SOF user-lib (no main.c).
         # Header/src-only libs like `clib` (issue #404) are linked into
         # apps via the SDK path, not packed as a standalone .lib.
+        # Exception: explicit archive-only freestanding libs that ship
+        # sources under `src/` (e.g. `sofpack`, #521 sub-slice of #409)
+        # — these get built into `artifacts/user/libs/lib<name>.a` for
+        # future on-target apps (the in-OS `cc` driver, #409) to link
+        # against. Opt-in list so SDK-path libs like `clib` keep their
+        # existing build flow.
         if [[ ! -f "$lib_path/main.c" ]]; then
+          case "$lib_name" in
+            sofpack)
+              "$ROOT_DIR/build/scripts/build_user_lib.sh" "$lib_name"
+              ;;
+          esac
           continue
         fi
         "$ROOT_DIR/build/scripts/build_user_lib.sh" "$lib_name"

--- a/build/scripts/build_user_lib.sh
+++ b/build/scripts/build_user_lib.sh
@@ -12,6 +12,43 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="$ROOT_DIR/artifacts/lib"
 LIB_NAME="${1:-envlib}"
 
+# build_user_archive_inner: archive-only freestanding userland libraries.
+#
+# Some libs (e.g. `sofpack`, issue #521 sub-slice of #409) have no `main.c`
+# and are not SOF-wrapped. They're plain `ar`-archives that future on-target
+# apps (e.g. the in-OS `cc` driver, #409) link against. Sources live under
+# `user/libs/<name>/src/*.c` with public headers under
+# `user/libs/<name>/include/`. Mirrors the freestanding cflags used by the
+# SOF-lib path so the archive is link-compatible with on-target apps.
+build_user_archive_inner() {
+  LIB_DIR="user/libs/$LIB_NAME"
+  local src_path
+  local object_path
+  local object_files=""
+  local user_cflags="--target=x86_64-unknown-none-elf -ffreestanding -fno-stack-protector -mno-red-zone"
+  user_cflags="$user_cflags -I $LIB_DIR/include -I user/include"
+  local archive_dir="artifacts/user/libs"
+  local archive_path="$archive_dir/lib${LIB_NAME}.a"
+  mkdir -p "$archive_dir"
+
+  for src_path in "$LIB_DIR"/src/*.c; do
+    [ -f "$src_path" ] || continue
+    object_path="$archive_dir/${LIB_NAME}_$(basename "$src_path" .c).o"
+    clang $user_cflags -c "$src_path" -o "$object_path"
+    object_files="$object_files $object_path"
+  done
+
+  if [ -z "$object_files" ]; then
+    echo "BUILD_USER_LIB:FAIL:$LIB_NAME:no_sources_under_src"
+    return 1
+  fi
+
+  rm -f "$archive_path"
+  llvm-ar rcs "$archive_path" $object_files 2>/dev/null \
+    || ar rcs "$archive_path" $object_files
+  echo "Built $archive_path"
+}
+
 build_user_lib_inner() {
   LIB_DIR="user/libs/$LIB_NAME"
   local src_path
@@ -76,5 +113,11 @@ build_user_lib_inner() {
 }
 
 mkdir -p "$OUT_DIR"
-build_user_lib_inner
-echo "PASS: user lib build ($LIB_NAME)"
+if [ ! -f "user/libs/$LIB_NAME/main.c" ] && compgen -G "user/libs/$LIB_NAME/src/*.c" >/dev/null; then
+  # Archive-only freestanding lib (no SOF wrap, no main.c). E.g. sofpack (#521).
+  build_user_archive_inner
+  echo "PASS: user archive build ($LIB_NAME)"
+else
+  build_user_lib_inner
+  echo "PASS: user lib build ($LIB_NAME)"
+fi

--- a/user/libs/sofpack/README.md
+++ b/user/libs/sofpack/README.md
@@ -91,6 +91,8 @@ ever drifts, that arm flips the bundle red.
   2. invoke `tcc_compile()` to emit an in-memory ELF,
   3. call `sofpack_wrap()` to produce the SOF container,
   4. write the result via `os_fs_*`.
-- **On-target build target** — once the `cc` driver app exists, wire
-  `libsofpack.a` into its link step (today the only consumer is the host
-  test).
+- **On-target build target** — `build/scripts/build_user_lib.sh sofpack`
+  (wired into `build.sh build_libs()`'s archive-only branch) produces
+  `artifacts/user/libs/libsofpack.a` next to the existing SOF-wrapped
+  libs. The future `cc` driver app (#409) will pick it up from there;
+  today the only consumer is the host link-pin test.


### PR DESCRIPTION
Closes done-when bullet **2** of #521 (`libsofpack.a builds via build_user_lib.sh sofpack`).

## Context

#521 splits M7-TOOLCHAIN-006 into a userland `sofpack` library + the future `cc` driver. Bullets 1, 3, 4 of #521 landed via merged **PR #511** (sources, host wire-equivalence test, bundle wiring). Bullet 5 (`docs/abi/sof-format.md`) is in-flight on **PR #529**. The only remaining gap was bullet 2 — the `build/scripts/build_user_lib.sh sofpack` archive target — which was deliberately left out of #511 because `sofpack` has no `main.c` and `build.sh`'s `build_libs()` loop `continue`s past dirs without one (same arm `clib` hits per #404). This PR closes that gap.

## What this lands

- **`build/scripts/build_user_lib.sh`** — new `build_user_archive_inner()` branch for freestanding userland libs that ship `src/*.c` with no `main.c` and no SOF-wrap. Uses the same freestanding cflags as the SOF-lib path (`--target=x86_64-unknown-none-elf -ffreestanding -fno-stack-protector -mno-red-zone`) so the archive is link-compatible with on-target apps. Emits `artifacts/user/libs/lib<name>.a` next to the existing SOF-wrapped libs. Top-level dispatch picks the archive branch when no `main.c` is present but `src/*.c` is — preserving the existing `build_user_lib_inner` path for all current SOF libs.
- **`build/scripts/build.sh`** — `build_libs()` now dispatches `sofpack` (explicit opt-in list) through the wrapper instead of `continue`-skipping. Other src-only libs like `clib` keep their existing SDK-path flow (they're linked into apps via `build_sdk_libos.sh`, not packed as standalone archives). Opt-in keeps the surface narrow per #404's recorded decision for `clib`.
- **`user/libs/sofpack/README.md`** — "On-target build target" follow-up bullet updated to reflect that the archive is now produced.

## Validation

```
$ bash -n build/scripts/build_user_lib.sh && bash -n build/scripts/build.sh
SYNTAX_OK

$ bash build/scripts/test.sh sofpack_wrap
TEST:PASS:sofpack_wrap:wrap_size_matches_wrap
TEST:PASS:sofpack_wrap:byte_identical_to_sof_build
TEST:PASS:sofpack_wrap:optional_fields_byte_identical
TEST:PASS:sofpack_wrap:parses_back_through_sof_parse
TEST:PASS:sofpack_wrap:rejects_invalid_args
TEST:PASS:sofpack_wrap:buffer_too_small
TEST:PASS:sofpack_wrap:long_value_clamped
TEST:PASS:sofpack_wrap
```

The full `build_libs()` invocation requires `clang` inside the Docker toolchain container and was not run on this host — but the new branch only uses the same toolchain commands (`clang`, `llvm-ar`/`ar`) that the existing `build_user_lib_inner` path uses, so any clang-available environment that builds the other libs will build this archive too. CI will exercise it.

## Surface impact

- No `OS_ABI_VERSION` change.
- No kernel/userland code change (build-only).
- No new bundle TEST_TARGETS entry — `sofpack_wrap` already gates the source-level archive contents via the symbol set in `tests/sofpack_wrap_test.c`. The new archive is the same TUs under the same cflags, packed with `ar rcs`.

## Done-when state of #521 after this lands

- [x] 1. `libsofpack.a` builds via `build_user_lib.sh sofpack` ← **this PR**
- [x] 2. `sofpack_wrap` round-trips a fake ELF byte-identically vs `tools/sof_wrap` (PR #511)
- [x] 3. Short-output-buffer negative path returns documented error, no overrun (PR #511)
- [x] 4. Host link-pin test added and wired into bundle (PR #511)
- [ ] 5. `docs/abi/sof-format.md` cross-reference (in-flight on PR #529)
- [x] No `OS_ABI_VERSION` change
- [x] No kernel change

## Follow-ups

- The `cc` driver app under `user/apps/cc/` will pick `libsofpack.a` up from `artifacts/user/libs/` once the TinyCC port (#408) lands.

_Filed by `cron:secureos-hourly-issue-work` (`e4c62e32`, 2026-06-03 14:38 UTC)._