### PR TITLE
chore(abi): bump Last-verified stamps for README/manifest/sof-format post-#525/#529

### DIFF
--- a/docs/abi/README.md
+++ b/docs/abi/README.md
@@ -66,4 +66,4 @@ touch the underlying surface (a syscall signature, a capability ID, the
 launcher API, the manifest layout), bump the verification line in the
 corresponding doc in the same change.
 
-Last verified against commit: 94231e5dada9f654065aa5cc1a8c080a23d449f2
+Last verified against commit: 8b4124007023626cf4d784620ed130dd3950e246

--- a/docs/abi/manifest.md
+++ b/docs/abi/manifest.md
@@ -490,4 +490,4 @@ When `OS_ABI_VERSION` itself moves to 1 (SDK beta freeze, per
   always rejected (you cannot target a newer manifest shape at an older
   ABI host).
 
-Last verified against commit: 3befdfe1676621d7d69c1489a880289fbb7851a9
+Last verified against commit: f40170f65a056f1edf02e73732ab9c2a6a785ac7

--- a/docs/abi/sof-format.md
+++ b/docs/abi/sof-format.md
@@ -234,4 +234,4 @@ surface. Values are stable for the lifetime of `format_version = 1`:
 - [`versioning.md`](versioning.md) — `OS_ABI_VERSION` / format-version
   bump policy.
 
-Last verified against commit: 94231e5dada9f654065aa5cc1a8c080a23d449f2
+Last verified against commit: 8b4124007023626cf4d784620ed130dd3950e246


### PR DESCRIPTION
## Why

`validate_abi_stamps` is currently red on `main` (verified locally @ `8b41240`):

```
ABI_STAMP:FAIL:docs/abi/README.md:stamp=94231e5dad:last_content=8b41240070
ABI_STAMP:FAIL:docs/abi/manifest.md:stamp=3befdfe167:last_content=f40170f65a
ABI_STAMP:FAIL:docs/abi/sof-format.md:stamp=94231e5dad:last_content=8b41240070
```

Three `docs/abi/*.md` files carry `Last verified against commit` stamps older than their most recent content-changing commit, so every open PR's `build-and-validate` job fails on a single `VALIDATION_FAIL:validate_abi_stamps` marker. The drift was introduced by:

- **PR #529** (`docs(abi): sof-format.md authoritative SOF container wire layout`, merge commit `8b41240`) — touched both `docs/abi/README.md` (index entry) and `docs/abi/sof-format.md` (the doc itself) but stamped neither.
- **PR #525** (`feat(#522): additive owner.kind="local" enumerator`, merge commit `f40170f`) — touched `docs/abi/manifest.md` to document the new enumerator but stamped against the prior content commit.

## What this PR lands

One-line stamp bumps, no other changes:

| File | Old stamp | New stamp | Source of drift |
| --- | --- | --- | --- |
| `docs/abi/README.md` | `94231e5d` | `8b412400` | PR #529 |
| `docs/abi/sof-format.md` | `94231e5d` | `8b412400` | PR #529 |
| `docs/abi/manifest.md` | `3befdfe1` | `f40170f6` | PR #525 |

Same shape as PR #528 / #420 / #438 / #451 / #465 (prior post-merge stamp-bump unblocks).

## Validation

```
$ bash build/scripts/validate_abi_stamps.sh
ABI_STAMP:PASS:docs/abi/README.md:8b41240070
ABI_STAMP:PASS:docs/abi/capabilities.md:ee4426283a
ABI_STAMP:PASS:docs/abi/capability-deny-contract.md:9349706d49
ABI_STAMP:PASS:docs/abi/capability-handle.md:609a26216b
ABI_STAMP:PASS:docs/abi/clib-symbols.md:18b317e67f
ABI_STAMP:PASS:docs/abi/ipc-wire.md:7f303d7e90
ABI_STAMP:PASS:docs/abi/manifest.md:f40170f65a
ABI_STAMP:PASS:docs/abi/sof-format.md:8b41240070
ABI_STAMP:PASS:docs/abi/sosh-capability-contract.md:a43ef3d7ef
ABI_STAMP:PASS:docs/abi/syscalls.md:ac856f74a8
ABI_STAMP:PASS:docs/abi/versioning.md:d60775d281
```

## Scope discipline

- No ABI surface change.
- No kernel / userland code change.
- No `OS_ABI_VERSION` bump.
- No content edits to the three docs — only the `Last verified against commit:` line.
- Non-conflicting with the three in-flight PRs (#534, #535, #536) — none of them touch the three stamp lines edited here.

## Follow-ups

None. Once merged, all open PRs' `build-and-validate` jobs should re-green on the `validate_abi_stamps` marker.

— Filed by `cron:secureos-hourly-issue-work` (`e4c62e32`, 2026-06-04 00:48 UTC).